### PR TITLE
Fix/responsive toolbar

### DIFF
--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -80,13 +80,14 @@ export default function Toolbar(props: ToolbarProps): React.ReactElement {
     checkSize();
   }, []); // Dependency-free effect will only run on mount
 
+  const scrollX = (amount: number): number => (barRef.current!.scrollLeft += amount);
   // Translate vertical scrolling into horizontal scrolling
-  const scrollX: WheelEventHandler<HTMLDivElement> = (e) => {
+  const scrollHandler: WheelEventHandler<HTMLDivElement> = (e) => {
     e.preventDefault();
     if (e.deltaY === 0) {
       return;
     }
-    barRef.current!.scrollLeft += e.deltaY;
+    scrollX(e.deltaY);
   };
 
   const twoDMode = props.mode !== ViewMode.threeD;
@@ -106,97 +107,105 @@ export default function Toolbar(props: ToolbarProps): React.ReactElement {
     "ant-btn-icon-only btn-borderless" + (active ? " btn-active" : "");
 
   return (
-    <div className={`viewer-toolbar${scrollMode ? " viewer-toolbar-scroll" : ""}`} ref={barRef} onWheel={scrollX}>
-      <span className="viewer-toolbar-left" ref={leftRef} />
-      <span className="viewer-toolbar-center" ref={centerRef}>
-        {renderGroup1 && (
-          <span className="viewer-toolbar-group">
-            {renderConfig.viewModeRadioButtons && (
-              <ViewModeRadioButtons mode={props.mode} onViewModeChange={props.onViewModeChange} />
-            )}
-            {renderConfig.resetCameraButton && (
-              <Tooltip placement="bottom" title="Reset camera">
-                <Button className="ant-btn-icon-only btn-borderless" onClick={props.onResetCamera}>
-                  <ViewerIcon type="resetView" />
-                </Button>
-              </Tooltip>
-            )}
-            {renderConfig.autoRotateButton && (
-              <Tooltip placement="bottom" title={turntableToggleTitle}>
-                <Button
-                  className={classForToggleBtn(autorotate && !twoDMode)}
-                  disabled={twoDMode || props.pathTraceOn}
-                  onClick={props.onAutorotateChange}
-                >
-                  <ViewerIcon type="turnTable" />
-                </Button>
-              </Tooltip>
-            )}
-          </span>
-        )}
+    <div className={`viewer-toolbar-container${scrollMode ? " viewer-toolbar-scroll" : ""}`}>
+      <div className="viewer-toolbar-scroll-btn scroll-btn-left" onClick={() => scrollX(-100)}>
+        <ViewerIcon type="closePanel" style={{ fontSize: "12px", transform: "rotate(180deg)" }} />
+      </div>
+      <div className="viewer-toolbar" ref={barRef} onWheel={scrollHandler}>
+        <span className="viewer-toolbar-left" ref={leftRef} />
+        <span className="viewer-toolbar-center" ref={centerRef}>
+          {renderGroup1 && (
+            <span className="viewer-toolbar-group">
+              {renderConfig.viewModeRadioButtons && (
+                <ViewModeRadioButtons mode={props.mode} onViewModeChange={props.onViewModeChange} />
+              )}
+              {renderConfig.resetCameraButton && (
+                <Tooltip placement="bottom" title="Reset camera">
+                  <Button className="ant-btn-icon-only btn-borderless" onClick={props.onResetCamera}>
+                    <ViewerIcon type="resetView" />
+                  </Button>
+                </Tooltip>
+              )}
+              {renderConfig.autoRotateButton && (
+                <Tooltip placement="bottom" title={turntableToggleTitle}>
+                  <Button
+                    className={classForToggleBtn(autorotate && !twoDMode)}
+                    disabled={twoDMode || props.pathTraceOn}
+                    onClick={props.onAutorotateChange}
+                  >
+                    <ViewerIcon type="turnTable" />
+                  </Button>
+                </Tooltip>
+              )}
+            </span>
+          )}
 
-        {renderConfig.fovCellSwitchControls && props.hasCellId && props.hasParentImage && (
-          <span className="viewer-toolbar-group">
-            <Radio.Group value={props.imageType} onChange={({ target }) => props.onSwitchFovCell(target.value)}>
-              <Radio.Button value={ImageType.segmentedCell}>Single cell</Radio.Button>
-              <Radio.Button value={ImageType.fullField}>Full field</Radio.Button>
-            </Radio.Group>
-          </span>
-        )}
+          {renderConfig.fovCellSwitchControls && props.hasCellId && props.hasParentImage && (
+            <span className="viewer-toolbar-group">
+              <Radio.Group value={props.imageType} onChange={({ target }) => props.onSwitchFovCell(target.value)}>
+                <Radio.Button value={ImageType.segmentedCell}>Single cell</Radio.Button>
+                <Radio.Button value={ImageType.fullField}>Full field</Radio.Button>
+              </Radio.Group>
+            </span>
+          )}
 
-        <span className="viewer-toolbar-group">
-          <Select
-            className="select-render-setting"
-            dropdownClassName="viewer-toolbar-dropdown"
-            value={props.renderSetting}
-            onChange={props.onChangeRenderingAlgorithm}
-          >
-            <Select.Option value={RenderMode.volumetric} key={RenderMode.volumetric}>
-              Volumetric
-            </Select.Option>
-            {props.canPathTrace && (
-              <Select.Option value={RenderMode.pathTrace} key={RenderMode.pathTrace} disabled={twoDMode}>
-                Path trace
+          <span className="viewer-toolbar-group">
+            <Select
+              className="select-render-setting"
+              dropdownClassName="viewer-toolbar-dropdown"
+              value={props.renderSetting}
+              onChange={props.onChangeRenderingAlgorithm}
+            >
+              <Select.Option value={RenderMode.volumetric} key={RenderMode.volumetric}>
+                Volumetric
               </Select.Option>
-            )}
-            <Select.Option value={RenderMode.maxProject} key={RenderMode.maxProject}>
-              Max project
-            </Select.Option>
-          </Select>
+              {props.canPathTrace && (
+                <Select.Option value={RenderMode.pathTrace} key={RenderMode.pathTrace} disabled={twoDMode}>
+                  Path trace
+                </Select.Option>
+              )}
+              <Select.Option value={RenderMode.maxProject} key={RenderMode.maxProject}>
+                Max project
+              </Select.Option>
+            </Select>
+          </span>
+
+          {renderGroup4 && (
+            <span className="viewer-toolbar-group">
+              {renderConfig.showAxesButton && (
+                <Tooltip placement="bottom" title={axesToggleTitle}>
+                  <Button className={classForToggleBtn(showAxes)} onClick={toggleAxis}>
+                    <ViewerIcon type="axes" />
+                  </Button>
+                </Tooltip>
+              )}
+              {renderConfig.showBoundingBoxButton && (
+                <Tooltip placement="bottom" title={boundingBoxToggleTitle}>
+                  <Button className={classForToggleBtn(showBoundingBox)} onClick={toggleBoundingBox}>
+                    <ViewerIcon type="boundingBox" />
+                  </Button>
+                </Tooltip>
+              )}
+            </span>
+          )}
         </span>
 
-        {renderGroup4 && (
-          <span className="viewer-toolbar-group">
-            {renderConfig.showAxesButton && (
-              <Tooltip placement="bottom" title={axesToggleTitle}>
-                <Button className={classForToggleBtn(showAxes)} onClick={toggleAxis}>
-                  <ViewerIcon type="axes" />
-                </Button>
-              </Tooltip>
-            )}
-            {renderConfig.showBoundingBoxButton && (
-              <Tooltip placement="bottom" title={boundingBoxToggleTitle}>
-                <Button className={classForToggleBtn(showBoundingBox)} onClick={toggleBoundingBox}>
-                  <ViewerIcon type="boundingBox" />
-                </Button>
-              </Tooltip>
-            )}
-          </span>
-        )}
-      </span>
-
-      <span className="viewer-toolbar-right viewer-toolbar-group" ref={rightRef}>
-        <Tooltip placement="bottom" title="Download">
-          <DownloadButton
-            cellDownloadHref={props.cellDownloadHref}
-            fovDownloadHref={props.fovDownloadHref}
-            hasFov={props.hasCellId && props.hasParentImage}
-          />
-        </Tooltip>
-        <Tooltip placement="bottom" title="Screenshot">
-          <Button icon="camera" className="btn-borderless" onClick={props.downloadScreenshot} />
-        </Tooltip>
-      </span>
+        <span className="viewer-toolbar-right viewer-toolbar-group" ref={rightRef}>
+          <Tooltip placement="bottom" title="Download">
+            <DownloadButton
+              cellDownloadHref={props.cellDownloadHref}
+              fovDownloadHref={props.fovDownloadHref}
+              hasFov={props.hasCellId && props.hasParentImage}
+            />
+          </Tooltip>
+          <Tooltip placement="bottom" title="Screenshot">
+            <Button icon="camera" className="btn-borderless" onClick={props.downloadScreenshot} />
+          </Tooltip>
+        </span>
+      </div>
+      <div className="viewer-toolbar-scroll-btn scroll-btn-right" onClick={() => scrollX(100)}>
+        <ViewerIcon type="closePanel" style={{ fontSize: "12px" }} />
+      </div>
     </div>
   );
 }

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -1,4 +1,4 @@
-import React, { WheelEventHandler } from "react";
+import React from "react";
 import { Button, Radio, Select, Tooltip } from "antd";
 import { debounce } from "lodash";
 
@@ -82,16 +82,14 @@ export default class Toolbar extends React.Component<ToolbarProps, ToolbarState>
       const requiredWidth = Math.max(leftRect.width, rightRect.width) * 2 + centerRect.width + 30;
       if (barWidth > requiredWidth) {
         this.setState({ scrollMode: false });
-      } else {
-        this.checkScrollBtnVisible();
       }
     } else {
       // Enter scroll mode if centered controls are overlapping either left/right-aligned ones
       if (leftRect.right > centerRect.left || centerRect.right > rightRect.left) {
         this.setState({ scrollMode: true });
-        this.checkScrollBtnVisible();
       }
     }
