### PR TITLE
handle zarr urls when there is no sub-image

### DIFF
--- a/public/index.tsx
+++ b/public/index.tsx
@@ -162,7 +162,7 @@ if (params) {
     } else {
       // image not specified
       if (decodedurl.endsWith(".zarr")) {
-        decodedimage = "0";
+        decodedimage = "";
       } else {
         const spliturl = decodedurl.split("/");
         decodedimage = spliturl[spliturl.length - 1];

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -193,7 +193,7 @@ export default class App extends React.Component<AppProps, AppState> {
         // { name, enabled, volumeEnabled, isosurfaceEnabled, isovalue, opacity, color, dataReady}
         channelSettings: [],
       },
-      currentlyLoadedImagePath: "",
+      currentlyLoadedImagePath: undefined,
       cachingInProgress: false,
       path: "",
     };

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -105,7 +105,7 @@ export interface AppState {
   hasCellId: boolean;
   // state set by the UI:
   userSelections: UserSelectionState;
-  currentlyLoadedImagePath: string;
+  currentlyLoadedImagePath?: string;
   cachingInProgress: boolean;
   path: string;
 }


### PR DESCRIPTION
The first revision of zarr loading was assuming that the first level under the .zarr store was a collection of images.  But really, usually there is just a single .zarr image.

This is a quick update to handle that so we can look at some data from the Brain science institute. The whole arrangement of url handling and dealing with multi-image, multi-resolution and multi-time is still a bit TBD for a future ticket.

Full loading also depends on https://github.com/allen-cell-animated/volume-viewer/pull/71 and there will be a small version bump once that pr is merged.
