### PR TITLE
Feature/roi slider polish

### DIFF
--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -49,9 +49,16 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     this.createSlider = this.createSlider.bind(this);
   }
 
-  // Reset sliders and pause if mode has changed
+  // Reset sliders and pause if mode or fov has changed
+  // TODO: this reset-state-on-props-update pattern is somewhat bad practice,
+  //   and indicates some state should potentially be lifted out of this component.
   componentDidUpdate(prevProps: AxisClipSlidersProps) {
-    if (prevProps.mode !== this.props.mode) {
+    const numSlicesChanged = AXES.reduce(
+      (hasChanged, axis) => hasChanged || prevProps.numSlices[axis] !== this.props.numSlices[axis],
+      false
+    );
+
+    if (numSlicesChanged || prevProps.mode !== this.props.mode) {
       window.clearInterval(this.state.intervalId);
       this.setState({ sliders: this.getSliderDefaults(), playing: false });
 
@@ -133,7 +140,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     const range = { min: 0, max: numSlices - 1 };
 
     return (
-      <div key={axis} className={`slider-row slider-${axis}`}>
+      <div key={axis + numSlices} className={`slider-row slider-${axis}`}>
         <span className="axis-slider-container">
           <span className="axis-slider">
             <Nouislider

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -7,7 +7,7 @@
   --color-z: #0099ff;
 
   @extend %axis-override;
-  /* .axis-slider (480) + .slider-name (10) + .slider-slices (85) + margins & padding (90) */
+  /* .axis-slider (480) + .slider-name (10) + .slider-slices (95) + margins & padding (80) */
   max-width: 665px;
   position: absolute;
   margin: 0 auto;
@@ -64,7 +64,6 @@
   }
 
   .slider-name,
-  .slider-slices,
   .slider-play-buttons {
     margin-left: 20px;
     white-space: nowrap;
@@ -76,9 +75,10 @@
   }
 
   .slider-slices {
-    flex: 0 0 85px;
+    flex: 0 0 95px;
+    margin-left: 10px;
     text-align: right;
-    max-width: 85px;
+    max-width: 95px;
   }
 
   .slider-play-buttons {
@@ -87,16 +87,16 @@
 
   &.clip-sliders-2d {
     /* Make room for play buttons */
-    /* .axis-slider (480) + .slider-name (10) + .slider-slices (60) + .slider-play-buttons (95) + margins & padding (110) */
+    /* .axis-slider (480) + .slider-name (10) + .slider-slices (70) + .slider-play-buttons (95) + margins & padding (100) */
     max-width: 755px;
 
     /* Slider slice display contains 2 numbers in 2d mode, not 3 - shrink accordingly */
     .slider-slices {
-      flex: 0 0 60px;
+      flex: 0 0 70px;
     }
 
     .axis-slider-container {
-      /* .axis-slider (480) + .slider-name (10) + .slider-slices (60) + margins (40) */
+      /* .axis-slider (480) + .slider-name (10) + .slider-slices (70) + margins (30) */
       flex: 0 1 590px;
     }
   }


### PR DESCRIPTION
Some final polish to ROI sliders, including:
- Update to how sliders map to clipping. Now, for e.g. an axis with 50 slices, slider positions `n` and `m` range from 0-49, and are mapped to clipping values `[n/50 - 0.5, (m+1)/50 - 0.5]`. This ensures at least one slice is visible for all valid slider positions.
- The third slices indicator number (in parentheses) in 3D mode now represents the number of slices currently visible on that axis, rather than the total number of slices. Also includes some very minor style changes to give the indicator some extra room.
- Clipping now resets when FOV changes (single cell vs. full field). Note that the way this is currently implemented creates some potentially unexpected behavior, as the slider range and slider handle positions visibly update separately and in that order.