### PR TITLE
Feature/ROI sliders: single-slice in 2d mode

### DIFF
--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -177,6 +177,8 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
         const thicknessReduce = isActiveAxis ? step - stepEpsilon : 0.0;
 
         const start = values[0] / max - 0.5;
+        // values.length is the number of handles on this slider:
+        // either one handle (2d mode), or a range with 2 handles (3d mode)
         const end = values[values.length - 1] / max - 0.5 - thicknessReduce / max;
 
         // get a value from -0.5..0.5
@@ -187,6 +189,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
 
   // When user finishes moving the active slider, update slice label
   makeSliderSetFn(axis: string) {
+    // Values may be of length 1 or 2 (see above, in makeSliderUpdateFn); ensure we pass 2 values regardless
     return (values: number[]) => this.setSliderState(axis, [values[0], values[values.length - 1]]);
   }
 

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -10,7 +10,7 @@ import "./styles.css";
 import viewMode from "../../shared/enums/viewMode";
 const ViewMode = viewMode.mainMapping;
 
-const AXES = Object.freeze(["x", "y", "z"]);
+const AXES = ["x", "y", "z"];
 const PLAY_RATE_MS_PER_STEP = 125;
 
 interface AxisClipSlidersProps {
@@ -82,7 +82,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     }
   }
 
-  setSliderState(axis: string, newState: number[]) {
+  setSliderState(axis: string, newState: [number, number]) {
     this.setState({
       sliders: {
         ...this.state.sliders,
@@ -126,11 +126,10 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     }
   }
 
-  createSlider(axis: string, playButton: boolean) {
-    const start = this.state.sliders[axis];
+  createSlider(axis: string, twoD: boolean) {
+    const { playing, sliders } = this.state;
+    const sliderVals = sliders[axis];
     const range = { min: 0, max: this.props.numSlices[axis] };
-    const playOnClick = this.state.playing ? this.pause : this.play;
-    const playIcon = this.state.playing ? "pause" : "caret-right";
 
     return (
       <div key={axis} className={`slider-row slider-${axis}`}>
@@ -138,7 +137,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
           <Nouislider
             connect={true}
             range={range}
-            start={start}
+            start={twoD ? [sliderVals[0]] : sliderVals}
             step={1}
             behaviour="drag"
             // round slider output to nearest slice; assume any string inputs represent ints
@@ -148,14 +147,16 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
           />
         </span>
         <span className="slider-name">{axis.toUpperCase()}</span>
-        <span className="slider-slices">{`${start[0]}, ${start[1]} (${range.max})`}</span>
-        {playButton && (
+        <span className="slider-slices">
+          {twoD ? `${sliderVals[0]} (${range.max})` : `${sliderVals[0]}, ${sliderVals[1]} (${range.max})`}
+        </span>
+        {twoD && (
           <Button.Group className="slider-play-buttons">
             <Tooltip placement="top" title="Step back">
               <Button icon="step-backward" onClick={() => this.step(true)} />
             </Tooltip>
             <Tooltip placement="top" title="Play through sequence">
-              <Button onClick={playOnClick} icon={playIcon} />
+              <Button onClick={playing ? this.pause : this.play} icon={playing ? "pause" : "caret-right"} />
             </Tooltip>
             <Tooltip placement="top" title="Step forward">
               <Button icon="step-forward" onClick={() => this.step(false)} />
@@ -176,7 +177,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
         const thicknessReduce = isActiveAxis ? step - stepEpsilon : 0.0;
 
         const start = values[0] / max - 0.5;
-        const end = values[1] / max - 0.5 - thicknessReduce / max;
+        const end = values[values.length - 1] / max - 0.5 - thicknessReduce / max;
 
         // get a value from -0.5..0.5
         this.props.setAxisClip(axis, start, end, isActiveAxis);
@@ -186,7 +187,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
 
   // When user finishes moving the active slider, update slice label
   makeSliderSetFn(axis: string) {
-    return (values: number[]) => this.setSliderState(axis, values);
+    return (values: number[]) => this.setSliderState(axis, [values[0], values[values.length - 1]]);
   }
 
   render() {

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -103,3 +103,14 @@
     }
   }
 }
+
+@media only screen and (max-width: 500px) {
+  .clip-sliders .slider-row {
+    display: none;
+  }
+
+  .clip-sliders::after {
+    content: "ROI clipping is not available at this size. Please try again with a larger viewport.";
+    font-style: italic;
+  }
+}


### PR DESCRIPTION
Finishes resolving #49 by making axis sliders have only one handle in 2D modes.

Given that slider state is stored internally as `[number, number]`, this is accomplished like this:
1. in the `Nouislider` component, if we're in 2d mode, pass only the first number from state as a handle position, not both
2. in event handlers, if we get only a single-element array of values back, treat this element as both the start and end of the slice and store that value in both state fields

Screenshot:
![image](https://user-images.githubusercontent.com/53030214/188992568-4e2217b8-9e2f-4f67-a299-2867a340b9a8.png)
