### PR TITLE
Fix/roi slider feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3384,6 +3384,12 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.185",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.185.tgz",
+      "integrity": "sha512-evMDG1bC4rgQg4ku9tKpuMh5iBNEwNa3tf9zRHdP1qlv+1WUg44xat4IxCE14gIpZRGUUWAx2VhItCZc25NfMA==",
+      "dev": true
+    },
     "@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@babel/preset-typescript": "^7.14.5",
     "@babel/runtime": "^7.14.6",
     "@types/jest": "^27.4.0",
+    "@types/lodash": "^4.14.185",
     "@types/react": "^16.x",
     "@types/react-dom": "^16.x",
     "@typescript-eslint/eslint-plugin": "^5.31.0",

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -12,6 +12,13 @@ const ViewMode = viewMode.mainMapping;
 const AXES = ["x", "y", "z"];
 const PLAY_RATE_MS_PER_STEP = 125;
 
+const ACTIVE_AXIS_MAP = {
+  [ViewMode.yz]: "x",
+  [ViewMode.xz]: "y",
+  [ViewMode.xy]: "z",
+  [ViewMode.threeD]: null,
+};
+
 interface AxisClipSlidersProps {
   mode: symbol;
   setAxisClip: (axis: string, minval: number, maxval: number, isOrthoAxis: boolean) => void;
@@ -73,15 +80,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     );
   }
 
