### PR TITLE
Feature/bounding box toggle button

### DIFF
--- a/public/index.jsx
+++ b/public/index.jsx
@@ -77,7 +77,7 @@ const args = {
 };
 const viewerConfig = {
   showAxes: false,
-  showBounds: false,
+  showBoundingBox: false,
   view: "3D", // "XY", "XZ", "YZ"
   mode: "default", // "pathtrace", "maxprojection"
   maskAlpha: 50,

--- a/public/index.jsx
+++ b/public/index.jsx
@@ -77,6 +77,7 @@ const args = {
 };
 const viewerConfig = {
   showAxes: false,
+  showBounds: false,
   view: "3D", // "XY", "XZ", "YZ"
   mode: "default", // "pathtrace", "maxprojection"
   maskAlpha: 50,

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -100,7 +100,7 @@ const defaultProps: AppProps = {
   },
   viewerConfig: {
     showAxes: false,
-    showBounds: false,
+    showBoundingBox: false,
     view: "3D", // "XY", "XZ", "YZ"
     mode: "default", // "pathtrace", "maxprojection"
     maskAlpha: ALPHA_MASK_SLIDER_3D_DEFAULT[0],
@@ -177,7 +177,7 @@ export default class App extends React.Component<AppProps, AppState> {
         [MODE]: viewmode,
         [AUTO_ROTATE]: false,
         [SHOW_AXES]: props.viewerConfig.showAxes,
-        showBounds: props.viewerConfig.showBounds,
+        showBoundingBox: props.viewerConfig.showBoundingBox,
         [MAX_PROJECT]: maxproject,
         [PATH_TRACE]: pathtrace,
         [ALPHA_MASK_SLIDER_LEVEL]: [props.viewerConfig.maskAlpha] || ALPHA_MASK_SLIDER_3D_DEFAULT,
@@ -229,7 +229,7 @@ export default class App extends React.Component<AppProps, AppState> {
     this.setInitialChannelConfig = this.setInitialChannelConfig.bind(this);
     this.changeRenderingAlgorithm = this.changeRenderingAlgorithm.bind(this);
     this.changeAxisShowing = this.changeAxisShowing.bind(this);
-    this.changeBoundsShowing = this.changeBoundsShowing.bind(this);
+    this.changeBoundingBoxShowing = this.changeBoundingBoxShowing.bind(this);
   }
 
   componentDidMount() {
@@ -436,7 +436,7 @@ export default class App extends React.Component<AppProps, AppState> {
     // update current camera mode to make sure the image gets the update
     view3d.setCameraMode(enums.viewMode.VIEW_MODE_ENUM_TO_LABEL_MAP.get(userSelections.mode));
     view3d.setShowAxis(userSelections[SHOW_AXES]);
-    view3d.setShowBoundingBox(aimg, userSelections.showBounds);
+    view3d.setShowBoundingBox(aimg, userSelections.showBoundingBox);
     // tell view that things have changed for this image
     view3d.updateActiveChannels(aimg);
   }
@@ -717,7 +717,7 @@ export default class App extends React.Component<AppProps, AppState> {
     // update current camera mode to make sure the image gets the update
     view3d.setCameraMode(enums.viewMode.VIEW_MODE_ENUM_TO_LABEL_MAP.get(userSelections.mode));
     view3d.setShowAxis(userSelections[SHOW_AXES]);
-    view3d.setShowBoundingBox(aimg, userSelections.showBounds);
+    view3d.setShowBoundingBox(aimg, userSelections.showBoundingBox);
     // tell view that things have changed for this image
     view3d.updateActiveChannels(aimg);
 
@@ -798,7 +798,7 @@ export default class App extends React.Component<AppProps, AppState> {
       case SHOW_AXES:
         view3d.setShowAxis(newValue);
         break;
-      case "showBounds":
+      case "showBoundingBox":
         view3d.setShowBoundingBox(image, newValue);
         break;
       case SAVE_ISO_SURFACE:
@@ -968,9 +968,9 @@ export default class App extends React.Component<AppProps, AppState> {
     this.handleChangeToImage(SHOW_AXES, showAxes);
   }
 
-  changeBoundsShowing(showBounds) {
-    this.setUserSelectionsInState({ showBounds });
-    this.handleChangeToImage("showBounds", showBounds);
+  changeBoundingBoxShowing(showBoundingBox) {
+    this.setUserSelectionsInState({ showBoundingBox });
+    this.handleChangeToImage("showBoundingBox", showBoundingBox);
   }
 
   updateChannelTransferFunction(index, lut) {
@@ -1105,7 +1105,7 @@ export default class App extends React.Component<AppProps, AppState> {
             imageType={userSelections.imageType}
             autorotate={userSelections[AUTO_ROTATE]}
             showAxes={userSelections[SHOW_AXES]}
-            showBounds={userSelections.showBounds}
+            showBoundingBox={userSelections.showBoundingBox}
             alphaMaskSliderLevel={userSelections[ALPHA_MASK_SLIDER_LEVEL]}
             brightnessSliderLevel={userSelections[BRIGHTNESS_SLIDER_LEVEL]}
             densitySliderLevel={userSelections[DENSITY_SLIDER_LEVEL]}
@@ -1124,7 +1124,7 @@ export default class App extends React.Component<AppProps, AppState> {
             changeOneChannelSetting={this.changeOneChannelSetting}
             changeRenderingAlgorithm={this.changeRenderingAlgorithm}
             changeAxisShowing={this.changeAxisShowing}
-            changeBoundsShowing={this.changeBoundsShowing}
+            changeBoundingBoxShowing={this.changeBoundingBoxShowing}
             viewerChannelSettings={viewerChannelSettings}
           />
         </Sider>

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -100,6 +100,7 @@ const defaultProps: AppProps = {
   },
   viewerConfig: {
     showAxes: false,
+    showBounds: false,
     view: "3D", // "XY", "XZ", "YZ"
     mode: "default", // "pathtrace", "maxprojection"
     maskAlpha: ALPHA_MASK_SLIDER_3D_DEFAULT[0],
@@ -176,6 +177,7 @@ export default class App extends React.Component<AppProps, AppState> {
         [MODE]: viewmode,
         [AUTO_ROTATE]: false,
         [SHOW_AXES]: props.viewerConfig.showAxes,
+        showBounds: props.viewerConfig.showBounds,
         [MAX_PROJECT]: maxproject,
         [PATH_TRACE]: pathtrace,
         [ALPHA_MASK_SLIDER_LEVEL]: [props.viewerConfig.maskAlpha] || ALPHA_MASK_SLIDER_3D_DEFAULT,
@@ -227,6 +229,7 @@ export default class App extends React.Component<AppProps, AppState> {
     this.setInitialChannelConfig = this.setInitialChannelConfig.bind(this);
     this.changeRenderingAlgorithm = this.changeRenderingAlgorithm.bind(this);
     this.changeAxisShowing = this.changeAxisShowing.bind(this);
+    this.changeBoundsShowing = this.changeBoundsShowing.bind(this);
   }
 
   componentDidMount() {
@@ -433,6 +436,7 @@ export default class App extends React.Component<AppProps, AppState> {
     // update current camera mode to make sure the image gets the update
     view3d.setCameraMode(enums.viewMode.VIEW_MODE_ENUM_TO_LABEL_MAP.get(userSelections.mode));
     view3d.setShowAxis(userSelections[SHOW_AXES]);
+    view3d.setShowBoundingBox(aimg, userSelections.showBounds);
     // tell view that things have changed for this image
     view3d.updateActiveChannels(aimg);
   }
@@ -713,6 +717,7 @@ export default class App extends React.Component<AppProps, AppState> {
     // update current camera mode to make sure the image gets the update
     view3d.setCameraMode(enums.viewMode.VIEW_MODE_ENUM_TO_LABEL_MAP.get(userSelections.mode));
     view3d.setShowAxis(userSelections[SHOW_AXES]);
+    view3d.setShowBoundingBox(aimg, userSelections.showBounds);
     // tell view that things have changed for this image
     view3d.updateActiveChannels(aimg);
 
@@ -792,6 +797,9 @@ export default class App extends React.Component<AppProps, AppState> {
         break;
       case SHOW_AXES:
         view3d.setShowAxis(newValue);
+        break;
+      case "showBounds":
+        view3d.setShowBoundingBox(image, newValue);
         break;
       case SAVE_ISO_SURFACE:
         view3d.saveChannelIsosurface(image, index, newValue);
@@ -960,6 +968,11 @@ export default class App extends React.Component<AppProps, AppState> {
     this.handleChangeToImage(SHOW_AXES, showAxes);
   }
 
+  changeBoundsShowing(showBounds) {
+    this.setUserSelectionsInState({ showBounds });
+    this.handleChangeToImage("showBounds", showBounds);
+  }
+
   updateChannelTransferFunction(index, lut) {
     if (this.state.image) {
       this.state.image.setLut(index, lut);
@@ -1092,6 +1105,7 @@ export default class App extends React.Component<AppProps, AppState> {
             imageType={userSelections.imageType}
             autorotate={userSelections[AUTO_ROTATE]}
             showAxes={userSelections[SHOW_AXES]}
+            showBounds={userSelections.showBounds}
             alphaMaskSliderLevel={userSelections[ALPHA_MASK_SLIDER_LEVEL]}
             brightnessSliderLevel={userSelections[BRIGHTNESS_SLIDER_LEVEL]}
             densitySliderLevel={userSelections[DENSITY_SLIDER_LEVEL]}
@@ -1110,6 +1124,7 @@ export default class App extends React.Component<AppProps, AppState> {
             changeOneChannelSetting={this.changeOneChannelSetting}
             changeRenderingAlgorithm={this.changeRenderingAlgorithm}
             changeAxisShowing={this.changeAxisShowing}
+            changeBoundsShowing={this.changeBoundsShowing}
             viewerChannelSettings={viewerChannelSettings}
           />
         </Sider>

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -44,7 +44,7 @@ export interface AppProps {
   };
   viewerConfig: {
     showAxes: boolean;
-    showBounds: boolean;
+    showBoundingBox: boolean;
     view: string; // "3D", "XY", "XZ", "YZ"
     mode: string; // "default", "pathtrace", "maxprojection"
     maskAlpha: number; //ALPHA_MASK_SLIDER_3D_DEFAULT[0],
@@ -72,7 +72,7 @@ export interface UserSelectionState {
   [MAX_PROJECT]: boolean;
   [PATH_TRACE]: boolean;
   [SHOW_AXES]: boolean;
-  showBounds: boolean;
+  showBoundingBox: boolean;
   [ALPHA_MASK_SLIDER_LEVEL]: number[]; //[props.viewerConfig.maskAlpha] || ALPHA_MASK_SLIDER_3D_DEFAULT,
   [BRIGHTNESS_SLIDER_LEVEL]: number[]; //[props.viewerConfig.brightness] || BRIGHTNESS_SLIDER_LEVEL_DEFAULT,
   [DENSITY_SLIDER_LEVEL]: number[]; // [props.viewerConfig.density] || DENSITY_SLIDER_LEVEL_DEFAULT,

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -44,6 +44,7 @@ export interface AppProps {
   };
   viewerConfig: {
     showAxes: boolean;
+    showBounds: boolean;
     view: string; // "3D", "XY", "XZ", "YZ"
     mode: string; // "default", "pathtrace", "maxprojection"
     maskAlpha: number; //ALPHA_MASK_SLIDER_3D_DEFAULT[0],
@@ -71,6 +72,7 @@ export interface UserSelectionState {
   [MAX_PROJECT]: boolean;
   [PATH_TRACE]: boolean;
   [SHOW_AXES]: boolean;
+  showBounds: boolean;
   [ALPHA_MASK_SLIDER_LEVEL]: number[]; //[props.viewerConfig.maskAlpha] || ALPHA_MASK_SLIDER_3D_DEFAULT,
   [BRIGHTNESS_SLIDER_LEVEL]: number[]; //[props.viewerConfig.brightness] || BRIGHTNESS_SLIDER_LEVEL_DEFAULT,
   [DENSITY_SLIDER_LEVEL]: number[]; // [props.viewerConfig.density] || DENSITY_SLIDER_LEVEL_DEFAULT,

--- a/src/aics-image-viewer/components/ControlPanel/index.jsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.jsx
@@ -87,6 +87,11 @@ export default class ControlPanel extends React.Component {
     this.props.changeAxisShowing(axisShowing);
   }
 
+  toggleBoundsShowing() {
+    const boundsShowing = !this.props.showBounds;
+    this.props.changeBoundsShowing(boundsShowing);
+  }
+
   changeRenderMode({ target }) {
     this.props.changeRenderingAlgorithm(target.value);
   }
@@ -154,6 +159,16 @@ export default class ControlPanel extends React.Component {
     );
   }
 
+  renderBoundsButton() {
+    const { showBounds } = this.props;
+    const buttonContent = showBounds ? "Hide Bounds" : "Show Bounds";
+    return (
+      <Button onClick={() => this.toggleBoundsShowing()}>
+        {buttonContent}
+      </Button>
+    );
+  }
+
   render() {
     const {
       viewerChannelSettings,
@@ -195,7 +210,12 @@ export default class ControlPanel extends React.Component {
               this.renderColorPresetsDropdown(),
           ]}
         />
-        <Card.Meta title={this.renderAxesButton()} />
+        <Card.Meta
+          title={[
+            this.renderAxesButton(),
+            this.renderBoundsButton()
+          ]}
+        />
         {hasImage ? (
           <div className="channel-rows-list">
             <ChannelsWidget

--- a/src/aics-image-viewer/components/ControlPanel/index.jsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.jsx
@@ -87,9 +87,9 @@ export default class ControlPanel extends React.Component {
     this.props.changeAxisShowing(axisShowing);
   }
 
-  toggleBoundsShowing() {
-    const boundsShowing = !this.props.showBounds;
-    this.props.changeBoundsShowing(boundsShowing);
+  toggleBoundingBoxShowing() {
+    const boundingBoxShowing = !this.props.showBoundingBox;
+    this.props.changeBoundingBoxShowing(boundingBoxShowing);
   }
 
   changeRenderMode({ target }) {
@@ -159,11 +159,11 @@ export default class ControlPanel extends React.Component {
     );
   }
 
-  renderBoundsButton() {
-    const { showBounds } = this.props;
-    const buttonContent = showBounds ? "Hide Bounds" : "Show Bounds";
+  renderBoundingBoxButton() {
+    const { showBoundingBox } = this.props;
+    const buttonContent = showBoundingBox ? "Hide Bounds" : "Show Bounds";
     return (
-      <Button onClick={() => this.toggleBoundsShowing()}>
+      <Button onClick={() => this.toggleBoundingBoxShowing()}>
         {buttonContent}
       </Button>
     );
@@ -213,7 +213,7 @@ export default class ControlPanel extends React.Component {
         <Card.Meta
           title={[
             this.renderAxesButton(),
-            this.renderBoundsButton()
+            this.renderBoundingBoxButton()
           ]}
         />
         {hasImage ? (


### PR DESCRIPTION
Resolves #28
- adds a toggle button to show/hide the bounding box
- adds the prop `showBoundingBox` to the `App` component

Per #32, does NOT add a symbolic constant for property key name (e.g. `SHOW_BOUNDS = "showBounds"`).

Screenshot from Cell Feature Explorer:
![image](https://user-images.githubusercontent.com/53030214/181640568-eed66cf5-7901-40fd-9420-1961bbf2867d.png)