### PR TITLE
dont show switch if no parent image

### DIFF
--- a/src/aics-image-viewer/components/App/index.jsx
+++ b/src/aics-image-viewer/components/App/index.jsx
@@ -931,6 +931,7 @@ export default class App extends React.Component {
                 channelDataChannels={this.state.image ? this.state.image.channels : null}
                 channelGroupedByType={this.state.channelGroupedByType}
                 hasCellId={this.state.hasCellId}
+                hasParentImage={!!this.state.fovPath}
                 channelDataReady={this.state.channelDataReady}
                 fovDownloadHref={fovDownloadHref}
                 cellDownloadHref={cellDownloadHref}

--- a/src/aics-image-viewer/components/ControlPanel/index.jsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.jsx
@@ -50,20 +50,20 @@ export default class ControlPanel extends React.Component {
   createFovCellSwitchControls() {
     const {
       imageType,
-      hasCellId
+      hasCellId,
+      hasParentImage
     } = this.props;
-    return hasCellId && (
-      <RadioGroup
-        defaultValue={imageType}
-        onChange={this.handleSwitchFovCell}
-      >
-        <Radio.Button
-          value={SEGMENTED_CELL}
-        >Cell</Radio.Button>
-        <Radio.Button
-          value={FULL_FIELD_IMAGE}
-        >Full Field</Radio.Button>
-      </RadioGroup>
+    return (
+      hasCellId &&
+      hasParentImage && (
+        <RadioGroup
+          defaultValue={imageType}
+          onChange={this.handleSwitchFovCell}
+        >
+          <Radio.Button value={SEGMENTED_CELL}>Cell</Radio.Button>
+          <Radio.Button value={FULL_FIELD_IMAGE}>Full Field</Radio.Button>
+        </RadioGroup>
+      )
     );
   }
 


### PR DESCRIPTION
Problem
If a cell image and full field image dont exist, we don't need to show the full field switcher

Solution
Hide the switch if full field image isn't sent in through props. 


Tech debt:
In the long run we need to change names to 'mainImage' 'parentImage' or something. And we might even want to send in the button names as props, instead of having it hard coded to "cell" and "full field" as it is now. 

