### PR TITLE
Feature/tab tooltips

### DIFF
--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -71,14 +71,12 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
         <div className="tab-divider" />
         <Button
           className={tab === ControlTab.Channels ? "ant-btn-icon-only btn-tabactive" : "ant-btn-icon-only"}
-          disabled={props.collapsed}
           onClick={() => setTab(ControlTab.Channels)}
         >
           <ViewerIcon type="channels" />
         </Button>
         <Button
           className={tab === ControlTab.Advanced ? "ant-btn-icon-only btn-tabactive" : "ant-btn-icon-only"}
-          disabled={props.collapsed}
           onClick={() => setTab(ControlTab.Advanced)}
         >
           <ViewerIcon type="preferences" />

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import { Card, Button, Dropdown, Icon, Menu } from "antd";
+import { Card, Button, Dropdown, Icon, Menu, Tooltip } from "antd";
 import { ClickParam } from "antd/lib/menu";
 
 import ChannelsWidget, { ChannelsWidgetProps } from "../ChannelsWidget";
@@ -68,19 +68,34 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
         >
           <ViewerIcon type="closePanel" />
         </Button>
+
         <div className="tab-divider" />
-        <Button
-          className={tab === ControlTab.Channels ? "ant-btn-icon-only btn-tabactive" : "ant-btn-icon-only"}
-          onClick={() => setTab(ControlTab.Channels)}
+
+        <Tooltip
+          title={ControlTabNames[ControlTab.Channels]}
+          placement="right"
+          {...(!props.collapsed && { visible: false })}
         >
-          <ViewerIcon type="channels" />
-        </Button>
-        <Button
-          className={tab === ControlTab.Advanced ? "ant-btn-icon-only btn-tabactive" : "ant-btn-icon-only"}
-          onClick={() => setTab(ControlTab.Advanced)}
+          <Button
+            className={tab === ControlTab.Channels ? "ant-btn-icon-only btn-tabactive" : "ant-btn-icon-only"}
+            onClick={() => setTab(ControlTab.Channels)}
+          >
+            <ViewerIcon type="channels" />
+          </Button>
+        </Tooltip>
+
+        <Tooltip
+          title={ControlTabNames[ControlTab.Channels]}
+          placement="right"
+          {...(!props.collapsed && { visible: false })}
         >
-          <ViewerIcon type="preferences" />
-        </Button>
+          <Button
+            className={tab === ControlTab.Advanced ? "ant-btn-icon-only btn-tabactive" : "ant-btn-icon-only"}
+            onClick={() => setTab(ControlTab.Advanced)}
+          >
+            <ViewerIcon type="preferences" />
+          </Button>
+        </Tooltip>
       </div>
       <div className="control-panel-col" style={{ flex: "0 0 450px" }}>
         <h2 className="control-panel-title">{ControlTabNames[tab]}</h2>

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -85,7 +85,7 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
         </Tooltip>
 
         <Tooltip
-          title={ControlTabNames[ControlTab.Channels]}
+          title={ControlTabNames[ControlTab.Advanced]}
           placement="right"
           {...(!props.collapsed && { visible: false })}
         >


### PR DESCRIPTION
Resolves #77

- Control panel tabs are no longer disabled when the control panel is collapsed
- Control panel tabs have tooltips that only appear when the control panel is closed

Screenshot:
![image](https://user-images.githubusercontent.com/53030214/199370220-707a7676-20b0-472e-8139-8ad9514a73be.png)
