### PR TITLE
Fix/progress bar is pushing viewer canvas down

### DIFF
--- a/public/App.scss
+++ b/public/App.scss
@@ -5,15 +5,17 @@ html,
 body {
   height: 100%;
   width: 100%;
+  display: flex;
   font-family: 'Overpass'
 }
 
-// Adjust container width (height needs to be changed through the appHeight prop for ImageViewerApp
-// because multiple components depend on it)
-.cell-viewer-app {
-  width: 100vw;
+.mycellviewer {
+  display: flex;
+  flex: 1;
+  height: 45vw;
+  width: 100%;
 }
 
-#cell-viewer .ant-collapse > .ant-collapse-item > .ant-collapse-header .ant-collapse-arrow {
+.mycellviewer .ant-collapse > .ant-collapse-item > .ant-collapse-header .ant-collapse-arrow {
   transform: translateY(-270%);
 }

--- a/public/index.jsx
+++ b/public/index.jsx
@@ -56,19 +56,23 @@ const channelGroupingMap = {
 
 
 ReactDOM.render(
-  <ImageViewerApp
-    cellId={cellid}
-    baseUrl={baseurl}
-    //cellPath="AICS-25/AICS-25_6035_43757"
-    //fovPath="AICS-25/AICS-25_6035"
-    cellPath={cellPath}
-    fovPath={fovPath}
-    defaultVolumesOn={[0, 1, 2]}
-    defaultSurfacesOn={[]}
-    fovDownloadHref={fovDownloadHref}
-    cellDownloadHref={cellDownloadHref}
-    channelNameMapping={mapping}
-    groupToChannelNameMap={channelGroupingMap}
-  />,
+  <section className="ant-layout">
+    <div className="mycellviewer">
+      <ImageViewerApp
+        cellId={cellid}
+        baseUrl={baseurl}
+        //cellPath="AICS-25/AICS-25_6035_43757"
+        //fovPath="AICS-25/AICS-25_6035"
+        cellPath={cellPath}
+        fovPath={fovPath}
+        defaultVolumesOn={[0, 1, 2]}
+        defaultSurfacesOn={[]}
+        fovDownloadHref={fovDownloadHref}
+        cellDownloadHref={cellDownloadHref}
+        channelNameMapping={mapping}
+        groupToChannelNameMap={channelGroupingMap}
+      />
+    </div>
+  </section>,
   document.getElementById("cell-viewer")
 );


### PR DESCRIPTION
Resolves: [canvas extends below bottom of component](https://aicsjira.corp.alleninstitute.org/browse/ANIMCELLGR-677)

I don't know what triggers the progress bar to animate, so I haven't checked that this change doesn't break the styling when the progress bar is animating. If someone wants to check that or let me know how I can see it animating that'd be great.

### Before:
![image](https://user-images.githubusercontent.com/12690133/129282092-e638cb37-416e-4bec-9b1e-bbe49e657956.png)

### After (Notice more room below the ROI clipping sliders):
![image](https://user-images.githubusercontent.com/12690133/129282144-d9437274-6f1b-45a1-b09c-285947b03b50.png)


**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
