### PR TITLE
fix bug when applying Color presets, when number of channels is less than number of colors

### DIFF
--- a/src/aics-image-viewer/components/App/index.jsx
+++ b/src/aics-image-viewer/components/App/index.jsx
@@ -822,7 +822,9 @@ export default class App extends React.Component {
   onApplyColorPresets(presets) {
     const { userSelections } = this.state;
     presets.forEach((color, index) => {
-      this.handleChangeToImage(COLOR, color, index);
+      if (index < userSelections[CHANNEL_SETTINGS].length) {
+        this.handleChangeToImage(COLOR, color, index);
+      }
     });
     const newChannels = userSelections[CHANNEL_SETTINGS].map((channel, channelindex) => {
       return presets[channelindex] ? { ...channel, color: presets[channelindex] } : channel;


### PR DESCRIPTION
Fixing an out of bounds access.  When the number of color presets is greater than the number of channels, it was crashing when trying to apply color presets.