-  getActiveAxis() {
-    const activeAxisMap = {
-      [ViewMode.yz]: "x",
-      [ViewMode.xz]: "y",
-      [ViewMode.xy]: "z",
-      [ViewMode.threeD]: null,
-    };
-    return activeAxisMap[this.props.mode];
-  }
+  getActiveAxis = () => ACTIVE_AXIS_MAP[this.props.mode];
 
   setSliderState(axis: string, newState: [number, number]) {
     this.setState({

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -65,8 +65,13 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     }
   }
 
-  getSliderDefaults = () =>
-    mapValues(this.props.numSlices, (max: number, axis: string) => [0, axis === this.getActiveAxis() ? 0 : max - 1]);
+  getSliderDefaults() {
+    const activeAxis = this.getActiveAxis();
+    return mapValues(
+      this.props.numSlices,
+      (max: number, axis: string) => [0, axis === activeAxis ? 0 : max - 1] as [number, number]
+    );
+  }
 
   getActiveAxis() {
     const activeAxisMap = {

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -110,8 +110,8 @@
   .slider-play-buttons .ant-btn {
     line-height: 1.2;
     height: 21px;
-    color: $dimgray;
-    border-color: $dimgray !important;
+    color: $light-gray;
+    border-color: $light-gray !important;
     background-color: transparent;
 
     &:hover {

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -7,8 +7,8 @@
   --color-z: #0099ff;
 
   @extend %axis-override;
-  /* .axis-slider (480) + .slider-name (10) + .slider-slices (95) + margins & padding (80) */
-  max-width: 665px;
+  /* .axis-slider (480) + .slider-name (10) + .slider-slices (105) + margins & padding (80) */
+  max-width: 675px;
   position: absolute;
   margin: 0 auto;
   left: 0;
@@ -75,10 +75,11 @@
   }
 
   .slider-slices {
-    flex: 0 0 95px;
+    flex: 0 0 105px;
     margin-left: 10px;
+    white-space: nowrap;
     text-align: right;
-    max-width: 95px;
+    max-width: 105px;
   }
 
   .slider-play-buttons {

--- a/src/aics-image-viewer/components/BottomPanel/styles.css
+++ b/src/aics-image-viewer/components/BottomPanel/styles.css
@@ -44,6 +44,10 @@
     &:focus {
       color: #aeacae;
     }
+
+    &:hover {
+      color: white;
+    }
   }
 
   .options-button {
@@ -57,7 +61,7 @@
 
   .button-arrow {
     transform: rotate(90deg);
-    transition: transform 0.2s linear;
+    transition: transform 0.2s linear !important;
   }
 
   .drawer-body-wrapper {

--- a/src/aics-image-viewer/components/ChannelsWidget/index.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidget/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { map, filter, find } from "lodash";
+import { map, find } from "lodash";
 
 import { Card, Collapse, List } from "antd";
 
@@ -88,13 +88,15 @@ export default class ChannelsWidget extends React.Component<ChannelsWidgetProps,
   renderVisibilityControls(channelArray: number[]) {
     const { channelSettings, channelDataChannels } = this.props;
 
-    const arrayOfNames = map(channelArray, (channelIndex: number) => channelDataChannels[channelIndex].name);
-    const volChecked = filter(arrayOfNames, (name: string) =>
-      find(channelSettings, { name }) ? find(channelSettings, { name })[VOLUME_ENABLED] : false
-    );
-    const isoChecked = filter(arrayOfNames, (name: string) =>
-      find(channelSettings, { name }) ? find(channelSettings, { name })[ISO_SURFACE_ENABLED] : false
-    );
+    const arrayOfNames = channelArray.map((channelIndex: number) => channelDataChannels[channelIndex].name);
+    const volChecked = arrayOfNames.filter((name: string) => {
+      const channelSetting = find(channelSettings, { name });
+      return channelSetting && channelSetting[VOLUME_ENABLED];
+    });
+    const isoChecked = arrayOfNames.filter((name: string) => {
+      const channelSetting = find(channelSettings, { name });
+      return channelSetting && channelSetting[ISO_SURFACE_ENABLED];
+    });
     return (
       <div style={STYLES.buttonRow}>
         <SharedCheckBox

--- a/src/aics-image-viewer/components/ChannelsWidget/index.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidget/index.tsx
@@ -100,17 +100,19 @@ export default class ChannelsWidget extends React.Component<ChannelsWidgetProps,
         <SharedCheckBox
           allOptions={channelArray}
           checkedList={volChecked}
-          label="All volumes"
           onChecked={this.showVolumes}
-          onUnchecekd={this.hideVolumes}
-        />
+          onUnchecked={this.hideVolumes}
+        >
+          All volumes
+        </SharedCheckBox>
         <SharedCheckBox
           allOptions={channelArray}
           checkedList={isoChecked}
-          label="All surfaces"
           onChecked={this.showSurfaces}
-          onUnchecekd={this.hideSurfaces}
-        />
+          onUnchecked={this.hideSurfaces}
+        >
+          All surfaces
+        </SharedCheckBox>
       </div>
     );
   }

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -59,7 +59,6 @@ export default function ControlPanel(props: ControlPanelProps) {
       <div className="control-panel-tab-col" style={{ flex: "0 0 50px" }}>
         <Button
           icon="vertical-right"
-          size="large"
           className={props.collapsed ? "btn-collapse btn-collapse-collapsed" : "btn-collapse"}
           onClick={() => props.setCollapsed(!props.collapsed)}
         />

--- a/src/aics-image-viewer/components/ControlPanel/styles.css
+++ b/src/aics-image-viewer/components/ControlPanel/styles.css
@@ -16,14 +16,14 @@
     .ant-btn {
       margin-top: 12px;
       background-color: transparent;
-      border: none;
+      border: 1px solid transparent;
       color: #bfbfbf;
 
       &:not([disabled]):hover,
       &:not([disabled]).btn-tabactive {
         color: white;
         background-color: #4b4b4b;
-        border: 1px solid #6e6e6e;
+        border-color: #6e6e6e;
       }
 
       &[ant-click-animating-without-extra-node="true"]::after {

--- a/src/aics-image-viewer/components/ControlPanel/styles.css
+++ b/src/aics-image-viewer/components/ControlPanel/styles.css
@@ -14,7 +14,7 @@
     text-align: center;
 
     .ant-btn {
-      margin-top: 5px;
+      margin-top: 12px;
       background-color: transparent;
       border: none;
       color: #bfbfbf;
@@ -28,7 +28,7 @@
 
       &[ant-click-animating-without-extra-node="true"]::after {
         box-shadow: none !important;
-        background-color: $light-gray;
+        background-color: #222;
       }
     }
 
@@ -44,7 +44,7 @@
 
     .tab-divider {
       width: 70%;
-      margin: 5px 15% 0;
+      margin: 12px 15% 0;
       border-bottom: 1px solid $border-color;
     }
   }
@@ -72,6 +72,7 @@
   .ant-card-head {
     border-radius: 0;
     border-bottom: none;
+    padding: 0 16px;
   }
 
   .ant-card-head-title {

--- a/src/aics-image-viewer/components/GlobalVolumeControls.tsx
+++ b/src/aics-image-viewer/components/GlobalVolumeControls.tsx
@@ -191,8 +191,7 @@ export default class GlobalVolumeControls extends React.Component<GlobalVolumeCo
 
 const STYLES = {
   slidersWrapper: {
-    width: "calc(100% - 20px)",
-    margin: "auto",
+    marginRight: "10px",
     paddingTop: "18px",
   },
   controlRow: {

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -60,6 +60,8 @@ export default function Toolbar(props: ToolbarProps) {
   const toggleAxis = () => props.changeAxisShowing(!props.showAxes);
   const toggleBoundingBox = () => props.changeBoundingBoxShowing(!props.showBoundingBox);
 
+  const classForToggleBtn = (active: boolean) => (active ? "btn-borderless btn-active" : "btn-borderless");
+
   return (
     <div className="toolbar">
       <span className="toolbar-center">
@@ -76,6 +78,7 @@ export default function Toolbar(props: ToolbarProps) {
             {renderConfig.autoRotateButton && (
               <Tooltip placement="bottom" title="Turntable">
                 <Button
+                  className={classForToggleBtn(props.autorotate && !twoDMode)}
                   icon={autorotateIcon}
                   disabled={twoDMode || props.pathTraceOn}
                   onClick={props.onAutorotateChange}
@@ -118,14 +121,14 @@ export default function Toolbar(props: ToolbarProps) {
           <span className="toolbar-group">
             {renderConfig.showAxesButton && (
               <Tooltip placement="bottom" title={showAxes ? "Hide axes" : "Show axes"}>
-                <Button icon="drag" className={showAxes ? "" : "btn-borderless"} onClick={toggleAxis} />
+                <Button icon="drag" className={classForToggleBtn(showAxes)} onClick={toggleAxis} />
               </Tooltip>
             )}
             {renderConfig.showBoundingBoxButton && (
               <Tooltip placement="bottom" title={showBoundingBox ? "Hide bounding box" : "Show bounding box"}>
                 <Button
                   icon="close-square"
-                  className={showBoundingBox ? "" : "btn-borderless"}
+                  className={classForToggleBtn(showBoundingBox)}
                   onClick={toggleBoundingBox}
                 />
               </Tooltip>

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -31,10 +31,12 @@
     padding-bottom: 1px;
   }
 
+  /* Icon-only buttons */
+
   .btn-borderless {
-    color: #bfbfbf;
     background-color: transparent;
     border-color: transparent;
+    color: #bfbfbf;
 
     > .ant-btn[disabled] {
       background-color: transparent;
@@ -46,40 +48,53 @@
     &:hover,
     &:focus-within {
       outline: none;
-      background-color: #4b4b4b;
       box-shadow: none;
+      background-color: #4b4b4b;
       color: white;
-      border-color: #6e6e6e;
+      border-color: $light-gray;
     }
 
     &[ant-click-animating-without-extra-node="true"]::after {
       box-shadow: none !important;
-      background-color: $light-gray;
+      background-color: #222222;
     }
   }
+
+  span.btn-borderless {
+    background-color: transparent !important;
+    border-color: transparent !important;
+  }
+
+  /* Radio buttons */
 
   .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled) {
     background-color: black;
 
     &.ant-radio-button-wrapper-checked,
     &:hover,
-    &.ant-radio-button-wrapper-checked:hover,
-    &:focus-within,
-    &.ant-radio-button-wrapper-checked:first-child {
+    &:focus-within {
       outline: none;
       background-color: #4b4b4b;
-      box-shadow: none;
       color: white;
-      border-color: #6e6e6e;
+      border-color: $light-gray;
+
+      &:not(:first-child) {
+        box-shadow: -1px 0px 0px 0px $light-gray;
+      }
     }
   }
 
+  /* Dropdown */
+
   .ant-select-selection {
+    border-color: $light-gray !important;
+    box-shadow: none !important;
     background-color: black;
 
-    &:hover {
+    &:hover,
+    &:focus {
       background-color: #4b4b4b;
-      border-color: #6e6e6e;
+      color: white;
     }
   }
 }

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -1,3 +1,5 @@
+@import "../../assets/styles/variables";
+
 .toolbar {
   position: absolute;
   width: 100%;
@@ -21,23 +23,63 @@
     margin-right: 6px;
   }
 
-  .btn-borderless {
-    color: #bfbfbf;
-  }
-
-  .btn-borderless:not(:hover) {
-    background-color: transparent;
-  }
-
-  .btn-borderless:not(:focus) {
-    border: none;
-  }
-
   .select-render-setting {
     min-width: 110px;
   }
 
   .ant-btn-icon-only {
     padding-bottom: 1px;
+  }
+
+  .btn-borderless {
+    color: #bfbfbf;
+    background-color: transparent;
+    border-color: transparent;
+
+    > .ant-btn[disabled] {
+      background-color: transparent;
+      border-color: transparent;
+      color: #bfbfbf;
+    }
+
+    &.btn-active,
+    &:hover,
+    &:focus-within {
+      outline: none;
+      background-color: #4b4b4b;
+      box-shadow: none;
+      color: white;
+      border-color: #6e6e6e;
+    }
+
+    &[ant-click-animating-without-extra-node="true"]::after {
+      box-shadow: none !important;
+      background-color: $light-gray;
+    }
+  }
+
+  .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled) {
+    background-color: black;
+
+    &.ant-radio-button-wrapper-checked,
+    &:hover,
+    &.ant-radio-button-wrapper-checked:hover,
+    &:focus-within,
+    &.ant-radio-button-wrapper-checked:first-child {
+      outline: none;
+      background-color: #4b4b4b;
+      box-shadow: none;
+      color: white;
+      border-color: #6e6e6e;
+    }
+  }
+
+  .ant-select-selection {
+    background-color: black;
+
+    &:hover {
+      background-color: #4b4b4b;
+      border-color: #6e6e6e;
+    }
   }
 }

--- a/src/aics-image-viewer/components/shared/SharedCheckBox.tsx
+++ b/src/aics-image-viewer/components/shared/SharedCheckBox.tsx
@@ -1,8 +1,21 @@
 import React from "react";
 import { Checkbox } from "antd";
 
-export default class SharedCheckbox extends React.Component {
-  constructor(props) {
+type SharedCheckboxProps<T> = React.PropsWithChildren<{
+  allOptions: T[];
+  checkedList: T[];
+  onChecked: (checked: T[]) => void;
+  onUnchecked: (unchecked: T[]) => void;
+}>;
+
+type SharedCheckboxState<T> = {
+  checkedList: T[];
+  indeterminate: boolean;
+  checkAll: boolean;
+};
+
+export default class SharedCheckbox<T> extends React.Component<SharedCheckboxProps<T>, SharedCheckboxState<T>> {
+  constructor(props: SharedCheckboxProps<T>) {
     super(props);
     this.onCheckAllChange = this.onCheckAllChange.bind(this);
     this.state = {
@@ -12,18 +25,19 @@ export default class SharedCheckbox extends React.Component {
     };
   }
 
-  componentWillReceiveProps(newProps) {
+  // TODO: Is this component's derived state strictly necessary? Can some or all of it be removed?
+  static getDerivedStateFromProps(newProps: SharedCheckboxProps<any>) {
     const { checkedList, allOptions } = newProps;
-    this.setState({
+    return {
       checkedList,
       indeterminate: !!checkedList.length && checkedList.length < allOptions.length,
       checkAll: checkedList.length === allOptions.length,
-    });
+    };
   }
 
   onCheckAllChange({ target }) {
-    const { allOptions, onChecked, onUnchecekd } = this.props;
-    target.checked ? onChecked(allOptions) : onUnchecekd(allOptions);
+    const { allOptions, onChecked, onUnchecked } = this.props;
+    target.checked ? onChecked(allOptions) : onUnchecked(allOptions);
     this.setState({
       checkedList: target.checked ? allOptions : [],
       indeterminate: false,
@@ -32,7 +46,6 @@ export default class SharedCheckbox extends React.Component {
   }
 
   render() {
-    const { label } = this.props;
     return (
       <Checkbox
         indeterminate={this.state.indeterminate}
@@ -40,7 +53,7 @@ export default class SharedCheckbox extends React.Component {
         checked={this.state.checkAll}
         style={{ margin: "auto", width: 120 }}
       >
-        {label}
+        {this.props.children}
       </Checkbox>
     );
   }

--- a/src/aics-image-viewer/components/shared/SmarterSlider.tsx
+++ b/src/aics-image-viewer/components/shared/SmarterSlider.tsx
@@ -4,17 +4,17 @@ import Nouislider, { NouisliderProps } from "nouislider-react";
 type CallbackArgs = [values: any[], handle: number, unencodedValues: number[], tap: boolean, positions: number[]];
 
 /** A wrapper around `Nouislider` that prevents updates while the slider is being dragged. */
-export default class SmarterSlider extends React.Component<NouisliderProps, { inactive: boolean }> {
+export default class SmarterSlider extends React.Component<NouisliderProps, { shouldUpdate: boolean }> {
   constructor(props: NouisliderProps) {
     super(props);
-    this.state = { inactive: true };
+    this.state = { shouldUpdate: true };
   }
 
-  shouldComponentUpdate = () => this.state.inactive;
+  shouldComponentUpdate = () => this.state.shouldUpdate;
 
   wrapEventHandler(inactive: boolean, handler?: (...args: CallbackArgs) => void) {
     return (...args: CallbackArgs) => {
-      this.setState({ inactive });
+      this.setState({ shouldUpdate: inactive });
       if (handler) {
         handler(...args);
       }

--- a/src/aics-image-viewer/components/shared/SmarterSlider.tsx
+++ b/src/aics-image-viewer/components/shared/SmarterSlider.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import Nouislider, { NouisliderProps } from "nouislider-react";
+
+type CallbackArgs = [values: any[], handle: number, unencodedValues: number[], tap: boolean, positions: number[]];
+
+/** A wrapper around `Nouislider` that prevents updates while the slider is being dragged. */
+export default class SmarterSlider extends React.Component<NouisliderProps, { inactive: boolean }> {
+  constructor(props: NouisliderProps) {
+    super(props);
+    this.state = { inactive: true };
+  }
+
+  shouldComponentUpdate = () => this.state.inactive;
+
+  wrapEventHandler(inactive: boolean, handler?: (...args: CallbackArgs) => void) {
+    return (...args: CallbackArgs) => {
+      this.setState({ inactive });
+      if (handler) {
+        handler(...args);
+      }
+    };
+  }
+
+  render() {
+    const onStart = this.wrapEventHandler(false, this.props.onStart);
+    const onEnd = this.wrapEventHandler(true, this.props.onEnd);
+    return <Nouislider {...{ ...this.props, onStart, onEnd }} />;
+  }
+}


### PR DESCRIPTION
Resolves a bunch of small UI feedback items and a few assorted code maintenance tasks.

### Clipping Sliders

Resolves #72 - clipping slider numbers now update while slider is being dragged. This prompted a number of internal behavior changes to `AxisClipSliders`; and the creation of a new component, `SmarterSlider`, which wraps `Nouislider` and pauses updates while the slider is being dragged.

Also: play buttons are lighter, and slice numbers should no longer wrap.

### Other UI polish

- Control panel: tightens up some spacing, colors, and sizes per Lyndsay's feedback. Notably: tabs no longer flash a white border when hovered.
- Toolbar: brings control styling to [specification](https://xd.adobe.com/view/904d6444-a800-48b6-8844-4f6f116d85ab-c51e/screen/5bd5a6b1-83e2-424b-9d0c-a47a15c0b3ba/specs/).

### Code maintenance

- Since I was adding another shared component anyways, I converted our other shared component, `SharedCheckBox`, to TypeScript and replaced the legacy lifecycle it was still using. With this change, the app is free from legacy lifecycle warnings, and should be upgrade-able to newer versions of React if we want.
- Added `@types/lodash` package to get type hints for Lodash functions.