### PR TITLE
Fix/update volume loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@aics/volume-viewer": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-2.7.0.tgz",
-      "integrity": "sha512-/cIDQ8zy3cfEF+A2YdhbPbP6rSUF0MEnDfOyvq7zjU8BpexaQILHXo9XenYdRRnD0at10QBpSJYjRXgC5sdGmg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.0.0.tgz",
+      "integrity": "sha512-BPvGkpRt/qDrB8wZEbgjZVGGiOTMte1w2sETqfjV+dwf4zv0UfHknyrDNF8tOoLd+4xRpXq1wxgOnrbqBkzpaw==",
       "requires": {
         "geotiff": "^2.0.5",
         "three": "^0.144.0",
@@ -3102,9 +3102,9 @@
       }
     },
     "@petamoriken/float16": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.6.6.tgz",
-      "integrity": "sha512-3MUulwMtsdCA9lw8a/Kc0XDBJJVCkYTQ5aGd+///TbfkOMXoOGAzzoiYKwPEsLYZv7He7fKJ/mCacqKOO7REyg=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.7.1.tgz",
+      "integrity": "sha512-oXZOc+aePd0FnhTWk15pyqK+Do87n0TyLV1nxdEougE95X/WXWDqmQobfhgnSY7QsWn5euZUWuDVeTQvoQ5VNw=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/volume-viewer": "^2.7.0",
+    "@aics/volume-viewer": "^3.0.0",
     "color-string": "^1.5.3",
     "d3": "^4.11.0",
     "lodash": "^4.17.20",


### PR DESCRIPTION
Update volume-viewer to 3.0.0 and use its new volume loading API, which removes the single `VolumeLoader` class in favor of specialized per-format loader classes which implement a common interface.