+    this.checkScrollBtnVisible();
   }, 50);
 
   scrollX = (amount: number): number => (this.barRef.current!.scrollLeft += amount);
@@ -124,7 +122,7 @@ export default class Toolbar extends React.Component<ToolbarProps, ToolbarState>
   // TODO remove ant-btn-icon-only hack when upgrading antd
   classForToggleBtn = (active: boolean): string => "ant-btn-icon-only btn-borderless" + (active ? " btn-active" : "");
 
-  render() {
+  render(): React.ReactElement {
     const { props } = this;
     const { renderConfig, showAxes, showBoundingBox, autorotate } = props;
     const { scrollMode, scrollBtnLeft, scrollBtnRight } = this.state;

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -45,7 +45,7 @@ interface ToolbarProps {
 export default function Toolbar(props: ToolbarProps): React.ReactElement {
   const { renderConfig, showAxes, showBoundingBox, autorotate } = props;
 
-  // Track if centered buttons overlap left or right buttons... with lots of refs
+  // Add a stateful value for whether we're in "scroll mode"
   const [scrollMode, _setScrollMode] = React.useState(false);
   const scrollModeRef = React.useRef(scrollMode);
   const setScrollMode = (mode: boolean): void => {
@@ -53,6 +53,7 @@ export default function Toolbar(props: ToolbarProps): React.ReactElement {
     _setScrollMode(mode);
   };
 
+  // Track if centered buttons overlap left or right buttons... with lots of refs
   const barRef = React.useRef<HTMLDivElement>(null);
   const leftRef = React.useRef<HTMLSpanElement>(null);
   const centerRef = React.useRef<HTMLSpanElement>(null);

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -81,7 +81,13 @@ export default function Toolbar(props: ToolbarProps): React.ReactElement {
   }, []); // Dependency-free effect will only run on mount
 
   // Translate vertical scrolling into horizontal scrolling
-  const scrollX: WheelEventHandler<HTMLDivElement> = ({ deltaY }) => barRef.current!.scroll({ left: deltaY });
+  const scrollX: WheelEventHandler<HTMLDivElement> = (e) => {
+    e.preventDefault();
+    if (e.deltaY === 0) {
+      return;
+    }
+    barRef.current!.scrollLeft += e.deltaY;
+  };
 
   const twoDMode = props.mode !== ViewMode.threeD;
 

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -48,6 +48,8 @@ interface ToolbarState {
   scrollBtnRight: boolean;
 }
 
+const RESIZE_DEBOUNCE_DELAY = 50;
+
 export default class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
   barRef: React.RefObject<HTMLDivElement>;
   leftRef: React.RefObject<HTMLDivElement>;
@@ -94,7 +96,7 @@ export default class Toolbar extends React.Component<ToolbarProps, ToolbarState>
       }
     }
     this.checkScrollBtnVisible();
-  }, 50);
+  }, RESIZE_DEBOUNCE_DELAY);
 
   scrollX = (amount: number): number => (this.barRef.current!.scrollLeft += amount);
 

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -76,10 +76,14 @@ export default class Toolbar extends React.Component<ToolbarProps, ToolbarState>
     const centerRect = centerRef.current!.getBoundingClientRect();
     const rightRect = rightRef.current!.getBoundingClientRect();
 
