### PR TITLE
Fix/volume settings for contour channels (update volume-viewer to v2.2.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@aics/volume-viewer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-2.2.0.tgz",
-      "integrity": "sha512-/8AUfpC+swhsnABA1AgId5ZJQEq8KMT9S3a4jKIGHuPYATdh3UbGKJtvMAbSjnMDrSn896trn6fYKbXHwbgBkw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-2.2.1.tgz",
+      "integrity": "sha512-DdvzAumNfc6OOQBgJq4ra5jcnD/vbwxHGguGVwn3NAVaOtksFJjNk55y85DWuhsnM21G58QY34nWAcfN1SuQog==",
       "requires": {
         "three": "^0.130.1"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/volume-viewer": "^2.2.0",
+    "@aics/volume-viewer": "^2.2.1",
     "classnames": "^2.2.5",
     "color-string": "^1.5.3",
     "d3": "^4.11.0",


### PR DESCRIPTION
Update volume-viewer from v2.2.0 to v2.2.1, which contains the [fix](https://github.com/AllenInstitute/volume-viewer/pull/33) for this bug:
[website-3d-cell-viewer crashes when trying to view volume settings for contour channels](https://aicsjira.corp.alleninstitute.org/browse/ANIMCELLGR-686)



**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
