### PR TITLE
Fix/color picker gets cut off at bottom

### DIFF
--- a/src/aics-image-viewer/components/ControlPanel/styles.scss
+++ b/src/aics-image-viewer/components/ControlPanel/styles.scss
@@ -7,7 +7,6 @@
 .control-panel {
     flex: 1 auto;
     order: 1;
-    overflow-y: scroll;
     max-width: 540px;
     .ant-card-head {
         border-bottom: none;


### PR DESCRIPTION
Resolves: [viewer: color picker is partially invisible](https://aicsjira.corp.alleninstitute.org/browse/CFE-74)

I removed the overflow setting for the `ControlPanel` card and the color picker doesn't get cut off anymore.  I checked that everything is still scrollable and accessible despite the overflow property being gone, but please double check me.

![image](https://user-images.githubusercontent.com/12690133/127545413-c90eb99d-1757-4cda-a55c-768447d5e041.png)


**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
