### PR TITLE
Feature/interpolation control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@aics/volume-viewer": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-2.6.1.tgz",
-      "integrity": "sha512-Zd7L3/DxuDsPfxaNmyyH1ZMsoc+91dBNBajTFWOFIkgvz/bZqjXW+IHOxxaKt9lpgA0M3q/780qASeL09b9L+w==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-2.7.0.tgz",
+      "integrity": "sha512-/cIDQ8zy3cfEF+A2YdhbPbP6rSUF0MEnDfOyvq7zjU8BpexaQILHXo9XenYdRRnD0at10QBpSJYjRXgC5sdGmg==",
       "requires": {
         "geotiff": "^2.0.5",
         "three": "^0.144.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/volume-viewer": "^2.6.1",
+    "@aics/volume-viewer": "^2.7.0",
     "color-string": "^1.5.3",
     "d3": "^4.11.0",
     "lodash": "^4.17.20",

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -193,7 +193,10 @@ export default class App extends React.Component<AppProps, AppState> {
         brightnessSliderLevel: [viewerConfig.brightness] || BRIGHTNESS_SLIDER_LEVEL_DEFAULT,
         densitySliderLevel: [viewerConfig.density] || DENSITY_SLIDER_LEVEL_DEFAULT,
         levelsSlider: viewerConfig.levels || LEVELS_SLIDER_DEFAULT,
-        interpolationEnabled: viewerConfig.interpolationEnabled || INTERPOLATION_ENABLED_DEFAULT,
+        interpolationEnabled:
+          viewerConfig.interpolationEnabled === undefined
+            ? INTERPOLATION_ENABLED_DEFAULT
+            : viewerConfig.interpolationEnabled,
         // channelSettings is a flat list of objects of this type:
         // { name, enabled, volumeEnabled, isosurfaceEnabled, isovalue, opacity, color, dataReady}
         channelSettings: [],

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -36,6 +36,7 @@ import {
   LUT_MAX_PERCENTILE,
   SINGLE_GROUP_CHANNEL_KEY,
   CONTROL_PANEL_CLOSE_WIDTH,
+  INTERPOLATION_ENABLED_DEFAULT,
 } from "../../shared/constants";
 
 import ControlPanel from "../ControlPanel";
@@ -91,6 +92,7 @@ const defaultProps: AppProps = {
     colorPresetsDropdown: true,
     densitySlider: true,
     levelsSliders: true,
+    interpolationControl: true,
     saveSurfaceButtons: true,
     fovCellSwitchControls: true,
     viewModeRadioButtons: true,
@@ -132,25 +134,27 @@ export default class App extends React.Component<AppProps, AppState> {
   constructor(props: AppProps) {
     super(props);
 
+    const { viewerConfig } = props;
+
     let viewmode = ViewMode.threeD;
     let pathtrace = false;
     let maxproject = false;
-    if (props.viewerConfig) {
-      if (props.viewerConfig.mode === "pathtrace") {
+    if (viewerConfig) {
+      if (viewerConfig.mode === "pathtrace") {
         pathtrace = true;
         maxproject = false;
-      } else if (props.viewerConfig.mode === "maxprojection") {
+      } else if (viewerConfig.mode === "maxprojection") {
         pathtrace = false;
         maxproject = true;
       } else {
         pathtrace = false;
         maxproject = false;
       }
-      if (props.viewerConfig.view === "XY") {
+      if (viewerConfig.view === "XY") {
         viewmode = ViewMode.xy;
-      } else if (props.viewerConfig.view === "YZ") {
+      } else if (viewerConfig.view === "YZ") {
         viewmode = ViewMode.yz;
-      } else if (props.viewerConfig.view === "XZ") {
+      } else if (viewerConfig.view === "XZ") {
         viewmode = ViewMode.xz;
       }
     }
@@ -178,17 +182,18 @@ export default class App extends React.Component<AppProps, AppState> {
         imageType: ImageType.segmentedCell,
         controlPanelClosed: window.innerWidth < CONTROL_PANEL_CLOSE_WIDTH,
         mode: viewmode,
-        autorotate: props.viewerConfig.autorotate,
-        showAxes: props.viewerConfig.showAxes,
-        showBoundingBox: props.viewerConfig.showBoundingBox,
-        boundingBoxColor: props.viewerConfig.boundingBoxColor || BOUNDING_BOX_COLOR_DEFAULT,
-        backgroundColor: props.viewerConfig.backgroundColor || BACKGROUND_COLOR_DEFAULT,
+        autorotate: viewerConfig.autorotate,
+        showAxes: viewerConfig.showAxes,
+        showBoundingBox: viewerConfig.showBoundingBox,
+        boundingBoxColor: viewerConfig.boundingBoxColor || BOUNDING_BOX_COLOR_DEFAULT,
+        backgroundColor: viewerConfig.backgroundColor || BACKGROUND_COLOR_DEFAULT,
         maxProject: maxproject,
         pathTrace: pathtrace,
-        alphaMaskSliderLevel: [props.viewerConfig.maskAlpha] || ALPHA_MASK_SLIDER_3D_DEFAULT,
-        brightnessSliderLevel: [props.viewerConfig.brightness] || BRIGHTNESS_SLIDER_LEVEL_DEFAULT,
-        densitySliderLevel: [props.viewerConfig.density] || DENSITY_SLIDER_LEVEL_DEFAULT,
-        levelsSlider: props.viewerConfig.levels || LEVELS_SLIDER_DEFAULT,
+        alphaMaskSliderLevel: [viewerConfig.maskAlpha] || ALPHA_MASK_SLIDER_3D_DEFAULT,
+        brightnessSliderLevel: [viewerConfig.brightness] || BRIGHTNESS_SLIDER_LEVEL_DEFAULT,
+        densitySliderLevel: [viewerConfig.density] || DENSITY_SLIDER_LEVEL_DEFAULT,
+        levelsSlider: viewerConfig.levels || LEVELS_SLIDER_DEFAULT,
+        interpolationEnabled: viewerConfig.interpolationEnabled || INTERPOLATION_ENABLED_DEFAULT,
         // channelSettings is a flat list of objects of this type:
         // { name, enabled, volumeEnabled, isosurfaceEnabled, isovalue, opacity, color, dataReady}
         channelSettings: [],
@@ -505,6 +510,10 @@ export default class App extends React.Component<AppProps, AppState> {
     view3d.setCameraMode(userSelections.mode);
     view3d.setShowBoundingBox(aimg, userSelections.showBoundingBox);
     view3d.setBoundingBoxColor(aimg, colorArrayToFloats(userSelections.boundingBoxColor));
+    // interpolation defaults to enabled in volume-viewer
+    if (!userSelections.interpolationEnabled) {
+      view3d.setInterpolationEnabled(aimg, false);
+    }
 
     view3d.setVolumeTranslation(aimg, this.props.transform?.translate || [0, 0, 0]);
     view3d.setVolumeRotation(aimg, this.props.transform?.rotate || [0, 0, 0]);
@@ -852,6 +861,7 @@ export default class App extends React.Component<AppProps, AppState> {
       const imageValues = gammaSliderToImageValues(value);
       view3d.setGamma(image, imageValues.min, imageValues.scale, imageValues.max);
     },
+    interpolationEnabled: (enabled, view3d, image) => view3d.setInterpolationEnabled(image, enabled),
   };
 
   /**
@@ -1148,6 +1158,7 @@ export default class App extends React.Component<AppProps, AppState> {
             brightnessSliderLevel={userSelections.brightnessSliderLevel}
             densitySliderLevel={userSelections.densitySliderLevel}
             gammaSliderLevel={userSelections.levelsSlider}
+            interpolationEnabled={userSelections.interpolationEnabled}
             collapsed={userSelections.controlPanelClosed}
             // functions
             setCollapsed={this.toggleControlPanel}

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -25,6 +25,7 @@ export interface AppProps {
     colorPresetsDropdown: boolean;
     densitySlider: boolean;
     levelsSliders: boolean;
+    interpolationControl: boolean;
     saveSurfaceButtons: boolean;
     fovCellSwitchControls: boolean;
     viewModeRadioButtons: boolean;
@@ -44,6 +45,7 @@ export interface AppProps {
     brightness: number; //BRIGHTNESS_SLIDER_LEVEL_DEFAULT[0],
     density: number; //DENSITY_SLIDER_LEVEL_DEFAULT[0],
     levels: [number, number, number]; // LEVELS_SLIDER_DEFAULT,
+    interpolationEnabled?: boolean;
     region?: [number, number, number, number, number, number]; //[0,1,0,1,0,1], // or ignored if slice is specified with a non-3D mode
     slice?: number; // or integer slice to show in view mode XY, YZ, or XZ.  mut. ex with region
   };
@@ -78,6 +80,7 @@ export interface UserSelectionState {
   brightnessSliderLevel: number[]; //[props.viewerConfig.brightness] || BRIGHTNESS_SLIDER_LEVEL_DEFAULT,
   densitySliderLevel: number[]; // [props.viewerConfig.density] || DENSITY_SLIDER_LEVEL_DEFAULT,
   levelsSlider: [number, number, number]; //props.viewerConfig.levels || LEVELS_SLIDER_DEFAULT,
+  interpolationEnabled: boolean;
   // channelSettings is a flat list of objects of this type:
   // { name, enabled, volumeEnabled, isosurfaceEnabled, isovalue, opacity, color, dataReady}
   // the list is in the order they were in the raw data.

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -135,6 +135,7 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
                     brightnessSliderLevel={props.brightnessSliderLevel}
                     densitySliderLevel={props.densitySliderLevel}
                     gammaSliderLevel={props.gammaSliderLevel}
+                    interpolationEnabled={props.interpolationEnabled}
                     maxProjectOn={props.maxProjectOn}
                     pathTraceOn={props.pathTraceOn}
                     renderConfig={renderConfig}

--- a/src/aics-image-viewer/components/GlobalVolumeControls.tsx
+++ b/src/aics-image-viewer/components/GlobalVolumeControls.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Nouislider from "nouislider-react";
 import "nouislider/distribute/nouislider.css";
 
-import { Card, Collapse } from "antd";
+import { Card, Collapse, Checkbox } from "antd";
 import { UserSelectionKey, UserSelectionState } from "./App/types";
 import { AxisName, Styles } from "../shared/types";
 const Panel = Collapse.Panel;
@@ -19,12 +19,14 @@ export interface GlobalVolumeControlsProps {
     brightnessSlider: boolean;
     densitySlider: boolean;
     levelsSliders: boolean;
+    interpolationControl: boolean;
   };
 
   alphaMaskSliderLevel: number[];
   brightnessSliderLevel: number[];
   densitySliderLevel: number[];
   gammaSliderLevel: [number, number, number];
+  interpolationEnabled: boolean;
 
   changeUserSelection: <K extends UserSelectionKey>(key: K, newValue: UserSelectionState[K]) => void;
   setImageAxisClip: (axis: AxisName, minval: number, maxval: number, isOrthoAxis: boolean) => void;
@@ -37,11 +39,12 @@ export default class GlobalVolumeControls extends React.Component<GlobalVolumeCo
   }
 
   shouldComponentUpdate(newProps: GlobalVolumeControlsProps): boolean {
-    const { imageName, alphaMaskSliderLevel, pathTraceOn } = this.props;
+    const { imageName, alphaMaskSliderLevel, pathTraceOn, interpolationEnabled } = this.props;
     const newImage = newProps.imageName !== imageName;
     const newPathTraceValue = newProps.pathTraceOn !== pathTraceOn;
     const newSliderValue = newProps.alphaMaskSliderLevel[0] !== alphaMaskSliderLevel[0];
-    return newImage || newSliderValue || newPathTraceValue;
+    const newInterpolationValue = newProps.interpolationEnabled !== interpolationEnabled;
+    return newImage || newSliderValue || newPathTraceValue || newInterpolationValue;
   }
 
   createSliderRow = (label: string, start: number[], max: number, propKey: GlobalVolumeControlKey): React.ReactNode => (
@@ -76,6 +79,17 @@ export default class GlobalVolumeControls extends React.Component<GlobalVolumeCo
               {renderConfig.densitySlider &&
                 this.createSliderRow("density", densitySliderLevel, 100, "densitySliderLevel")}
               {renderConfig.levelsSliders && this.createSliderRow("levels", gammaSliderLevel, 255, "levelsSlider")}
+              {renderConfig.interpolationControl && (
+                <div style={STYLES.controlRow}>
+                  <div style={STYLES.controlName}>interpolate</div>
+                  <div style={{ flex: 5 }}>
+                    <Checkbox
+                      checked={this.props.interpolationEnabled}
+                      onChange={({ target }) => this.props.changeUserSelection("interpolationEnabled", target.checked)}
+                    />
+                  </div>
+                </div>
+              )}
             </div>
           </Panel>
         </Collapse>
@@ -100,6 +114,6 @@ const STYLES: Styles = {
   control: {
     flex: 5,
     height: 30,
-    marginTop: 15,
+    marginTop: 10,
   },
 };

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -16,6 +16,7 @@ export const // Control panel will automatically close if viewport is less than 
   BRIGHTNESS_SLIDER_LEVEL_DEFAULT = [70],
   DENSITY_SLIDER_LEVEL_DEFAULT = [50],
   LEVELS_SLIDER_DEFAULT: ColorArray = [35.0, 140.0, 255.0],
+  INTERPOLATION_ENABLED_DEFAULT = true,
   OTHER_CHANNEL_KEY = "Other",
   SINGLE_GROUP_CHANNEL_KEY = "Channels";
 


### PR DESCRIPTION
Add a checkbox to the viewer to enable/disable interpolation, and props `renderConfig.interpolationControl` and `viewerConfig.interpolationEnabled` to set visibility and default value of the checkbox respectively.

### Screenshot:
(Could use a quick look and sign-off from @lynwilhelm. Lots of empty space to the right of that checkbox - is there any better way to position this control?)
![image](https://user-images.githubusercontent.com/53030214/206067202-2aae5b47-3f00-4e80-b37a-75c7fbb39fbd.png)