### PR TITLE
Feature/transform props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@aics/volume-viewer": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-2.6.0.tgz",
-      "integrity": "sha512-JElic4Nl3JUcIMcHX6MdYRyNRUpCp4wGfybKYdiV38fYA75BrURPXs7AUfkX9ZTAbJNpEdjEH9D+Ev7aSuSiQg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-2.6.1.tgz",
+      "integrity": "sha512-Zd7L3/DxuDsPfxaNmyyH1ZMsoc+91dBNBajTFWOFIkgvz/bZqjXW+IHOxxaKt9lpgA0M3q/780qASeL09b9L+w==",
       "requires": {
         "geotiff": "^2.0.5",
         "three": "^0.144.0",
@@ -8041,15 +8041,15 @@
       "dev": true
     },
     "geotiff": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.0.5.tgz",
-      "integrity": "sha512-U5kVYm118YAmw2swiLu8rhfrYnDKOFI7VaMjuQwcq6Intuuid9Pyb4jjxYUxxkq8kOu2r7Am0Rmb52PObGp4pQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.0.7.tgz",
+      "integrity": "sha512-FKvFTNowMU5K6lHYY2f83d4lS2rsCNdpUC28AX61x9ZzzqPNaWFElWv93xj0eJFaNyOYA63ic5OzJ88dHpoA5Q==",
       "requires": {
         "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
         "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
-        "quick-lru": "^6.1.0",
+        "quick-lru": "^6.1.1",
         "web-worker": "^1.2.0",
         "xml-utils": "^1.0.2"
       }
@@ -12815,9 +12815,9 @@
       "dev": true
     },
     "pako": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "param-case": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/volume-viewer": "^2.6.0",
