### PR TITLE
Fix/move axis and scale indicators with clipping drawer

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -237,7 +237,8 @@ export default class App extends React.Component<AppProps, AppState> {
     this.updateStateOnLoadImage = this.updateStateOnLoadImage.bind(this);
     this.initializeNewImage = this.initializeNewImage.bind(this);
     this.onView3DCreated = this.onView3DCreated.bind(this);
-    this.onClippingPanelOpen = this.onClippingPanelOpen.bind(this);
+    this.onClippingPanelVisibleChange = this.onClippingPanelVisibleChange.bind(this);
+    this.onClippingPanelVisibleChangeEnd = this.onClippingPanelVisibleChangeEnd.bind(this);
     this.createChannelGrouping = this.createChannelGrouping.bind(this);
     this.beginRequestImage = this.beginRequestImage.bind(this);
     this.loadNextImage = this.loadNextImage.bind(this);
@@ -1043,9 +1044,8 @@ export default class App extends React.Component<AppProps, AppState> {
     this.state.view3d?.resetCamera();
   }
 
-  onClippingPanelOpen(open: boolean): void {
+  onClippingPanelVisibleChange(open: boolean): void {
     const CLIPPING_PANEL_HEIGHT = 130;
-    const CLIPPING_PANEL_OPEN_TIME = 300;
 
     const { view3d, userSelections } = this.state;
     if (view3d) {
@@ -1063,13 +1063,16 @@ export default class App extends React.Component<AppProps, AppState> {
       if (userSelections.showAxes) {
         view3d.setShowAxis(false);
       }
+    }
+  }
 
-      window.setTimeout(() => {
-        view3d.setShowScaleBar(true);
-        if (userSelections.showAxes) {
-          view3d.setShowAxis(true);
-        }
-      }, CLIPPING_PANEL_OPEN_TIME);
+  onClippingPanelVisibleChangeEnd(_open: boolean): void {
+    const { view3d, userSelections } = this.state;
+    if (view3d) {
+      view3d.setShowScaleBar(true);
+      if (userSelections.showAxes) {
+        view3d.setShowAxis(true);
+      }
     }
   }
 
@@ -1245,7 +1248,8 @@ export default class App extends React.Component<AppProps, AppState> {
               onView3DCreated={this.onView3DCreated}
               appHeight={this.props.appHeight}
               renderConfig={renderConfig}
-              onClippingPanelOpen={this.onClippingPanelOpen}
+              onClippingPanelVisibleChange={this.onClippingPanelVisibleChange}
+              onClippingPanelVisibleChangeEnd={this.onClippingPanelVisibleChangeEnd}
             />
           </Content>
         </Layout>

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -1044,13 +1044,14 @@ export default class App extends React.Component<AppProps, AppState> {
   }
 
   onClippingPanelOpen(open: boolean): void {
+    const CLIPPING_PANEL_HEIGHT = 130;
     const { view3d, userSelections } = this.state;
     if (view3d) {
       let axisY = AXIS_MARGIN_DEFAULT[1];
       let scaleBarY = SCALE_BAR_MARGIN_DEFAULT[1];
       if (open) {
-        axisY += 130;
-        scaleBarY += 130;
+        axisY += CLIPPING_PANEL_HEIGHT;
+        scaleBarY += CLIPPING_PANEL_HEIGHT;
       }
       view3d.setAxisPosition(AXIS_MARGIN_DEFAULT[0], axisY);
       view3d.setScaleBarPosition(SCALE_BAR_MARGIN_DEFAULT[0], scaleBarY);

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -37,6 +37,8 @@ import {
   SINGLE_GROUP_CHANNEL_KEY,
   CONTROL_PANEL_CLOSE_WIDTH,
   INTERPOLATION_ENABLED_DEFAULT,
+  AXIS_MARGIN_DEFAULT,
+  SCALE_BAR_MARGIN_DEFAULT,
 } from "../../shared/constants";
 
 import ControlPanel from "../ControlPanel";
@@ -231,6 +233,7 @@ export default class App extends React.Component<AppProps, AppState> {
     this.updateStateOnLoadImage = this.updateStateOnLoadImage.bind(this);
     this.initializeNewImage = this.initializeNewImage.bind(this);
     this.onView3DCreated = this.onView3DCreated.bind(this);
+    this.onClippingPanelOpen = this.onClippingPanelOpen.bind(this);
     this.createChannelGrouping = this.createChannelGrouping.bind(this);
     this.beginRequestImage = this.beginRequestImage.bind(this);
     this.loadNextImage = this.loadNextImage.bind(this);
@@ -303,6 +306,8 @@ export default class App extends React.Component<AppProps, AppState> {
     const { userSelections } = this.state;
     view3d.setBackgroundColor(colorArrayToFloats(userSelections.backgroundColor));
     view3d.setShowAxis(userSelections.showAxes);
+    view3d.setAxisPosition(...AXIS_MARGIN_DEFAULT);
+    view3d.setScaleBarPosition(...SCALE_BAR_MARGIN_DEFAULT);
 
     this.setState({ view3d });
   }
@@ -1038,8 +1043,32 @@ export default class App extends React.Component<AppProps, AppState> {
   changeBoundingBoxShowing = (showing: boolean): void => this.changeUserSelection("showBoundingBox", showing);
 
   onResetCamera(): void {
-    if (this.state.view3d) {
-      this.state.view3d.resetCamera();
+    this.state.view3d?.resetCamera();
+  }
+
+  onClippingPanelOpen(open: boolean): void {
+    const { view3d, userSelections } = this.state;
+    if (view3d) {
+      let axisY = AXIS_MARGIN_DEFAULT[1];
+      let scaleBarY = SCALE_BAR_MARGIN_DEFAULT[1];
+      if (open) {
+        axisY += 130;
+        scaleBarY += 130;
+      }
+      view3d.setAxisPosition(AXIS_MARGIN_DEFAULT[0], axisY);
+      view3d.setScaleBarPosition(SCALE_BAR_MARGIN_DEFAULT[0], scaleBarY);
+
+      view3d.setShowScaleBar(false);
+      if (userSelections.showAxes) {
+        view3d.setShowAxis(false);
+      }
+
+      window.setTimeout(() => {
+        view3d.setShowScaleBar(true);
+        if (userSelections.showAxes) {
+          view3d.setShowAxis(true);
+        }
+      }, 300);
     }
   }
 
@@ -1215,6 +1244,7 @@ export default class App extends React.Component<AppProps, AppState> {
               onView3DCreated={this.onView3DCreated}
               appHeight={this.props.appHeight}
               renderConfig={renderConfig}
+              onClippingPanelOpen={this.onClippingPanelOpen}
             />
           </Content>
         </Layout>

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -1045,6 +1045,8 @@ export default class App extends React.Component<AppProps, AppState> {
 
   onClippingPanelOpen(open: boolean): void {
     const CLIPPING_PANEL_HEIGHT = 130;
+    const CLIPPING_PANEL_OPEN_TIME = 300;
+
     const { view3d, userSelections } = this.state;
     if (view3d) {
       let axisY = AXIS_MARGIN_DEFAULT[1];
@@ -1056,6 +1058,7 @@ export default class App extends React.Component<AppProps, AppState> {
       view3d.setAxisPosition(AXIS_MARGIN_DEFAULT[0], axisY);
       view3d.setScaleBarPosition(SCALE_BAR_MARGIN_DEFAULT[0], scaleBarY);
 
+      // Hide indicators while clipping panel is in motion - otherwise they pop to the right place prematurely
       view3d.setShowScaleBar(false);
       if (userSelections.showAxes) {
         view3d.setShowAxis(false);
@@ -1066,7 +1069,7 @@ export default class App extends React.Component<AppProps, AppState> {
         if (userSelections.showAxes) {
           view3d.setShowAxis(true);
         }
-      }, 300);
+      }, CLIPPING_PANEL_OPEN_TIME);
     }
   }
 

--- a/src/aics-image-viewer/components/BottomPanel/index.tsx
+++ b/src/aics-image-viewer/components/BottomPanel/index.tsx
@@ -6,15 +6,16 @@ import "./styles.css";
 
 type BottomPanelProps = {
   title?: string;
-  onVisibilityChange?: (visible: boolean) => void;
+  onVisibleChange?: (visible: boolean) => void;
+  onVisibleChangeEnd?: (visible: boolean) => void;
 };
 
-const BottomPanel: React.FC<BottomPanelProps> = ({ children, title, onVisibilityChange }) => {
+const BottomPanel: React.FC<BottomPanelProps> = ({ children, title, onVisibleChange, onVisibleChangeEnd }) => {
   const [isVisible, setIsVisible] = useState(false);
   const toggleDrawer = (): void => {
     setIsVisible(!isVisible);
-    if (onVisibilityChange) {
-      onVisibilityChange(!isVisible);
+    if (onVisibleChange) {
+      onVisibleChange(!isVisible);
     }
   };
 
@@ -35,6 +36,7 @@ const BottomPanel: React.FC<BottomPanelProps> = ({ children, title, onVisibility
         visible={isVisible}
         mask={false}
         title={optionsButton}
+        afterVisibleChange={onVisibleChangeEnd}
       >
         <div className="drawer-body-wrapper">{children}</div>
       </Drawer>

--- a/src/aics-image-viewer/components/BottomPanel/index.tsx
+++ b/src/aics-image-viewer/components/BottomPanel/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
-import { Drawer, Button, Icon } from "antd";
+import { Drawer, Button } from "antd";
 
+import ViewerIcon from "../shared/ViewerIcon";
 import "./styles.css";
 
 type BottomPanelProps = {
@@ -20,7 +21,7 @@ const BottomPanel: React.FC<BottomPanelProps> = ({ children, title, onVisibility
   const optionsButton = (
     <Button className="options-button" size="small" onClick={toggleDrawer}>
       {title || "Options"}
-      <Icon type="double-left" className="button-arrow" />
+      <ViewerIcon type="closePanel" className="button-arrow" style={{ fontSize: "15px" }} />
     </Button>
   );
 

--- a/src/aics-image-viewer/components/BottomPanel/index.tsx
+++ b/src/aics-image-viewer/components/BottomPanel/index.tsx
@@ -3,9 +3,19 @@ import { Drawer, Button, Icon } from "antd";
 
 import "./styles.css";
 
-export function BottomPanel({ title, children }: React.PropsWithChildren<{ title?: string }>): React.ReactElement {
+type BottomPanelProps = {
+  title?: string;
+  onVisibilityChange?: (visible: boolean) => void;
+};
+
+const BottomPanel: React.FC<BottomPanelProps> = ({ children, title, onVisibilityChange }) => {
   const [isVisible, setIsVisible] = useState(false);
-  const toggleDrawer = (): void => setIsVisible(!isVisible);
+  const toggleDrawer = (): void => {
+    setIsVisible(!isVisible);
+    if (onVisibilityChange) {
+      onVisibilityChange(!isVisible);
+    }
+  };
 
   const optionsButton = (
     <Button className="options-button" size="small" onClick={toggleDrawer}>
@@ -29,4 +39,6 @@ export function BottomPanel({ title, children }: React.PropsWithChildren<{ title
       </Drawer>
     </div>
   );
-}
+};
+
+export default BottomPanel;

--- a/src/aics-image-viewer/components/BottomPanel/styles.css
+++ b/src/aics-image-viewer/components/BottomPanel/styles.css
@@ -60,7 +60,7 @@
   }
 
   .button-arrow {
-    transform: rotate(90deg);
+    transform: rotate(270deg);
     transition: transform 0.2s linear !important;
   }
 
@@ -85,7 +85,7 @@
     }
 
     .button-arrow {
-      transform: rotate(-90deg);
+      transform: rotate(90deg);
     }
   }
 }

--- a/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
+++ b/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
@@ -25,8 +25,9 @@ interface ViewerWrapperProps {
     axisClipSliders: boolean;
   };
   onView3DCreated: (view3d: View3d) => void;
-  onClippingPanelOpen?: (open: boolean) => void;
   setAxisClip: (axis: AxisName, minval: number, maxval: number, isOrthoAxis: boolean) => void;
+  onClippingPanelVisibleChange?: (open: boolean) => void;
+  onClippingPanelVisibleChangeEnd?: (open: boolean) => void;
 }
 
 interface ViewerWrapperState {}
@@ -78,11 +79,15 @@ export default class ViewerWrapper extends React.Component<ViewerWrapperProps, V
   }
 
   render(): React.ReactNode {
-    const { appHeight, renderConfig, image, numSlices, mode, setAxisClip, onClippingPanelOpen } = this.props;
+    const { appHeight, renderConfig, image, numSlices, mode, setAxisClip } = this.props;
     return (
       <div className="cell-canvas" style={{ ...STYLES.viewer, height: appHeight }}>
         <div ref={this.view3dviewerRef} style={STYLES.view3d}></div>
-        <BottomPanel title="Clipping" onVisibilityChange={onClippingPanelOpen}>
+        <BottomPanel
+          title="Clipping"
+          onVisibleChange={this.props.onClippingPanelVisibleChange}
+          onVisibleChangeEnd={this.props.onClippingPanelVisibleChangeEnd}
+        >
           {renderConfig.axisClipSliders && !!image && (
             <AxisClipSliders mode={mode} setAxisClip={setAxisClip} numSlices={numSlices} />
           )}

--- a/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
+++ b/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
@@ -7,7 +7,7 @@ import { AxisName, Styles } from "../../shared/types";
 import { ViewMode } from "../../shared/enums";
 
 import AxisClipSliders from "../AxisClipSliders";
-import { BottomPanel } from "../BottomPanel";
+import BottomPanel from "../BottomPanel";
 import "./styles.css";
 
 interface ViewerWrapperProps {
@@ -25,6 +25,7 @@ interface ViewerWrapperProps {
     axisClipSliders: boolean;
   };
   onView3DCreated: (view3d: View3d) => void;
+  onClippingPanelOpen?: (open: boolean) => void;
   setAxisClip: (axis: AxisName, minval: number, maxval: number, isOrthoAxis: boolean) => void;
 }
 
@@ -77,11 +78,11 @@ export default class ViewerWrapper extends React.Component<ViewerWrapperProps, V
   }
 
   render(): React.ReactNode {
-    const { appHeight, renderConfig, image, numSlices, mode, setAxisClip } = this.props;
+    const { appHeight, renderConfig, image, numSlices, mode, setAxisClip, onClippingPanelOpen } = this.props;
     return (
       <div className="cell-canvas" style={{ ...STYLES.viewer, height: appHeight }}>
         <div ref={this.view3dviewerRef} style={STYLES.view3d}></div>
-        <BottomPanel title="Clipping">
+        <BottomPanel title="Clipping" onVisibilityChange={onClippingPanelOpen}>
           {renderConfig.axisClipSliders && !!image && (
             <AxisClipSliders mode={mode} setAxisClip={setAxisClip} numSlices={numSlices} />
           )}

--- a/src/aics-image-viewer/components/shared/ViewerIcon.tsx
+++ b/src/aics-image-viewer/components/shared/ViewerIcon.tsx
@@ -1,13 +1,14 @@
-import React, { CSSProperties } from "react";
+import React from "react";
 import { Icon } from "antd";
+import { IconProps } from "antd/lib/icon";
 
 import ICONS from "../../assets/icons";
 
 const STYLE = { fontSize: "19px" };
 
 /** Wrapper component for easy inclusion of our own custom icons. */
-const ViewerIcon: React.FC<{ type: keyof typeof ICONS; style?: Partial<CSSProperties> }> = ({ type, style }) => (
-  <Icon component={ICONS[type]} style={{ ...STYLE, ...style }} />
+const ViewerIcon: React.FC<{ type: keyof typeof ICONS } & Omit<IconProps, "type" | "component">> = (props) => (
+  <Icon component={ICONS[props.type]} {...{ ...props, style: { ...STYLE, ...props.style } }} />
 );
 
 export default ViewerIcon;

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -5,6 +5,8 @@ export const // Control panel will automatically close if viewport is less than 
   CONTROL_PANEL_CLOSE_WIDTH = 970,
   BACKGROUND_COLOR_DEFAULT: ColorArray = [0, 0, 0],
   BOUNDING_BOX_COLOR_DEFAULT: ColorArray = [255, 255, 255],
+  AXIS_MARGIN_DEFAULT: [number, number] = [16, 16],
+  SCALE_BAR_MARGIN_DEFAULT: [number, number] = [120, 12],
   // These settings were chosen to work well with most AICS microscopy pipeline images.
   // These numbers mean: remap the bottom LUT_MIN_PERCENTILE fraction of pixels to zero intensity,
   // and linearly increase intensity up to the LUT_MAX_PERCENTILE fraction of pixels.


### PR DESCRIPTION
## Problem

#73: the clipping panel covers the axis indicator when open.

The introduction of scale bars, which appear in the bottom-right corner of the viewport by default, creates a similar but worse problem: not only are scale bars covered by the open clipping panel, they are also covered by the button to open the clipping panel when the panel is closed.

## Solution

Use `View3d`'s new methods `setAxisPosition` and `setScaleBarPosition` to move the indicators out of the way. This requires adding a new prop `onVisibilityChange` to the `BottomPanel` component so that this state can be passed up. This resolves #73, though per comments on that issue it may be worth opening another ticket to investigate other related changes that can be made to the UI.

Additionally, the bottom panel button uses an icon from antd that's nearly identical to one of our own custom icons, so I replaced it with the custom icon, and upgraded the ergonomics of the `ViewerIcon` utility component along the way. (See comment on #102 for why we should prefer our own icons.)

## Screenshots
![image](https://user-images.githubusercontent.com/53030214/214731981-0fa1c936-57e3-44d6-8b70-48fd8ac584c4.png)
![image](https://user-images.githubusercontent.com/53030214/214732081-b67966dd-4255-4fcd-a22b-9e514be71e60.png)
![image](https://user-images.githubusercontent.com/53030214/214732366-143c94f2-e173-44c8-9fe1-9d167b40e588.png)

