### PR TITLE
Feature/ROI sliders: responsive design

### DIFF
--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -133,22 +133,24 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
 
     return (
       <div key={axis} className={`slider-row slider-${axis}`}>
-        <span className="axis-slider">
-          <Nouislider
-            connect={true}
-            range={range}
-            start={twoD ? [sliderVals[0]] : sliderVals}
-            step={1}
-            behaviour="drag"
-            // round slider output to nearest slice; assume any string inputs represent ints
-            format={{ to: Math.round, from: parseInt }}
-            onUpdate={this.makeSliderUpdateFn(axis)}
-            onSet={this.makeSliderSetFn(axis)}
-          />
-        </span>
-        <span className="slider-name">{axis.toUpperCase()}</span>
-        <span className="slider-slices">
-          {twoD ? `${sliderVals[0]} (${range.max})` : `${sliderVals[0]}, ${sliderVals[1]} (${range.max})`}
+        <span className="axis-slider-container">
+          <span className="axis-slider">
+            <Nouislider
+              connect={true}
+              range={range}
+              start={twoD ? [sliderVals[0]] : sliderVals}
+              step={1}
+              behaviour="drag"
+              // round slider output to nearest slice; assume any string inputs represent ints
+              format={{ to: Math.round, from: parseInt }}
+              onUpdate={this.makeSliderUpdateFn(axis)}
+              onSet={this.makeSliderSetFn(axis)}
+            />
+          </span>
+          <span className="slider-name">{axis.toUpperCase()}</span>
+          <span className="slider-slices">
+            {twoD ? `${sliderVals[0]} (${range.max})` : `${sliderVals[0]}, ${sliderVals[1]} (${range.max})`}
+          </span>
         </span>
         {twoD && (
           <Button.Group className="slider-play-buttons">

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -9,15 +9,16 @@
   @extend %axis-override;
   max-width: 665px;
   position: absolute;
-  margin: auto;
+  margin: 0 auto;
   left: 0;
   right: 0;
   padding: 0 24px;
 
   .slider-row {
     display: flex;
-    justify-content: center;
-    align-items: center;
+    justify-content: flex-end;
+    align-items: flex-start;
+    flex-wrap: wrap;
     color: #bfbfbf;
 
     &.slider-x {
@@ -48,6 +49,13 @@
     }
   }
 
+  /* container to keep slider and labels on one line while play buttons wrap */
+  .axis-slider-container {
+    display: flex;
+    flex: 0 1 617px;
+    align-items: center;
+  }
+
   .axis-slider {
     flex: 1 1 480px;
     max-width: 480px;
@@ -72,8 +80,22 @@
     max-width: 85px;
   }
 
+  .slider-play-buttons {
+    margin-top: 2px;
+  }
+
   &.clip-sliders-2d {
-    max-width: 780px;
+    /* Make room for play buttons */
+    max-width: 755px;
+
+    /* Slider slice display contains 2 numbers in 2d mode, not 3 - shrink accordingly */
+    .slider-slices {
+      flex: 0 0 60px;
+    }
+
+    .axis-slider-container {
+      flex: 0 1 592px;
+    }
   }
 
   .noUi-target {

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -7,12 +7,13 @@
   --color-z: #0099ff;
 
   @extend %axis-override;
+  /* .axis-slider (480) + .slider-name (10) + .slider-slices (85) + margins & padding (90) */
   max-width: 665px;
   position: absolute;
   margin: 0 auto;
   left: 0;
   right: 0;
-  padding: 0 24px;
+  padding: 0 25px;
 
   .slider-row {
     display: flex;
@@ -52,7 +53,7 @@
   /* container to keep slider and labels on one line while play buttons wrap */
   .axis-slider-container {
     display: flex;
-    flex: 0 1 617px;
+    flex: 1 1 auto;
     align-items: center;
   }
 
@@ -70,7 +71,7 @@
   }
 
   .slider-name {
-    flex: 0 0 12px;
+    flex: 0 0 10px;
     font-weight: bold;
   }
 
@@ -86,6 +87,7 @@
 
   &.clip-sliders-2d {
     /* Make room for play buttons */
+    /* .axis-slider (480) + .slider-name (10) + .slider-slices (60) + .slider-play-buttons (95) + margins & padding (110) */
     max-width: 755px;
 
     /* Slider slice display contains 2 numbers in 2d mode, not 3 - shrink accordingly */
@@ -94,7 +96,8 @@
     }
 
     .axis-slider-container {
-      flex: 0 1 592px;
+      /* .axis-slider (480) + .slider-name (10) + .slider-slices (60) + margins (40) */
+      flex: 0 1 590px;
     }
   }
 


### PR DESCRIPTION
Resolves #50 by replacing the sliders with an error message at very narrow widths, and allowing play buttons to shift to below the slice numbers to make more room for the slider in 2d mode.

NOTE: the `@media` query at the bottom of AxisClipSliders/styles.css was accidentally included as part of the last pull request, but was added as part of this task. See [this commit](https://github.com/allen-cell-animated/website-3d-cell-viewer/pull/64/commits/cb70a78852a75d872aa43f6bf82b453d418214bc) for those changes.

Screenshots:
![image](https://user-images.githubusercontent.com/53030214/189217301-2c470780-8d7f-4378-9ffd-1e6bb91611d3.png)
![image](https://user-images.githubusercontent.com/53030214/189217390-cf96fed7-5d62-40dc-9579-56d32f6bd45c.png)
