### PR TITLE
transform fields: `translate`/`rotate` -> `translation`/`rotation`

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -286,8 +286,8 @@ export default class App extends React.Component<AppProps, AppState> {
     if (!isEqual(prevProps.transform, this.props.transform)) {
       const { view3d, image } = this.state;
       if (view3d && image) {
-        view3d.setVolumeTranslation(image, this.props.transform?.translate || [0, 0, 0]);
-        view3d.setVolumeRotation(image, this.props.transform?.rotate || [0, 0, 0]);
+        view3d.setVolumeTranslation(image, this.props.transform?.translation || [0, 0, 0]);
+        view3d.setVolumeRotation(image, this.props.transform?.rotation || [0, 0, 0]);
       }
     }
 
@@ -518,8 +518,8 @@ export default class App extends React.Component<AppProps, AppState> {
       view3d.setInterpolationEnabled(aimg, false);
     }
 
-    view3d.setVolumeTranslation(aimg, this.props.transform?.translate || [0, 0, 0]);
-    view3d.setVolumeRotation(aimg, this.props.transform?.rotate || [0, 0, 0]);
+    view3d.setVolumeTranslation(aimg, this.props.transform?.translation || [0, 0, 0]);
+    view3d.setVolumeRotation(aimg, this.props.transform?.rotation || [0, 0, 0]);
     // tell view that things have changed for this image
     view3d.updateActiveChannels(aimg);
   }

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -58,8 +58,8 @@ export interface AppProps {
   pixelSize?: [number, number, number];
   canvasMargin: string;
   transform?: {
-    translate: [number, number, number];
-    rotate: [number, number, number];
+    translation: [number, number, number];
+    rotation: [number, number, number];
   };
 
   onControlPanelToggle?: (collapsed: boolean) => void;


### PR DESCRIPTION
### Problem

The `transform` prop on `App` has fields `translate` and `rotate`, but transforms in the Variance dataset, for which the prop was originally added, has fields `translation` and `rotation`. Passing transforms directly in from CFE doesn't work.

### Solution

Change the names.

Note that this is a breaking change: any dependent software that has come to rely on this interface in the hour since v2.4.0 was published will unfortunately need to be updated.