### PR TITLE
Feature/dry state on init

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -228,7 +228,7 @@ export default class App extends React.Component<AppProps, AppState> {
     this.handleChangeUserSelection = this.handleChangeUserSelection.bind(this);
     this.handleChangeToImage = this.handleChangeToImage.bind(this);
     this.updateStateOnLoadImage = this.updateStateOnLoadImage.bind(this);
-    this.intializeNewImage = this.intializeNewImage.bind(this);
+    this.initializeNewImage = this.initializeNewImage.bind(this);
     this.onView3DCreated = this.onView3DCreated.bind(this);
     this.createChannelGrouping = this.createChannelGrouping.bind(this);
     this.beginRequestImage = this.beginRequestImage.bind(this);
@@ -365,7 +365,7 @@ export default class App extends React.Component<AppProps, AppState> {
           [MODE]: doResetViewMode ? ViewMode.threeD : this.state.userSelections.mode,
         },
       });
-      this.intializeNewImage(aimg, newChannelSettings);
+      this.initializeNewImage(aimg, newChannelSettings);
     } else if (stateKey === "prevImg") {
       this.setState({ prevImg: aimg });
     } else if (stateKey === "nextImg") {
@@ -448,7 +448,7 @@ export default class App extends React.Component<AppProps, AppState> {
     }
   }
 
-  intializeNewImage(aimg, newChannelSettings?) {
+  initializeNewImage(aimg: Volume, newChannelSettings?) {
     // set alpha slider first time image is loaded to something that makes sense
     let alphaLevel = this.getInitialAlphaLevel();
     this.setUserSelectionsInState({ [ALPHA_MASK_SLIDER_LEVEL]: alphaLevel });
@@ -536,7 +536,7 @@ export default class App extends React.Component<AppProps, AppState> {
     return newChannelSettings;
   }
 
-  initializeLut(aimg, channelIndex) {
+  initializeLut(aimg: Volume, channelIndex) {
     const histogram = aimg.getHistogram(channelIndex);
 
     const initViewerSettings = this.props.viewerChannelSettings;
@@ -587,7 +587,7 @@ export default class App extends React.Component<AppProps, AppState> {
     return newControlPoints;
   }
 
-  onChannelDataLoaded(aimg, thisChannelsSettings, channelIndex, keepLuts) {
+  onChannelDataLoaded(aimg: Volume, thisChannelsSettings, channelIndex, keepLuts) {
     const { image, view3d } = this.state;
     if (aimg !== image) {
       return;
@@ -633,7 +633,7 @@ export default class App extends React.Component<AppProps, AppState> {
     const { prevImgPath } = this.props;
 
     // assume prevImg is available to initialize
-    this.intializeNewImage(prevImg);
+    this.initializeNewImage(prevImg);
     this.setState({
       image: prevImg,
       nextImg: image,
@@ -647,7 +647,7 @@ export default class App extends React.Component<AppProps, AppState> {
     const { nextImgPath } = this.props;
 
     // assume nextImg is available to initialize
-    this.intializeNewImage(nextImg);
+    this.initializeNewImage(nextImg);
     this.setState({
       image: nextImg,
       prevImg: image,
@@ -656,7 +656,7 @@ export default class App extends React.Component<AppProps, AppState> {
     this.openImage(nextImgPath, true, "nextImg");
   }
 
-  initializeOneChannelSetting(aimg, channel, index, defaultColor) {
+  initializeOneChannelSetting(aimg: Volume, channel, index, defaultColor) {
     const { viewerChannelSettings } = this.props;
     let color = defaultColor;
     let volumeEnabled = false;

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -472,7 +472,7 @@ export default class App extends React.Component<AppProps, AppState> {
   }
 
   // set up the Volume into the Viewer using the current initial settings
-  private placeImageInViewer(aimg:Volume, newChannelSettings?):void {
+  private placeImageInViewer(aimg: Volume, newChannelSettings?): void {
     const { userSelections, view3d } = this.state;
     const channelSetting = newChannelSettings || userSelections[CHANNEL_SETTINGS];
     view3d.removeAllVolumes();
@@ -497,7 +497,7 @@ export default class App extends React.Component<AppProps, AppState> {
     view3d.updateMaskAlpha(aimg, imageMask);
 
     view3d.setMaxProjectMode(aimg, userSelections[MAX_PROJECT]);
-    
+
     const imageBrightness = brightnessSliderToImageValue(
       userSelections[BRIGHTNESS_SLIDER_LEVEL],
       userSelections[PATH_TRACE]
@@ -874,10 +874,10 @@ export default class App extends React.Component<AppProps, AppState> {
     let newSelectionState: Partial<UserSelectionState> = {
       [MODE]: newMode,
     };
-    
+
     // TODO the following behavior/logic is very specific to a particular application's needs
     // and is not necessarily appropriate for a general viewer.
-    // Why should the alpha setting matter whether we are viewing the primary image 
+    // Why should the alpha setting matter whether we are viewing the primary image
     // or its parent?
 
     // If switching between 2D and 3D reset alpha mask to default (off in in 2D, 50% in 3D)

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -1121,8 +1121,6 @@ export default class App extends React.Component<AppProps, AppState> {
         >
           <ControlPanel
             renderConfig={renderConfig}
-            // viewer capabilities
-            canPathTrace={this.state.view3d ? this.state.view3d.canvas3d.hasWebGL2 : false}
             // image state
             imageName={this.state.image ? this.state.image.name : false}
             hasImage={!!this.state.image}

--- a/src/aics-image-viewer/components/ControlPanel/index.jsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.jsx
@@ -70,7 +70,6 @@ export default function ControlPanel(props) {
             densitySliderLevel={props.densitySliderLevel}
             gammaSliderLevel={props.gammaSliderLevel}
             maxProjectOn={props.maxProjectOn}
-            canPathTrace={props.canPathTrace}
             pathTraceOn={props.pathTraceOn}
             renderConfig={renderConfig}
           />


### PR DESCRIPTION
While debugging some code, I made a few DRY refactors that consolidate repeated code in a couple of places, and removed an unused function and an unused prop.

This is hopefully a net positive on readability, even if the diff looks funky.  It also consolidates a couple of places where setState was being called consecutively... there are a lot more of those, unfortunately.

A lot of what happens in the top level code here is that the react state changes also need to make calls into a pure JS api on this "view3d" object, and keep the ui consistent with what's internal to the view3d.