### PR TITLE
Feature: screenshot button

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -242,6 +242,7 @@ export default class App extends React.Component<AppProps, AppState> {
     this.onResetCamera = this.onResetCamera.bind(this);
     this.changeBackgroundColor = this.changeBackgroundColor.bind(this);
     this.changeBoundingBoxColor = this.changeBoundingBoxColor.bind(this);
+    this.downloadScreenshot = this.downloadScreenshot.bind(this);
   }
 
   componentDidMount() {
@@ -863,6 +864,15 @@ export default class App extends React.Component<AppProps, AppState> {
     }
   }
 
+  downloadScreenshot() {
+    this.state.view3d.capture((dataUrl: string) => {
+      const anchor = document.createElement("a");
+      anchor.href = dataUrl;
+      anchor.download = "screenshot.png";
+      anchor.click();
+    });
+  }
+
   onWindowResize() {
     if (window.innerWidth < CONTROL_PANEL_CLOSE_WIDTH) {
       this.toggleControlPanel(true);
@@ -1180,6 +1190,7 @@ export default class App extends React.Component<AppProps, AppState> {
               onChangeRenderingAlgorithm={this.onChangeRenderingAlgorithm}
               changeAxisShowing={this.changeAxisShowing}
               changeBoundingBoxShowing={this.changeBoundingBoxShowing}
+              downloadScreenshot={this.downloadScreenshot}
               renderConfig={renderConfig}
             />
             <CellViewerCanvasWrapper

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -139,12 +139,12 @@ export default function Toolbar(props: ToolbarProps) {
       </span>
 
       <span className="toolbar-right toolbar-group">
-        <Button icon="camera" className="btn-borderless" onClick={props.downloadScreenshot} />
         <DownloadButton
           cellDownloadHref={props.cellDownloadHref}
           fovDownloadHref={props.fovDownloadHref}
           hasFov={props.hasCellId && props.hasParentImage}
         />
+        <Button icon="camera" className="btn-borderless" onClick={props.downloadScreenshot} />
       </span>
     </div>
   );

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -29,13 +29,14 @@ interface ToolbarProps {
   showAxes: boolean;
   showBoundingBox: boolean;
 
-  onViewModeChange(mode: symbol): void;
-  onResetCamera(): void;
-  onAutorotateChange(): void;
-  onSwitchFovCell(value: string): void;
-  onChangeRenderingAlgorithm(newAlgorithm: string): void;
-  changeAxisShowing(showing: boolean): void;
-  changeBoundingBoxShowing(showing: boolean): void;
+  onViewModeChange: (mode: symbol) => void;
+  onResetCamera: () => void;
+  onAutorotateChange: () => void;
+  downloadScreenshot: () => void;
+  onSwitchFovCell: (value: string) => void;
+  onChangeRenderingAlgorithm: (newAlgorithm: string) => void;
+  changeAxisShowing: (showing: boolean) => void;
+  changeBoundingBoxShowing: (showing: boolean) => void;
 
   renderConfig: {
     autoRotateButton: boolean;
@@ -137,7 +138,8 @@ export default function Toolbar(props: ToolbarProps) {
         )}
       </span>
 
-      <span className="toolbar-right">
+      <span className="toolbar-right toolbar-group">
+        <Button icon="camera" className="btn-borderless" onClick={props.downloadScreenshot} />
         <DownloadButton
           cellDownloadHref={props.cellDownloadHref}
           fovDownloadHref={props.fovDownloadHref}


### PR DESCRIPTION
Resolves #74: adds a screenshot button to the location [specified](https://xd.adobe.com/view/904d6444-a800-48b6-8844-4f6f116d85ab-c51e/screen/a01f264e-ec99-42ab-a84a-90f2e17a533b/specs/). When the user clicks it, the viewer will download a screenshot of the current view named "screenshot.png."

Screenshot:
![image](https://user-images.githubusercontent.com/53030214/191612120-1822c147-32bc-407c-b0e3-493860f2d10c.png)