+    // when calculating width required to leave scroll mode, add a bit of extra width to ensure that triggers
+    // for entering and leaving scroll mode never overlap (causing toolbar to rapidly switch when resizing)
+    const SCROLL_OFF_EXTRA_WIDTH = 15;
+
     if (this.state.scrollMode) {
       // Leave scroll mode if there is enough space for centered controls not to overlap left/right-aligned ones
       const barWidth = barRef.current!.getBoundingClientRect().width;
-      const requiredWidth = Math.max(leftRect.width, rightRect.width) * 2 + centerRect.width + 30;
+      const requiredWidth = Math.max(leftRect.width, rightRect.width) * 2 + centerRect.width + SCROLL_OFF_EXTRA_WIDTH;
       if (barWidth > requiredWidth) {
         this.setState({ scrollMode: false });
       }

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -42,171 +42,216 @@ interface ToolbarProps {
   };
 }
 
-export default function Toolbar(props: ToolbarProps): React.ReactElement {
-  const { renderConfig, showAxes, showBoundingBox, autorotate } = props;
+interface ToolbarState {
+  scrollMode: boolean;
+  scrollBtnLeft: boolean;
+  scrollBtnRight: boolean;
+}
 
-  // Add a stateful value for whether we're in "scroll mode"
-  const [scrollMode, _setScrollMode] = React.useState(false);
-  const scrollModeRef = React.useRef(scrollMode);
-  const setScrollMode = (mode: boolean): void => {
-    scrollModeRef.current = mode;
-    _setScrollMode(mode);
-  };
+export default class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
+  barRef: React.RefObject<HTMLDivElement>;
+  leftRef: React.RefObject<HTMLDivElement>;
+  rightRef: React.RefObject<HTMLDivElement>;
+  centerRef: React.RefObject<HTMLDivElement>;
 
-  // Track if centered buttons overlap left or right buttons... with lots of refs
-  const barRef = React.useRef<HTMLDivElement>(null);
-  const leftRef = React.useRef<HTMLSpanElement>(null);
-  const centerRef = React.useRef<HTMLSpanElement>(null);
-  const rightRef = React.useRef<HTMLSpanElement>(null);
+  constructor(props: ToolbarProps) {
+    super(props);
+    this.state = {
+      scrollMode: false,
+      scrollBtnLeft: false,
+      scrollBtnRight: false,
+    };
+    this.barRef = React.createRef();
+    this.leftRef = React.createRef();
+    this.rightRef = React.createRef();
+    this.centerRef = React.createRef();
 
-  const checkSize = debounce((): void => {
+    window.addEventListener("resize", this.checkSize);
+    this.checkSize();
+  }
+
+  checkSize = debounce((): void => {
+    const { leftRef, centerRef, rightRef, barRef } = this;
     const leftRect = leftRef.current!.getBoundingClientRect();
     const centerRect = centerRef.current!.getBoundingClientRect();
     const rightRect = rightRef.current!.getBoundingClientRect();
-    if (scrollModeRef.current) {
+
+    if (this.state.scrollMode) {
+      // Leave scroll mode if there is enough space for centered controls not to overlap left/right-aligned ones
       const barWidth = barRef.current!.getBoundingClientRect().width;
       const requiredWidth = Math.max(leftRect.width, rightRect.width) * 2 + centerRect.width + 30;
       if (barWidth > requiredWidth) {
-        setScrollMode(false);
+        this.setState({ scrollMode: false });
+      } else {
+        this.checkScrollBtnVisible();
       }
     } else {
+      // Enter scroll mode if centered controls are overlapping either left/right-aligned ones
       if (leftRect.right > centerRect.left || centerRect.right > rightRect.left) {
-        setScrollMode(true);
+        this.setState({ scrollMode: true });
+        this.checkScrollBtnVisible();
       }
     }
   }, 50);
 
-  React.useEffect((): void => {
-    window.addEventListener("resize", checkSize);
-    checkSize();
-  }, []); // Dependency-free effect will only run on mount
+  scrollX = (amount: number): number => (this.barRef.current!.scrollLeft += amount);
 
-  const scrollX = (amount: number): number => (barRef.current!.scrollLeft += amount);
   // Translate vertical scrolling into horizontal scrolling
-  const scrollHandler: WheelEventHandler<HTMLDivElement> = (e) => {
+  wheelHandler: React.WheelEventHandler<HTMLDivElement> = (e) => {
     e.preventDefault();
     if (e.deltaY === 0) {
       return;
     }
-    scrollX(e.deltaY);
+    this.scrollX(e.deltaY);
   };
 
-  const twoDMode = props.mode !== ViewMode.threeD;
+  // Scroll buttons are only visible when toolbar can be scrolled in that direction.
+  // This may change on either scroll or resize.
+  checkScrollBtnVisible = (): void => {
+    const barEl = this.barRef.current;
+    if (!barEl) {
+      return;
+    }
+    const scrollBtnLeft = barEl.scrollLeft > 0;
+    const scrollBtnRight = barEl.scrollLeft < barEl.scrollWidth - barEl.clientWidth;
+    if (scrollBtnLeft !== this.state.scrollBtnLeft || scrollBtnRight !== this.state.scrollBtnRight) {
+      this.setState({ scrollBtnLeft, scrollBtnRight });
+    }
+  };
 
-  const renderGroup1 =
-    renderConfig.viewModeRadioButtons || renderConfig.resetCameraButton || renderConfig.autoRotateButton;
-  const renderGroup4 = renderConfig.showAxesButton || renderConfig.showBoundingBoxButton;
-
-  const toggleAxis = (): void => props.changeAxisShowing(!props.showAxes);
-  const toggleBoundingBox = (): void => props.changeBoundingBoxShowing(!props.showBoundingBox);
-  const axesToggleTitle = showAxes ? "Hide axes" : "Show axes";
-  const boundingBoxToggleTitle = showBoundingBox ? "Hide bounding box" : "Show bounding box";
-  const turntableToggleTitle = autorotate ? "Turn off turntable" : "Turn on turntable";
-
+  toggleAxis = (): void => this.props.changeAxisShowing(!this.props.showAxes);
+  toggleBoundingBox = (): void => this.props.changeBoundingBoxShowing(!this.props.showBoundingBox);
   // TODO remove ant-btn-icon-only hack when upgrading antd
-  const classForToggleBtn = (active: boolean): string =>
-    "ant-btn-icon-only btn-borderless" + (active ? " btn-active" : "");
+  classForToggleBtn = (active: boolean): string => "ant-btn-icon-only btn-borderless" + (active ? " btn-active" : "");
 
-  return (
-    <div className={`viewer-toolbar-container${scrollMode ? " viewer-toolbar-scroll" : ""}`}>
-      <div className="viewer-toolbar-scroll-left" onClick={() => scrollX(-100)}>
-        <ViewerIcon type="closePanel" style={{ fontSize: "12px", transform: "rotate(180deg)" }} />
-      </div>
-      <div className="viewer-toolbar" ref={barRef} onWheel={scrollHandler}>
-        <span className="viewer-toolbar-left" ref={leftRef} />
-        <span className="viewer-toolbar-center" ref={centerRef}>
-          {renderGroup1 && (
+  render() {
+    const { props } = this;
+    const { renderConfig, showAxes, showBoundingBox, autorotate } = props;
+    const { scrollMode, scrollBtnLeft, scrollBtnRight } = this.state;
+    const twoDMode = props.mode !== ViewMode.threeD;
+
+    const renderGroup1 =
+      renderConfig.viewModeRadioButtons || renderConfig.resetCameraButton || renderConfig.autoRotateButton;
+    const renderGroup4 = renderConfig.showAxesButton || renderConfig.showBoundingBoxButton;
+
+    const axesToggleTitle = showAxes ? "Hide axes" : "Show axes";
+    const boundingBoxToggleTitle = showBoundingBox ? "Hide bounding box" : "Show bounding box";
+    const turntableToggleTitle = autorotate ? "Turn off turntable" : "Turn on turntable";
+
+    return (
+      <div className={`viewer-toolbar-container${scrollMode ? " viewer-toolbar-scroll" : ""}`}>
+        <div
+          className="viewer-toolbar-scroll-left"
+          style={{ display: scrollBtnLeft ? "flex" : "none" }}
+          onClick={() => this.scrollX(-100)}
+        >
+          <ViewerIcon type="closePanel" style={{ fontSize: "12px", transform: "rotate(180deg)" }} />
+        </div>
+        <div
+          className="viewer-toolbar"
+          ref={this.barRef}
+          onWheel={this.wheelHandler}
+          onScroll={this.checkScrollBtnVisible}
+        >
+          <span className="viewer-toolbar-left" ref={this.leftRef} />
+          <span className="viewer-toolbar-center" ref={this.centerRef}>
+            {renderGroup1 && (
+              <span className="viewer-toolbar-group">
+                {renderConfig.viewModeRadioButtons && (
+                  <ViewModeRadioButtons mode={props.mode} onViewModeChange={props.onViewModeChange} />
+                )}
+                {renderConfig.resetCameraButton && (
+                  <Tooltip placement="bottom" title="Reset camera">
+                    <Button className="ant-btn-icon-only btn-borderless" onClick={props.onResetCamera}>
+                      <ViewerIcon type="resetView" />
+                    </Button>
+                  </Tooltip>
+                )}
+                {renderConfig.autoRotateButton && (
+                  <Tooltip placement="bottom" title={turntableToggleTitle}>
+                    <Button
+                      className={this.classForToggleBtn(autorotate && !twoDMode)}
+                      disabled={twoDMode || props.pathTraceOn}
+                      onClick={props.onAutorotateChange}
+                    >
+                      <ViewerIcon type="turnTable" />
+                    </Button>
+                  </Tooltip>
+                )}
+              </span>
+            )}
+
+            {renderConfig.fovCellSwitchControls && props.hasCellId && props.hasParentImage && (
+              <span className="viewer-toolbar-group">
+                <Radio.Group value={props.imageType} onChange={({ target }) => props.onSwitchFovCell(target.value)}>
+                  <Radio.Button value={ImageType.segmentedCell}>Single cell</Radio.Button>
+                  <Radio.Button value={ImageType.fullField}>Full field</Radio.Button>
+                </Radio.Group>
+              </span>
+            )}
+
             <span className="viewer-toolbar-group">
-              {renderConfig.viewModeRadioButtons && (
-                <ViewModeRadioButtons mode={props.mode} onViewModeChange={props.onViewModeChange} />
-              )}
-              {renderConfig.resetCameraButton && (
-                <Tooltip placement="bottom" title="Reset camera">
-                  <Button className="ant-btn-icon-only btn-borderless" onClick={props.onResetCamera}>
-                    <ViewerIcon type="resetView" />
-                  </Button>
-                </Tooltip>
-              )}
-              {renderConfig.autoRotateButton && (
-                <Tooltip placement="bottom" title={turntableToggleTitle}>
-                  <Button
-                    className={classForToggleBtn(autorotate && !twoDMode)}
-                    disabled={twoDMode || props.pathTraceOn}
-                    onClick={props.onAutorotateChange}
-                  >
-                    <ViewerIcon type="turnTable" />
-                  </Button>
-                </Tooltip>
-              )}
-            </span>
-          )}
-
-          {renderConfig.fovCellSwitchControls && props.hasCellId && props.hasParentImage && (
-            <span className="viewer-toolbar-group">
-              <Radio.Group value={props.imageType} onChange={({ target }) => props.onSwitchFovCell(target.value)}>
-                <Radio.Button value={ImageType.segmentedCell}>Single cell</Radio.Button>
-                <Radio.Button value={ImageType.fullField}>Full field</Radio.Button>
-              </Radio.Group>
-            </span>
-          )}
-
-          <span className="viewer-toolbar-group">
-            <Select
-              className="select-render-setting"
-              dropdownClassName="viewer-toolbar-dropdown"
-              value={props.renderSetting}
-              onChange={props.onChangeRenderingAlgorithm}
-            >
-              <Select.Option value={RenderMode.volumetric} key={RenderMode.volumetric}>
-                Volumetric
-              </Select.Option>
-              {props.canPathTrace && (
-                <Select.Option value={RenderMode.pathTrace} key={RenderMode.pathTrace} disabled={twoDMode}>
-                  Path trace
+              <Select
+                className="select-render-setting"
+                dropdownClassName="viewer-toolbar-dropdown"
+                value={props.renderSetting}
+                onChange={props.onChangeRenderingAlgorithm}
+              >
+                <Select.Option value={RenderMode.volumetric} key={RenderMode.volumetric}>
+                  Volumetric
                 </Select.Option>
-              )}
-              <Select.Option value={RenderMode.maxProject} key={RenderMode.maxProject}>
-                Max project
-              </Select.Option>
-            </Select>
+                {props.canPathTrace && (
+                  <Select.Option value={RenderMode.pathTrace} key={RenderMode.pathTrace} disabled={twoDMode}>
+                    Path trace
+                  </Select.Option>
+                )}
+                <Select.Option value={RenderMode.maxProject} key={RenderMode.maxProject}>
+                  Max project
+                </Select.Option>
+              </Select>
+            </span>
+
+            {renderGroup4 && (
+              <span className="viewer-toolbar-group">
+                {renderConfig.showAxesButton && (
+                  <Tooltip placement="bottom" title={axesToggleTitle}>
+                    <Button className={this.classForToggleBtn(showAxes)} onClick={this.toggleAxis}>
+                      <ViewerIcon type="axes" />
+                    </Button>
+                  </Tooltip>
+                )}
+                {renderConfig.showBoundingBoxButton && (
+                  <Tooltip placement="bottom" title={boundingBoxToggleTitle}>
+                    <Button className={this.classForToggleBtn(showBoundingBox)} onClick={this.toggleBoundingBox}>
+                      <ViewerIcon type="boundingBox" />
+                    </Button>
+                  </Tooltip>
+                )}
+              </span>
+            )}
           </span>
 
-          {renderGroup4 && (
-            <span className="viewer-toolbar-group">
-              {renderConfig.showAxesButton && (
-                <Tooltip placement="bottom" title={axesToggleTitle}>
-                  <Button className={classForToggleBtn(showAxes)} onClick={toggleAxis}>
-                    <ViewerIcon type="axes" />
-                  </Button>
-                </Tooltip>
-              )}
-              {renderConfig.showBoundingBoxButton && (
-                <Tooltip placement="bottom" title={boundingBoxToggleTitle}>
-                  <Button className={classForToggleBtn(showBoundingBox)} onClick={toggleBoundingBox}>
-                    <ViewerIcon type="boundingBox" />
-                  </Button>
-                </Tooltip>
-              )}
-            </span>
-          )}
-        </span>
-
-        <span className="viewer-toolbar-right viewer-toolbar-group" ref={rightRef}>
-          <Tooltip placement="bottom" title="Download">
-            <DownloadButton
-              cellDownloadHref={props.cellDownloadHref}
-              fovDownloadHref={props.fovDownloadHref}
-              hasFov={props.hasCellId && props.hasParentImage}
-            />
-          </Tooltip>
-          <Tooltip placement="bottom" title="Screenshot">
-            <Button icon="camera" className="btn-borderless" onClick={props.downloadScreenshot} />
-          </Tooltip>
-        </span>
+          <span className="viewer-toolbar-right viewer-toolbar-group" ref={this.rightRef}>
+            <Tooltip placement="bottom" title="Download">
+              <DownloadButton
+                cellDownloadHref={props.cellDownloadHref}
+                fovDownloadHref={props.fovDownloadHref}
+                hasFov={props.hasCellId && props.hasParentImage}
+              />
+            </Tooltip>
+            <Tooltip placement="bottom" title="Screenshot">
+              <Button icon="camera" className="btn-borderless" onClick={props.downloadScreenshot} />
+            </Tooltip>
+          </span>
+        </div>
+        <div
+          className="viewer-toolbar-scroll-right"
+          style={{ display: scrollBtnRight ? "flex" : "none" }}
+          onClick={() => this.scrollX(100)}
+        >
+          <ViewerIcon type="closePanel" style={{ fontSize: "12px" }} />
+        </div>
       </div>
-      <div className="viewer-toolbar-scroll-right" onClick={() => scrollX(100)}>
-        <ViewerIcon type="closePanel" style={{ fontSize: "12px" }} />
-      </div>
-    </div>
-  );
+    );
+  }
 }

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -108,7 +108,7 @@ export default function Toolbar(props: ToolbarProps): React.ReactElement {
 
   return (
     <div className={`viewer-toolbar-container${scrollMode ? " viewer-toolbar-scroll" : ""}`}>
-      <div className="viewer-toolbar-scroll-btn scroll-btn-left" onClick={() => scrollX(-100)}>
+      <div className="viewer-toolbar-scroll-left" onClick={() => scrollX(-100)}>
         <ViewerIcon type="closePanel" style={{ fontSize: "12px", transform: "rotate(180deg)" }} />
       </div>
       <div className="viewer-toolbar" ref={barRef} onWheel={scrollHandler}>
@@ -203,7 +203,7 @@ export default function Toolbar(props: ToolbarProps): React.ReactElement {
           </Tooltip>
         </span>
       </div>
-      <div className="viewer-toolbar-scroll-btn scroll-btn-right" onClick={() => scrollX(100)}>
+      <div className="viewer-toolbar-scroll-right" onClick={() => scrollX(100)}>
         <ViewerIcon type="closePanel" style={{ fontSize: "12px" }} />
       </div>
     </div>

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -1,11 +1,63 @@
 @import "../../assets/styles/variables";
 
-.viewer-toolbar {
+/* Provides background and buttons when toolbar is in scroll mode */
+.viewer-toolbar-container {
   position: absolute;
   width: 100%;
-  margin-top: 12px;
-  z-index: 1500;
-  padding: 0 12px;
+  z-index: 250;
+
+  .viewer-toolbar-scroll-btn {
+    height: 100%;
+    width: 15px;
+    justify-content: center;
+    align-items: center;
+    background-color: rgba(75, 75, 75, 0.85);
+    display: none;
+    position: absolute;
+    top: 0;
+    z-index: 255;
+    transition: color 0.3s;
+
+    &.scroll-btn-left {
+      left: 0;
+    }
+    &.scroll-btn-right {
+      right: 0;
+    }
+    &:hover {
+      color: white;
+    }
+  }
+
+  /* Toolbar scroll mode: collapse all sections to the left and scroll */
+  &.viewer-toolbar-scroll {
+    border-bottom: 1px solid $light-gray;
+
+    .viewer-toolbar-scroll-btn {
+      display: flex;
+    }
+
+    .viewer-toolbar {
+      display: static;
+      text-align: left;
+      white-space: nowrap;
+
+      overflow-x: scroll;
+      scrollbar-width: none;
+      &::-webkit-scrollbar {
+        display: none;
+      }
+
+      .viewer-toolbar-left,
+      .viewer-toolbar-right {
+        position: static;
+      }
+    }
+  }
+}
+
+.viewer-toolbar {
+  padding: 12px;
   text-align: center;
 
   .viewer-toolbar-left {
@@ -30,24 +82,6 @@
 
   .select-render-setting {
     min-width: 110px;
-  }
-
-  /* Toolbar scroll mode: collapse all sections to the left and scroll */
-  &.viewer-toolbar-scroll {
-    display: static;
-    text-align: left;
-    white-space: nowrap;
-
-    overflow-x: scroll;
-    scrollbar-width: none;
-    &::-webkit-scrollbar {
-      display: none;
-    }
-
-    .viewer-toolbar-left,
-    .viewer-toolbar-right {
-      position: static;
-    }
   }
 
   /* Icon-only buttons */

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -5,14 +5,18 @@
   width: 100%;
   margin-top: 12px;
   z-index: 1500;
-  display: flex;
-  justify-content: center;
-  text-align: center;
   padding: 0 12px;
 
   .viewer-toolbar-left {
     position: absolute;
     left: 12px;
+  }
+
+  .viewer-toolbar-center {
+    position: absolute;
+    left: 0;
+    right: 0;
+    text-align: center;
   }
 
   .viewer-toolbar-right {
@@ -30,6 +34,26 @@
 
   .select-render-setting {
     min-width: 110px;
+  }
+
+  /* Toolbar scroll mode: collapse all sections to the left and scroll */
+  &.viewer-toolbar-scroll {
+    display: static;
+    text-align: left;
+    white-space: nowrap;
+
+    overflow-x: scroll;
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    .viewer-toolbar-left,
+    .viewer-toolbar-center,
+    .viewer-toolbar-right {
+      position: static;
+      margin-left: 6px;
+    }
   }
 
   /* Icon-only buttons */

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -6,7 +6,9 @@
   width: 100%;
   z-index: 250;
 
-  .viewer-toolbar-scroll-btn {
+  /* Scroll buttons */
+  .viewer-toolbar-scroll-left,
+  .viewer-toolbar-scroll-right {
     height: 100%;
     width: 15px;
     justify-content: center;
@@ -17,23 +19,23 @@
     top: 0;
     z-index: 255;
     transition: color 0.3s;
-
-    &.scroll-btn-left {
-      left: 0;
-    }
-    &.scroll-btn-right {
-      right: 0;
-    }
     &:hover {
       color: white;
     }
+  }
+  .viewer-toolbar-scroll-left {
+    left: 0;
+  }
+  .viewer-toolbar-scroll-right {
+    right: 0;
   }
 
   /* Toolbar scroll mode: collapse all sections to the left and scroll */
   &.viewer-toolbar-scroll {
     border-bottom: 1px solid $light-gray;
 
-    .viewer-toolbar-scroll-btn {
+    .viewer-toolbar-scroll-left,
+    .viewer-toolbar-scroll-right {
       display: flex;
     }
 
@@ -48,40 +50,43 @@
         display: none;
       }
 
-      .viewer-toolbar-left,
+      .viewer-toolbar-left {
+        position: static;
+        margin-left: 15px;
+      }
       .viewer-toolbar-right {
         position: static;
+        margin-right: 15px;
       }
     }
   }
 }
 
+/* Alignment and spacing of groups of toolbar controls */
+
 .viewer-toolbar {
   padding: 12px;
   text-align: center;
 
-  .viewer-toolbar-left {
-    position: absolute;
-    padding: 0 12px;
-    left: 0;
-  }
-
+  .viewer-toolbar-left,
   .viewer-toolbar-right {
     position: absolute;
-    padding: 0 12px;
+    &:not(:empty) {
+      padding: 0 12px;
+    }
+  }
+  .viewer-toolbar-left {
+    left: 0;
+  }
+  .viewer-toolbar-right {
     right: 0;
   }
 
   .viewer-toolbar-group:not(:last-child) {
     margin-right: 14px;
   }
-
   .viewer-toolbar-group > :not(:last-child) {
     margin-right: 6px;
-  }
-
-  .select-render-setting {
-    min-width: 110px;
   }
 
   /* Icon-only buttons */
@@ -172,6 +177,10 @@
   }
 
   /* Dropdown */
+
+  .select-render-setting {
+    min-width: 110px;
+  }
 
   .ant-select-selection {
     border-color: $light-gray !important;

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -10,7 +10,7 @@
   .viewer-toolbar-scroll-left,
   .viewer-toolbar-scroll-right {
     height: 100%;
-    width: 15px;
+    width: 18px;
     justify-content: center;
     align-items: center;
     background-color: rgba(75, 75, 75, 0.85);
@@ -32,7 +32,7 @@
 
   /* Toolbar scroll mode: collapse all sections to the left and scroll */
   &.viewer-toolbar-scroll {
-    border-bottom: 1px solid $light-gray;
+    border-bottom: 1px solid $border-color;
 
     .viewer-toolbar-scroll-left,
     .viewer-toolbar-scroll-right {

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -37,7 +37,6 @@
     display: static;
     text-align: left;
     white-space: nowrap;
-    scroll-behavior: smooth;
 
     overflow-x: scroll;
     scrollbar-width: none;

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -6,22 +6,18 @@
   margin-top: 12px;
   z-index: 1500;
   padding: 0 12px;
+  text-align: center;
 
   .viewer-toolbar-left {
     position: absolute;
-    left: 12px;
-  }
-
-  .viewer-toolbar-center {
-    position: absolute;
+    padding: 0 12px;
     left: 0;
-    right: 0;
-    text-align: center;
   }
 
   .viewer-toolbar-right {
     position: absolute;
-    right: 12px;
+    padding: 0 12px;
+    right: 0;
   }
 
   .viewer-toolbar-group:not(:last-child) {
@@ -41,6 +37,7 @@
     display: static;
     text-align: left;
     white-space: nowrap;
+    scroll-behavior: smooth;
 
     overflow-x: scroll;
     scrollbar-width: none;
@@ -49,10 +46,8 @@
     }
 
     .viewer-toolbar-left,
-    .viewer-toolbar-center,
     .viewer-toolbar-right {
       position: static;
-      margin-left: 6px;
     }
   }
 

--- a/src/aics-image-viewer/components/shared/ViewerIcon.tsx
+++ b/src/aics-image-viewer/components/shared/ViewerIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { CSSProperties } from "react";
 import { Icon } from "antd";
 
 import ICONS from "../../assets/icons";
@@ -6,6 +6,8 @@ import ICONS from "../../assets/icons";
 const STYLE = { fontSize: "19px" };
 
 /** Wrapper component for easy inclusion of our own custom icons. */
-const ViewerIcon: React.FC<{ type: keyof typeof ICONS }> = ({ type }) => <Icon component={ICONS[type]} style={STYLE} />;
+const ViewerIcon: React.FC<{ type: keyof typeof ICONS; style?: Partial<CSSProperties> }> = ({ type, style }) => (
+  <Icon component={ICONS[type]} style={{ ...STYLE, ...style }} />
+);
 
 export default ViewerIcon;


### PR DESCRIPTION
Resolve #105: when centered toolbar controls would otherwise overlap with left- or right-aligned controls, collapse all controls into a single left-aligned block and enter "scrolling mode."

In scrolling mode:
- Left/right scroll buttons will appear if controls are hidden off either edge of the screen. These can be clicked to access those controls, and will disappear when scrolled all the way to one side. A border appears below the toolbar to anchor these buttons, per specification (see linked issue).
- Users may also scroll up/down with the mouse wheel to access controls clipped off the side of the screen.
- The toolbar will scroll to show focused controls for users navigating with keyboard (in all the browsers I tested).

With the addition of state to `Toolbar`, along with the necessity to reference that state in a global event handler (window resize), I refactored `Toolbar` to a class component for clarity.

Screenshots:
![image](https://user-images.githubusercontent.com/53030214/207984527-fc614605-ae4d-44e9-86e7-c935fdc54967.png)
![image](https://user-images.githubusercontent.com/53030214/207984588-138d9ec1-f05d-437a-b38a-c9e73b004de8.png)