+    "@aics/volume-viewer": "^2.6.1",
     "color-string": "^1.5.3",
     "d3": "^4.11.0",
     "lodash": "^4.17.20",

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -140,8 +140,8 @@ export default class App extends React.Component<AppProps, AppState> {
         pathtrace = true;
         maxproject = false;
       } else if (props.viewerConfig.mode === "maxprojection") {
-        pathtrace = true;
-        maxproject = false;
+        pathtrace = false;
+        maxproject = true;
       } else {
         pathtrace = false;
         maxproject = false;
@@ -183,6 +183,7 @@ export default class App extends React.Component<AppProps, AppState> {
         showBoundingBox: props.viewerConfig.showBoundingBox,
         boundingBoxColor: props.viewerConfig.boundingBoxColor || BOUNDING_BOX_COLOR_DEFAULT,
         backgroundColor: props.viewerConfig.backgroundColor || BACKGROUND_COLOR_DEFAULT,
+        transformEnabled: (props.viewerConfig.transformEnabled || false) && !!props.transform,
         maxProject: maxproject,
         pathTrace: pathtrace,
         alphaMaskSliderLevel: [props.viewerConfig.maskAlpha] || ALPHA_MASK_SLIDER_3D_DEFAULT,
@@ -827,6 +828,15 @@ export default class App extends React.Component<AppProps, AppState> {
     boundingBoxColor: (color, view3d, image) => view3d.setBoundingBoxColor(image, colorArrayToFloats(color)),
     backgroundColor: (color, view3d, _image) => view3d.setBackgroundColor(colorArrayToFloats(color)),
 
+    transformEnabled: (enabled, view3d, image) => {
+      const { transform } = this.props;
+      if (!transform) {
+        return;
+      }
+      view3d.setVolumeTranslation(image, enabled ? transform.translate : [0, 0, 0]);
+      view3d.setVolumeRotation(image, enabled ? transform.rotate : [0, 0, 0]);
+    },
+
     alphaMaskSliderLevel: (value, view3d, image) => {
       view3d.updateMaskAlpha(image, alphaSliderToImageValue(value));
       view3d.updateActiveChannels(image);
@@ -1014,6 +1024,7 @@ export default class App extends React.Component<AppProps, AppState> {
 
   changeAxisShowing = (showing: boolean): void => this.changeUserSelection("showAxes", showing);
   changeBoundingBoxShowing = (showing: boolean): void => this.changeUserSelection("showBoundingBox", showing);
+  changeTransformEnabled = (enabled: boolean): void => this.changeUserSelection("transformEnabled", enabled);
 
   onResetCamera(): void {
     if (this.state.view3d) {
@@ -1172,6 +1183,7 @@ export default class App extends React.Component<AppProps, AppState> {
               renderSetting={
                 maxProject ? RenderMode.maxProject : pathTrace ? RenderMode.pathTrace : RenderMode.volumetric
               }
+              transformEnabled={userSelections.transformEnabled}
               onViewModeChange={this.onViewModeChange}
               onResetCamera={this.onResetCamera}
               onAutorotateChange={this.onAutorotateChange}
@@ -1179,6 +1191,7 @@ export default class App extends React.Component<AppProps, AppState> {
               onChangeRenderingAlgorithm={this.onChangeRenderingAlgorithm}
               changeAxisShowing={this.changeAxisShowing}
               changeBoundingBoxShowing={this.changeBoundingBoxShowing}
+              changeTransformEnabled={this.changeTransformEnabled}
               downloadScreenshot={this.saveScreenshot}
               renderConfig={renderConfig}
             />

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -31,12 +31,14 @@ export interface AppProps {
     resetCameraButton: boolean;
     showAxesButton: boolean;
     showBoundingBoxButton: boolean;
+    showTransformButton?: boolean;
   };
   viewerConfig: {
     showAxes: boolean;
     showBoundingBox: boolean;
     boundingBoxColor?: ColorArray;
     backgroundColor?: ColorArray;
+    transformEnabled?: boolean;
     autorotate: boolean;
     view: string; // "3D", "XY", "XZ", "YZ"
     mode: string; // "default", "pathtrace", "maxprojection"
@@ -55,6 +57,10 @@ export interface AppProps {
   preLoad: boolean;
   pixelSize?: [number, number, number];
   canvasMargin: string;
+  transform?: {
+    translate: [number, number, number];
+    rotate: [number, number, number];
+  }
 
   onControlPanelToggle?: (collapsed: boolean) => void;
 }
@@ -68,6 +74,7 @@ export interface UserSelectionState {
   pathTrace: boolean;
   showAxes: boolean;
   showBoundingBox: boolean;
+  transformEnabled: boolean;
   boundingBoxColor: ColorArray;
   backgroundColor: ColorArray;
   alphaMaskSliderLevel: number[]; //[props.viewerConfig.maskAlpha] || ALPHA_MASK_SLIDER_3D_DEFAULT,

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -31,14 +31,12 @@ export interface AppProps {
     resetCameraButton: boolean;
     showAxesButton: boolean;
     showBoundingBoxButton: boolean;
-    showTransformButton?: boolean;
   };
   viewerConfig: {
     showAxes: boolean;
     showBoundingBox: boolean;
     boundingBoxColor?: ColorArray;
     backgroundColor?: ColorArray;
-    transformEnabled?: boolean;
     autorotate: boolean;
     view: string; // "3D", "XY", "XZ", "YZ"
     mode: string; // "default", "pathtrace", "maxprojection"
@@ -60,7 +58,7 @@ export interface AppProps {
   transform?: {
     translate: [number, number, number];
     rotate: [number, number, number];
-  }
+  };
 
   onControlPanelToggle?: (collapsed: boolean) => void;
 }
@@ -74,7 +72,6 @@ export interface UserSelectionState {
   pathTrace: boolean;
   showAxes: boolean;
   showBoundingBox: boolean;
-  transformEnabled: boolean;
   boundingBoxColor: ColorArray;
   backgroundColor: ColorArray;
   alphaMaskSliderLevel: number[]; //[props.viewerConfig.maskAlpha] || ALPHA_MASK_SLIDER_3D_DEFAULT,

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -21,7 +21,6 @@ interface ToolbarProps {
   canPathTrace: boolean;
   showAxes: boolean;
   showBoundingBox: boolean;
-  transformEnabled: boolean;
 
   onViewModeChange: (mode: ViewMode) => void;
   onResetCamera: () => void;
@@ -31,7 +30,6 @@ interface ToolbarProps {
   onChangeRenderingAlgorithm: (newAlgorithm: RenderMode) => void;
   changeAxisShowing: (showing: boolean) => void;
   changeBoundingBoxShowing: (showing: boolean) => void;
-  changeTransformEnabled: (enabled: boolean) => void;
 
   renderConfig: {
     autoRotateButton: boolean;
@@ -40,12 +38,11 @@ interface ToolbarProps {
     resetCameraButton: boolean;
     showAxesButton: boolean;
     showBoundingBoxButton: boolean;
-    showTransformButton?: boolean;
   };
 }
 
 export default function Toolbar(props: ToolbarProps): React.ReactElement {
-  const { renderConfig, showAxes, showBoundingBox, transformEnabled } = props;
+  const { renderConfig, showAxes, showBoundingBox } = props;
 
   const twoDMode = props.mode !== ViewMode.threeD;
 
@@ -55,7 +52,6 @@ export default function Toolbar(props: ToolbarProps): React.ReactElement {
 
   const toggleAxis = (): void => props.changeAxisShowing(!props.showAxes);
   const toggleBoundingBox = (): void => props.changeBoundingBoxShowing(!props.showBoundingBox);
-  const toggleTransform = (): void => props.changeTransformEnabled(!props.transformEnabled);
 
   // TODO remove ant-btn-icon-only hack when upgrading antd
   const classForToggleBtn = (active: boolean): string =>
@@ -63,16 +59,6 @@ export default function Toolbar(props: ToolbarProps): React.ReactElement {
 
   return (
     <div className="viewer-toolbar">
-      {renderConfig.showTransformButton && (
-        <span className="viewer-toolbar-left viewer-toolbar-group">
-          <Button
-            className={transformEnabled ? "btn-borderless btn-active" : "btn-borderless"}
-            onClick={toggleTransform}
-          >
-            {transformEnabled ? "Unalign" : "Align"}
-          </Button>
-        </span>
-      )}
       <span className="viewer-toolbar-center">
         {renderGroup1 && (
           <span className="viewer-toolbar-group">

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -21,6 +21,7 @@ interface ToolbarProps {
   canPathTrace: boolean;
   showAxes: boolean;
   showBoundingBox: boolean;
+  transformEnabled: boolean;
 
   onViewModeChange: (mode: ViewMode) => void;
   onResetCamera: () => void;
@@ -30,6 +31,7 @@ interface ToolbarProps {
   onChangeRenderingAlgorithm: (newAlgorithm: RenderMode) => void;
   changeAxisShowing: (showing: boolean) => void;
   changeBoundingBoxShowing: (showing: boolean) => void;
+  changeTransformEnabled: (enabled: boolean) => void;
 
   renderConfig: {
     autoRotateButton: boolean;
@@ -38,11 +40,12 @@ interface ToolbarProps {
     resetCameraButton: boolean;
     showAxesButton: boolean;
     showBoundingBoxButton: boolean;
+    showTransformButton?: boolean;
   };
 }
 
 export default function Toolbar(props: ToolbarProps): React.ReactElement {
-  const { renderConfig, showAxes, showBoundingBox } = props;
+  const { renderConfig, showAxes, showBoundingBox, transformEnabled } = props;
 
   const twoDMode = props.mode !== ViewMode.threeD;
 
@@ -52,6 +55,7 @@ export default function Toolbar(props: ToolbarProps): React.ReactElement {
 
   const toggleAxis = (): void => props.changeAxisShowing(!props.showAxes);
   const toggleBoundingBox = (): void => props.changeBoundingBoxShowing(!props.showBoundingBox);
+  const toggleTransform = (): void => props.changeTransformEnabled(!props.transformEnabled);
 
   // TODO remove ant-btn-icon-only hack when upgrading antd
   const classForToggleBtn = (active: boolean): string =>
@@ -132,6 +136,11 @@ export default function Toolbar(props: ToolbarProps): React.ReactElement {
               </Tooltip>
             )}
           </span>
+        )}
+        {renderConfig.showTransformButton && (
+          <Button className={classForToggleBtn(transformEnabled)} onClick={toggleTransform}>
+            A
+          </Button>
         )}
       </span>
 

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -63,6 +63,16 @@ export default function Toolbar(props: ToolbarProps): React.ReactElement {
 
   return (
     <div className="viewer-toolbar">
+      {renderConfig.showTransformButton && (
+        <span className="viewer-toolbar-left viewer-toolbar-group">
+          <Button
+            className={transformEnabled ? "btn-borderless btn-active" : "btn-borderless"}
+            onClick={toggleTransform}
+          >
+            {transformEnabled ? "Unalign" : "Align"}
+          </Button>
+        </span>
+      )}
       <span className="viewer-toolbar-center">
         {renderGroup1 && (
           <span className="viewer-toolbar-group">
@@ -136,11 +146,6 @@ export default function Toolbar(props: ToolbarProps): React.ReactElement {
               </Tooltip>
             )}
           </span>
-        )}
-        {renderConfig.showTransformButton && (
-          <Button className={classForToggleBtn(transformEnabled)} onClick={toggleTransform}>
-            A
-          </Button>
         )}
       </span>
 

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -10,6 +10,11 @@
   text-align: center;
   padding: 0 12px;
 
+  .viewer-toolbar-left {
+    position: absolute;
+    left: 12px;
+  }
+
   .viewer-toolbar-right {
     position: absolute;
     right: 12px;


### PR DESCRIPTION
Resolve #51:
- Add optional `transform` prop to viewer, with fields `translate` (in pixels) and `rotate` (in radians).
- Propagate transform to viewer on load and update

And also:
- Bump volume-viewer to get new max project behavior
- Fix bug with `viewerConfig.mode` prop
- Add a new CSS class to toolbar: `.viewer-toolbar-left` (currently unused in the main viewer) for toolbar controls in the left corner.