### PR TITLE
Fix/remove duplicate `maskChannelName`

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -14,7 +14,6 @@ import {
 } from "../../shared/utils/viewerChannelSettings";
 import enums from "../../shared/enums";
 import {
-  CELL_SEGMENTATION_CHANNEL_NAME,
   PRESET_COLORS_0,
   ALPHA_MASK_SLIDER_3D_DEFAULT,
   ALPHA_MASK_SLIDER_2D_DEFAULT,
@@ -87,8 +86,6 @@ const defaultProps: AppProps = {
   rawData: undefined,
   // rawDims is the volume dims that normally come from a json file
   rawDims: undefined,
-
-  maskChannelName: "",
 
   appHeight: "100vh",
   cellPath: "",
@@ -616,7 +613,7 @@ export default class App extends React.Component<AppProps, AppState> {
     }
 
     if (view3d) {
-      if (aimg.channelNames()[channelIndex] === CELL_SEGMENTATION_CHANNEL_NAME) {
+      if (aimg.channelNames()[channelIndex] === this.props.viewerChannelSettings?.maskChannelName) {
         view3d.setVolumeChannelAsMask(aimg, channelIndex);
       }
     }

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -11,8 +11,6 @@ export interface AppProps {
   // replaces / obviates groupToChannelNameMap, channelNameClean, channelNameMapping, filterFunc, initialChannelSettings, defaultSurfacesOn and defaultVolumesOn
   viewerChannelSettings?: ViewerChannelSettings;
 
-  maskChannelName: string;
-
   appHeight: string;
   cellId: string;
   cellPath: string;

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -1,8 +1,7 @@
 import { ColorArray } from "./utils/colorRepresentations";
 
 // Add all exported constants here to prevent circular dependencies
-export const 
-  // View modes
+export const // View modes
   YZ_MODE = "YZ",
   XZ_MODE = "XZ",
   XY_MODE = "XY",
@@ -43,8 +42,7 @@ export const
   DENSITY_SLIDER_LEVEL_DEFAULT = [50],
   LEVELS_SLIDER_DEFAULT: ColorArray = [35.0, 140.0, 255.0],
   OTHER_CHANNEL_KEY = "Other",
-  SINGLE_GROUP_CHANNEL_KEY = "Channels",
-  CELL_SEGMENTATION_CHANNEL_NAME = "SEG_Memb";
+  SINGLE_GROUP_CHANNEL_KEY = "Channels";
 
 export const PRESET_COLORS_1: ColorArray[] = [
   [190, 68, 171],

--- a/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
+++ b/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
@@ -52,7 +52,7 @@ export interface ViewerChannelGroup {
 }
 
 export interface ViewerChannelSettings {
-  maskChannelName: string;
+  maskChannelName?: string;
   groups: ViewerChannelGroup[];
 }
 


### PR DESCRIPTION
## Problem

`App` currently has two required props named `maskChannelName`, one on the base `AppProps` type and one on `ViewerChannelSettings`. Neither actually affect anything because the segmentation channel name is hardcoded via the constant `CELL_SEGMENTATION_CHANNEL_NAME`.

## Solution

- Remove the prop on `AppProps`, make the one on `maskChannelName` optional.
- Remove `CELL_SEGMENTATION_CHANNEL_NAME` and make the viewer search for the channel named by the prop instead. I have confirmed this still works in CFE, because it already sets this prop to the same value as was previously hardcoded.