### PR TITLE
Fix/apply style constant to antd sliders

### DIFF
--- a/src/aics-image-viewer/components/ChannelsWidgetRow/index.jsx
+++ b/src/aics-image-viewer/components/ChannelsWidgetRow/index.jsx
@@ -119,7 +119,7 @@ export default class ChannelsWidgetRow extends React.Component {
               min={isoRange.min || 0}
               max={isoRange.max || 225}
               defaultValue={ISOVALUE_DEFAULT}
-              sliderStyle={STYLES.slider}
+              style={STYLES.slider}
               onChange={this.onIsovalueChange}/>
         </Col>
       </Row>
@@ -140,7 +140,7 @@ export default class ChannelsWidgetRow extends React.Component {
             min={range.min}
             max={range.max}
             defaultValue={ISOSURFACE_OPACITY_DEFAULT * ISOSURFACE_OPACITY_SLIDER_MAX}
-            sliderStyle={STYLES.slider}
+            style={STYLES.slider}
             onChange={this.onOpacityChange}/>
         </Col>
       </Row>


### PR DESCRIPTION
While I was working on https://aicsjira.corp.alleninstitute.org/browse/CFE-68, I noticed that the antd `Slider` components in this repo had a strange sounding attribute called `sliderStyle`. When I adjusted the value of `sliderStyle` I saw that the changes were not reflected in the UI. When I renamed `sliderStyle` to `style`, however, I could change the style value (`STYLES.slider`) and see the changes reflected in the UI.

For some reason, the antd stylesheet for the Slider component isn't getting imported and/or applied to cell-feature-explorer. That is probably what's causing the bug in CFE-68, and maybe this PR will fix that. But even if this doesn't fix CFE-68, this `sliderStyle` -> `style` renaming seems like a good thing to do.