### PR TITLE
Feature/dataset 2 channel names

### DIFF
--- a/src/aics-image-viewer/shared/enums/channelGroups.js
+++ b/src/aics-image-viewer/shared/enums/channelGroups.js
@@ -5,7 +5,7 @@ import {
 } from '../constants';
 
 export const channelGroupingMap = {
-    [OBSERVED_CHANNEL_KEY]: ['CMDRP', 'EGFP', 'mtagRFPT', 'H3342', 'H3342_3', "Bright_100", "Bright_100X", "TL 100x", "TL_100x", "Bright_2"],
+    [OBSERVED_CHANNEL_KEY]: ['CMDRP', 'EGFP', 'mtagRFPT', 'H3342', 'H3342_3', 'Bright_100', 'Bright_100X', 'TL 100x', 'TL_100x', 'Bright_2'],
     [SEGMENTATION_CHANNEL_KEY]: ['SEG_STRUCT', 'SEG_Memb', 'SEG_DNA'],
     [CONTOUR_CHANNEL_KEY]: ['CON_Memb', 'CON_DNA']
 };


### PR DESCRIPTION
Fixes a bug in which channels are grouped wrongly because the name matches a regex but is not in the proper list of approved names.
Future TODO: can this be more data driven somehow?  It's pretty specific to AICS data.