### PR TITLE
Feature/ROI sliders: styling

### DIFF
--- a/src/aics-image-viewer/assets/styles/axis-style-override.css
+++ b/src/aics-image-viewer/assets/styles/axis-style-override.css
@@ -22,18 +22,16 @@
     content: none;
   }
 
+  /* Slider handle arrow */
   .noUi-handle::after {
     background-color: inherit;
     width: 6px;
     height: 6px;
     top: 0;
     left: 0;
+    /* rotate 45deg, skew vertically, translate down */
     transform: matrix(0.5, 1, -0.5, 1, 0, 5);
     content: "";
-  }
-
-  .noUi-connects {
-    border-radius: 0;
   }
 
   .noUi-connect {
@@ -48,11 +46,6 @@
     height: 2px;
   }
 
-  .axis-slider .noUi-horizontal {
-    height: 4px;
-    background: $dimgray;
-  }
-
   .noUi-target {
     border: none;
     box-shadow: none;
@@ -63,5 +56,6 @@
     background-color: transparent;
     color: inherit;
     font-size: 10px;
+    top: calc(100% + 3px);
   }
 }

--- a/src/aics-image-viewer/assets/styles/axis-style-override.css
+++ b/src/aics-image-viewer/assets/styles/axis-style-override.css
@@ -4,30 +4,25 @@
   /*slider settings*/
   .noUi-handle {
     box-shadow: none;
-    box-sizing: border-box;
-    position: absolute;
     cursor: pointer;
     pointer-events: inherit;
+    background-color: $slider-color;
     top: 0px;
     left: 100%;
     z-index: 1;
-    margin: 1px 0px 0px;
     width: 6px;
     height: 8px;
-    background-clip: padding-box;
     border: none;
     border-radius: 0;
-    transform: translate(-50%, calc(-100% - 6px));
-    transition: background-color 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms,
-      border-color 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, width 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms,
-      height 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
-    overflow: visible;
-    outline: none;
+    transform: translate(-50%, calc(-100% - 5px));
+  }
+
+  .noUi-handle::before {
+    display: none;
+    content: none;
   }
 
   .noUi-handle::after {
-    position: absolute;
-    display: block;
     background-color: inherit;
     width: 6px;
     height: 6px;
@@ -61,11 +56,6 @@
   .noUi-target {
     border: none;
     box-shadow: none;
-  }
-
-  .noUi-handle:before {
-    display: none;
-    content: none;
   }
 
   .noUi-tooltip {

--- a/src/aics-image-viewer/assets/styles/axis-style-override.css
+++ b/src/aics-image-viewer/assets/styles/axis-style-override.css
@@ -2,8 +2,7 @@
 
 %axis-override {
   /*slider settings*/
-  .noUi-handle,
-  .noUi-horizontal .noUi-handle {
+  .noUi-handle {
     box-shadow: none;
     box-sizing: border-box;
     position: absolute;
@@ -13,25 +12,43 @@
     left: 100%;
     z-index: 1;
     margin: 1px 0px 0px;
-    width: 12px;
-    height: 12px;
-    background-color: $dark-gray;
+    width: 6px;
+    height: 8px;
     background-clip: padding-box;
-    border: 2px solid $slider-color;
-    border-radius: 50%;
-    transform: translate(-50%, -50%);
-    transition: background 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms,
+    border: none;
+    border-radius: 0;
+    transform: translate(-50%, calc(-100% - 6px));
+    transition: background-color 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms,
       border-color 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms, width 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms,
       height 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
     overflow: visible;
     outline: none;
   }
+
+  .noUi-handle::after {
+    position: absolute;
+    display: block;
+    background-color: inherit;
+    width: 6px;
+    height: 6px;
+    top: 0;
+    left: 0;
+    transform: matrix(0.5, 1, -0.5, 1, 0, 5);
+    content: "";
+  }
+
+  .noUi-connects {
+    border-radius: 0;
+  }
+
   .noUi-connect {
-    background: $slider-color;
+    background-color: $slider-color;
   }
+
   .noUi-target.noUi-ltr.noUi-horizontal {
-    background: $slider-color;
+    background-color: $slider-color;
   }
+
   .noUi-horizontal {
     height: 2px;
   }
@@ -46,20 +63,14 @@
     box-shadow: none;
   }
 
-  .axis-slider .noUi-handle:before,
-  .noUi-handle:before,
-  .noUi-handle:after,
-  [disabled].axis-slider .noUi-handle:after,
-  .noUi-handle:after,
-  .axis-slider .noUi-handle:after,
-  .noUi-handle:after,
   .noUi-handle:before {
     display: none;
     content: none;
   }
+
   .noUi-tooltip {
     border: none;
-    background: transparent;
+    background-color: transparent;
     color: inherit;
     font-size: 10px;
   }

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -126,12 +126,14 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     }
   }
 
-  createSlider(axis: string) {
+  createSlider(axis: string, playButton: boolean) {
     const start = this.state.sliders[axis];
     const range = { min: 0, max: this.props.numSlices[axis] };
+    const playOnClick = this.state.playing ? this.pause : this.play;
+    const playIcon = this.state.playing ? "pause" : "caret-right";
 
     return (
-      <div key={axis} className="slider-row">
+      <div key={axis} className={`slider-row slider-${axis}`}>
         <span className="axis-slider">
           <Nouislider
             connect={true}
@@ -146,6 +148,13 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
         </span>
         <span className="slider-name">{axis.toUpperCase()}</span>
         <span className="slider-slices">{`${start[0]}, ${start[1]} (${range.max})`}</span>
+        {playButton && (
+          <Button.Group>
+            <Button type="primary" shape="circle" icon="step-backward" onClick={() => this.step(true)} />
+            <Button type="primary" onClick={playOnClick} icon={playIcon} />
+            <Button type="primary" shape="circle" icon="step-forward" onClick={() => this.step(false)} />
+          </Button.Group>
+        )}
       </div>
     );
   }
@@ -174,20 +183,11 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
   }
 
   render() {
-    const playOnClick = this.state.playing ? this.pause : this.play;
-    const playIcon = this.state.playing ? "pause" : "caret-right";
     const activeAxis = this.getActiveAxis();
     return (
-      <div className="clip-sliders">
-        <h4>Region of interest clipping</h4>
-        {activeAxis ? this.createSlider(activeAxis) : AXES.map(this.createSlider)}
-        {activeAxis && (
-          <Button.Group>
-            <Button type="primary" shape="circle" icon="step-backward" onClick={() => this.step(true)} />
-            <Button type="primary" onClick={playOnClick} icon={playIcon} />
-            <Button type="primary" shape="circle" icon="step-forward" onClick={() => this.step(false)} />
-          </Button.Group>
-        )}
+      <div className={activeAxis ? "clip-sliders clip-sliders-2d" : "clip-sliders"}>
+        <h4>Region of interest</h4>
+        {activeAxis ? this.createSlider(activeAxis, true) : AXES.map((axis) => this.createSlider(axis, false))}
       </div>
     );
   }

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -1,5 +1,5 @@
 import { mapValues } from "lodash";
-import { Button } from "antd";
+import { Button, Tooltip } from "antd";
 import Nouislider from "nouislider-react";
 import "nouislider/distribute/nouislider.css";
 
@@ -150,9 +150,15 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
         <span className="slider-slices">{`${start[0]}, ${start[1]} (${range.max})`}</span>
         {playButton && (
           <Button.Group>
-            <Button type="primary" shape="circle" icon="step-backward" onClick={() => this.step(true)} />
-            <Button type="primary" onClick={playOnClick} icon={playIcon} />
-            <Button type="primary" shape="circle" icon="step-forward" onClick={() => this.step(false)} />
+            <Tooltip placement="top" title="Step back">
+              <Button icon="step-backward" onClick={() => this.step(true)} />
+            </Tooltip>
+            <Tooltip placement="top" title="Play through sequence">
+              <Button onClick={playOnClick} icon={playIcon} />
+            </Tooltip>
+            <Tooltip placement="top" title="Step forward">
+              <Button icon="step-forward" onClick={() => this.step(false)} />
+            </Tooltip>
           </Button.Group>
         )}
       </div>

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -139,6 +139,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
             connect={true}
             range={range}
             start={start}
+            step={1}
             behaviour="drag"
             // round slider output to nearest slice; assume any string inputs represent ints
             format={{ to: Math.round, from: parseInt }}
@@ -149,7 +150,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
         <span className="slider-name">{axis.toUpperCase()}</span>
         <span className="slider-slices">{`${start[0]}, ${start[1]} (${range.max})`}</span>
         {playButton && (
-          <Button.Group>
+          <Button.Group className="slider-play-buttons">
             <Tooltip placement="top" title="Step back">
               <Button icon="step-backward" onClick={() => this.step(true)} />
             </Tooltip>

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -144,7 +144,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
             // round slider output to nearest slice; assume any string inputs represent ints
             format={{ to: Math.round, from: parseInt }}
             onUpdate={this.makeSliderUpdateFn(axis)}
-            onEnd={this.makeSliderDragEndFn(axis)}
+            onSet={this.makeSliderSetFn(axis)}
           />
         </span>
         <span className="slider-name">{axis.toUpperCase()}</span>
@@ -184,8 +184,8 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     };
   }
 
-  // When user finishes dragging the active slider, update slice label
-  makeSliderDragEndFn(axis: string) {
+  // When user finishes moving the active slider, update slice label
+  makeSliderSetFn(axis: string) {
     return (values: number[]) => this.setSliderState(axis, values);
   }
 

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -82,14 +82,14 @@
   }
 
   .ant-btn {
-    line-height: 1.25;
+    line-height: 1.2;
     height: 20px;
     color: $dimgray;
-    border-color: #d9d9d9 !important;
+    border-color: $dimgray !important;
 
     &:hover,
     &:focus {
-      color: $light-gray;
+      color: white;
     }
 
     &[ant-click-animating-without-extra-node="true"]::after {

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -1,4 +1,5 @@
 @import "../../assets/styles/axis-style-override";
+@import "../../assets/styles/variables";
 
 .clip-sliders {
   --color-x: #ff4d4d;
@@ -78,5 +79,22 @@
   .noUi-target {
     height: 4px;
     background-color: rgba(160, 160, 160, 0.4) !important;
+  }
+
+  .ant-btn {
+    line-height: 1.25;
+    height: 20px;
+    color: $dimgray;
+    border-color: #d9d9d9 !important;
+
+    &:hover,
+    &:focus {
+      color: $light-gray;
+    }
+
+    &[ant-click-animating-without-extra-node="true"]::after {
+      box-shadow: none !important;
+      background-color: $dimgray;
+    }
   }
 }

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -56,7 +56,7 @@
 
   .slider-name,
   .slider-slices,
-  .ant-btn-group {
+  .slider-play-buttons {
     margin-left: 20px;
     white-space: nowrap;
   }
@@ -73,7 +73,7 @@
   }
 
   &.clip-sliders-2d {
-    max-width: 800px;
+    max-width: 780px;
   }
 
   .noUi-target {

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -18,7 +18,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    color: gray;
+    color: #bfbfbf;
 
     &.slider-x {
       .slider-name {
@@ -81,11 +81,16 @@
     background-color: rgba(160, 160, 160, 0.4) !important;
   }
 
-  .ant-btn {
+  .slider-play-buttons .ant-btn {
     line-height: 1.2;
-    height: 20px;
+    height: 21px;
     color: $dimgray;
     border-color: $dimgray !important;
+    background-color: transparent;
+
+    &:hover {
+      background-color: rgba(160, 160, 160, 0.4);
+    }
 
     &:hover,
     &:focus {
@@ -94,7 +99,7 @@
 
     &[ant-click-animating-without-extra-node="true"]::after {
       box-shadow: none !important;
-      background-color: $dimgray;
+      background-color: $light-gray;
     }
   }
 }

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -6,7 +6,7 @@
   --color-z: #0099ff;
 
   @extend %axis-override;
-  max-width: 612px;
+  max-width: 665px;
   position: absolute;
   margin: auto;
   left: 0;
@@ -18,46 +18,65 @@
     justify-content: center;
     align-items: center;
     color: gray;
+
+    &.slider-x {
+      .slider-name {
+        color: var(--color-x);
+      }
+      .noUi-handle {
+        background-color: var(--color-x) !important;
+      }
+    }
+
+    &.slider-y {
+      .slider-name {
+        color: var(--color-y);
+      }
+      .noUi-handle {
+        background-color: var(--color-y) !important;
+      }
+    }
+
+    &.slider-z {
+      .slider-name {
+        color: var(--color-z);
+      }
+      .noUi-handle {
+        background-color: var(--color-z) !important;
+      }
+    }
   }
 
   .axis-slider {
-    flex: 1 1 auto;
+    flex: 1 1 480px;
     max-width: 480px;
     margin-top: 0.5em;
   }
 
   .slider-name,
-  .slider-slices {
+  .slider-slices,
+  .ant-btn-group {
     margin-left: 20px;
     white-space: nowrap;
   }
 
   .slider-name {
     flex: 0 0 12px;
+    font-weight: bold;
   }
 
   .slider-slices {
-    flex: 0 0 80px;
+    flex: 0 0 85px;
+    text-align: right;
+    max-width: 85px;
   }
 
-  .slider-x {
-    color: var(--color-x);
-    .noUi-handle {
-      background-color: var(--color-x) !important;
-    }
+  &.clip-sliders-2d {
+    max-width: 800px;
   }
 
-  .slider-y {
-    color: var(--color-y);
-    .noUi-handle {
-      background-color: var(--color-y) !important;
-    }
-  }
-
-  .slider-z {
-    color: var(--color-z);
-    .noUi-handle {
-      background-color: var(--color-z) !important;
-    }
+  .noUi-target {
+    height: 4px;
+    background-color: rgba(160, 160, 160, 0.4) !important;
   }
 }

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -43,21 +43,21 @@
   .slider-x {
     color: var(--color-x);
     .noUi-handle {
-      background-color: var(--color-x);
+      background-color: var(--color-x) !important;
     }
   }
 
   .slider-y {
     color: var(--color-y);
     .noUi-handle {
-      background-color: var(--color-y);
+      background-color: var(--color-y) !important;
     }
   }
 
   .slider-z {
     color: var(--color-z);
     .noUi-handle {
-      background-color: var(--color-z);
+      background-color: var(--color-z) !important;
     }
   }
 }

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -1,6 +1,10 @@
 @import "../../assets/styles/axis-style-override";
 
 .clip-sliders {
+  --color-x: #ff4d4d;
+  --color-y: #61d900;
+  --color-z: #0099ff;
+
   @extend %axis-override;
   max-width: 612px;
   position: absolute;
@@ -34,5 +38,26 @@
 
   .slider-slices {
     flex: 0 0 80px;
+  }
+
+  .slider-x {
+    color: var(--color-x);
+    .noUi-handle {
+      background-color: var(--color-x);
+    }
+  }
+
+  .slider-y {
+    color: var(--color-y);
+    .noUi-handle {
+      background-color: var(--color-y);
+    }
+  }
+
+  .slider-z {
+    color: var(--color-z);
+    .noUi-handle {
+      background-color: var(--color-z);
+    }
   }
 }

--- a/src/aics-image-viewer/components/BottomPanel/index.tsx
+++ b/src/aics-image-viewer/components/BottomPanel/index.tsx
@@ -3,13 +3,13 @@ import { Drawer, Button, Icon } from "antd";
 
 import "./styles.css";
 
-export function BottomPanel({ children }: React.PropsWithChildren<{}>) {
+export function BottomPanel({ title, children }: React.PropsWithChildren<{ title?: string }>) {
   const [isVisible, setIsVisible] = useState(false);
   const toggleDrawer = () => setIsVisible(!isVisible);
 
   const optionsButton = (
     <Button className="options-button" size="small" onClick={toggleDrawer}>
-      Options
+      {title || "Options"}
       <Icon type="double-left" className="button-arrow" />
     </Button>
   );

--- a/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.jsx
+++ b/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.jsx
@@ -55,7 +55,7 @@ export default class ViewerWrapper extends React.Component {
     return (
       <div className="cell-canvas" style={{ ...STYLES.viewer, height: appHeight }}>
         <div ref={this.view3dviewerRef} style={STYLES.view3d}></div>
-        <BottomPanel>
+        <BottomPanel title="Clipping">
           {renderConfig.axisClipSliders && !!image && (
             <AxisClipSliders mode={mode} setAxisClip={setAxisClip} numSlices={numSlices} />
           )}


### PR DESCRIPTION
Resolves #48 by restyling the ROI sliders and associated elements to [specification](https://xd.adobe.com/view/904d6444-a800-48b6-8844-4f6f116d85ab-c51e). Highlights include: color coded axis sliders, new slider handles that allow dragging ranges even when the range is very small, restyled play buttons with tooltips.

Also: sliders step along integer values, numeric readouts should update more reliably when slider is moved with arrow keys, and the `BottomPanel` component gets a `title` prop.

NOTE: some color choices, particularly in play buttons, are chosen specifically to stand out against the dark backdrop of CFE and don't work well at all with the current default look of web-3d-viewer. A separate PR in the very near future will attempt to consolidate some styles from CFE, clean up existing styles, and unify colors to provide a sensible default theme (and potentially one or more alternate themes), per #45.

Screenshots from Cell Feature Explorer:
![image](https://user-images.githubusercontent.com/53030214/187802658-ec69141b-7f48-4ba7-9506-10c019fca502.png)
![image](https://user-images.githubusercontent.com/53030214/187802715-5167caa5-fc6e-4f0f-81de-f16a1e208ccb.png)
