### PR TITLE
Feature/metadata viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@aics/volume-viewer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.0.0.tgz",
-      "integrity": "sha512-BPvGkpRt/qDrB8wZEbgjZVGGiOTMte1w2sETqfjV+dwf4zv0UfHknyrDNF8tOoLd+4xRpXq1wxgOnrbqBkzpaw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.1.0.tgz",
+      "integrity": "sha512-FrYctw+QXsidbXPWtsm1UuQlhfvvhhhwH825kfSZe2xdZQIHPn+ae6qg94E4kVaAyixwJ4zelG1gdPkBo1WbhQ==",
       "requires": {
         "geotiff": "^2.0.5",
         "three": "^0.144.0",
@@ -12785,9 +12785,9 @@
       "dev": true
     },
     "p-queue": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
-      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.4.tgz",
+      "integrity": "sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==",
       "requires": {
         "eventemitter3": "^4.0.7",
         "p-timeout": "^5.0.2"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/volume-viewer": "^3.0.0",
+    "@aics/volume-viewer": "^3.1.0",
     "color-string": "^1.5.3",
     "d3": "^4.11.0",
     "lodash": "^4.17.20",

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -264,6 +264,7 @@ function runApp() {
       cellDownloadHref={args.cellDownloadHref}
       viewerConfig={viewerConfig}
       viewerChannelSettings={args.initialChannelSettings}
+      metadataConfig={["dimensions", "pixelPhysicalSize", "physicalDimensions", "channels", "userData"]}
     />,
     document.getElementById("cell-viewer")
   );

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -264,7 +264,6 @@ function runApp() {
       cellDownloadHref={args.cellDownloadHref}
       viewerConfig={viewerConfig}
       viewerChannelSettings={args.initialChannelSettings}
-      metadataConfig={["dimensions", "pixelPhysicalSize", "physicalDimensions", "channels", "userData"]}
     />,
     document.getElementById("cell-viewer")
   );

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -1188,27 +1188,25 @@ export default class App extends React.Component<AppProps, AppState> {
     },
     channels: (image) => ({ Channels: image.num_channels }),
     timeSeriesFrames: (_image) => ({ "Time series frames": 1 }), // TODO
-    userData: (image) => {
-      const { userData } = image.imageInfo;
-      return userData ? { "User data": userData as MetadataRecord } : {};
-    },
+    userData: (image) => image.imageInfo.userData as MetadataRecord,
   };
 
   getMetadata(): MetadataRecord {
-    let customMetadata = {};
     const { metadata, metadataConfig } = this.props;
     const { image } = this.state;
 
-    if (image && metadataConfig) {
+    let customMetadata = {};
+    if (image && metadataConfig && metadataConfig.length > 0) {
       metadataConfig.forEach((category) => {
         if (category in this.metadataSelectors) {
           const newMetadata = this.metadataSelectors[category](image);
           customMetadata = { ...customMetadata, ...newMetadata };
         }
       });
+      return { Image: customMetadata, ...metadata };
+    } else {
+      return metadata || {};
     }
-
-    return { Image: customMetadata, ...metadata };
   }
 
   render(): React.ReactNode {

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -1,7 +1,7 @@
 // 3rd Party Imports
 import { Layout } from "antd";
 import React from "react";
-import { includes, isEqual, find, map, debounce } from "lodash";
+import { includes, isEqual, find, map, debounce, mapValues } from "lodash";
 import {
   ControlPoint,
   IVolumeLoader,
@@ -25,7 +25,7 @@ import {
   ChannelStateChangeHandlers,
   ChannelGrouping,
 } from "../../shared/utils/viewerChannelSettings";
-import { AxisName, IsosurfaceFormat, MetadataFormatRecord, MetadataRecord } from "../../shared/types";
+import { AxisName, IsosurfaceFormat, MetadataRecord } from "../../shared/types";
 import { ImageType, RenderMode, ViewMode } from "../../shared/enums";
 import {
   PRESET_COLORS_0,
@@ -1161,15 +1161,11 @@ export default class App extends React.Component<AppProps, AppState> {
     return { x: 0, y: 0, z: 0 };
   }
 
-  getExtraMetadata(): { metadata: MetadataRecord; metadataFormat: MetadataFormatRecord } {
+  getExtraMetadata(): MetadataRecord {
     if (!this.props.renderConfig.dimensionsInMetadataViewer) {
-      return { metadata: {}, metadataFormat: {} };
+      return {};
     }
-    const dimensionFormat = { unit: "px" };
-    return {
-      metadata: { Dimensions: this.getNumberOfSlices() },
-      metadataFormat: { x: dimensionFormat, y: dimensionFormat, z: dimensionFormat },
-    };
+    return { Dimensions: mapValues(this.getNumberOfSlices(), (num) => num + "px") };
   }
 
   render(): React.ReactNode {
@@ -1191,7 +1187,6 @@ export default class App extends React.Component<AppProps, AppState> {
             renderConfig={renderConfig}
             metadata={this.props.metadata}
             getExtraMetadata={() => this.getExtraMetadata()}
-            metadataFormat={this.props.metadataFormat}
             // image state
             imageName={this.state.image?.name}
             hasImage={!!this.state.image}

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -1,7 +1,7 @@
 // 3rd Party Imports
 import { Layout } from "antd";
 import React from "react";
-import { includes, isEqual, find, map, debounce, mapValues } from "lodash";
+import { includes, isEqual, find, map, debounce } from "lodash";
 import {
   ControlPoint,
   IVolumeLoader,
@@ -1208,7 +1208,7 @@ export default class App extends React.Component<AppProps, AppState> {
       });
     }
 
-    return { ...customMetadata, ...metadata };
+    return { Image: customMetadata, ...metadata };
   }
 
   render(): React.ReactNode {

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -97,6 +97,7 @@ const defaultProps: AppProps = {
     resetCameraButton: true,
     showAxesButton: true,
     showBoundingBoxButton: true,
+    metadataViewer: false,
   },
   viewerConfig: {
     showAxes: false,

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -1177,8 +1177,8 @@ export default class App extends React.Component<AppProps, AppState> {
       return { "Original dimensions": { x: width + "px", y: height + "px", z: tiles + "px" } };
     },
     physicalDimensions: (image) => {
-      const { physicalScale, physicalUnitSymbol } = image;
-      const [x, y, z] = image.normalizedPhysicalSize.toArray().map((dim) => dim * physicalScale + physicalUnitSymbol);
+      const { physicalScale, physicalUnitSymbol, normalizedPhysicalSize } = image;
+      const [x, y, z] = normalizedPhysicalSize.toArray().map((dim) => dim * physicalScale + physicalUnitSymbol);
       return { "Physical size": { x, y, z } };
     },
     pixelPhysicalSize: (image) => {

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -21,7 +21,7 @@ import {
   ChannelStateChangeHandlers,
   ChannelGrouping,
 } from "../../shared/utils/viewerChannelSettings";
-import { AxisName, IsosurfaceFormat } from "../../shared/types";
+import { AxisName, IsosurfaceFormat, MetadataFormatRecord, MetadataRecord } from "../../shared/types";
 import { ImageType, RenderMode, ViewMode } from "../../shared/enums";
 import {
   PRESET_COLORS_0,
@@ -98,6 +98,7 @@ const defaultProps: AppProps = {
     showAxesButton: true,
     showBoundingBoxButton: true,
     metadataViewer: true,
+    dimensionsInMetadataViewer: true,
   },
   viewerConfig: {
     showAxes: false,
@@ -1114,6 +1115,17 @@ export default class App extends React.Component<AppProps, AppState> {
     return { x: 0, y: 0, z: 0 };
   }
 
+  getExtraMetadata(): { metadata: MetadataRecord; metadataFormat: MetadataFormatRecord } {
+    if (!this.props.renderConfig.dimensionsInMetadataViewer) {
+      return { metadata: {}, metadataFormat: {} };
+    }
+    const dimensionFormat = { unit: "px" };
+    return {
+      metadata: { Dimensions: this.getNumberOfSlices() },
+      metadataFormat: { x: dimensionFormat, y: dimensionFormat, z: dimensionFormat },
+    };
+  }
+
   render(): React.ReactNode {
     const { renderConfig, cellDownloadHref, fovDownloadHref, viewerChannelSettings } = this.props;
     const { userSelections } = this.state;
@@ -1132,6 +1144,7 @@ export default class App extends React.Component<AppProps, AppState> {
           <ControlPanel
             renderConfig={renderConfig}
             metadata={this.props.metadata}
+            getExtraMetadata={() => this.getExtraMetadata()}
             metadataFormat={this.props.metadataFormat}
             // image state
             imageName={this.state.image?.name}

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -1185,7 +1185,7 @@ export default class App extends React.Component<AppProps, AppState> {
         >
           <ControlPanel
             renderConfig={renderConfig}
-            metadata={this.props.metadata}
+            metadata={this.props.metadata || {}}
             getExtraMetadata={() => this.getExtraMetadata()}
             // image state
             imageName={this.state.image?.name}

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -15,14 +15,7 @@ import {
   Volume,
 } from "@aics/volume-viewer";
 
-import {
-  AppProps,
-  AppState,
-  MetadataSelectors,
-  UserSelectionChangeHandlers,
-  UserSelectionKey,
-  UserSelectionState,
-} from "./types";
+import { AppProps, AppState, UserSelectionChangeHandlers, UserSelectionKey, UserSelectionState } from "./types";
 import { controlPointsToLut } from "../../shared/utils/controlPointsToLut";
 import {
   ChannelState,
@@ -1167,43 +1160,17 @@ export default class App extends React.Component<AppProps, AppState> {
     return { x: 0, y: 0, z: 0 };
   }
 
-  private metadataSelectors: MetadataSelectors = {
-    dimensions: (image) => {
-      const { x, y, z } = image;
-      return { Dimensions: { x: x + "px", y: y + "px", z: z + "px" } };
-    },
-    originalDimensions: (image) => {
-      const { width, height, tiles } = image.imageInfo;
-      return { "Original dimensions": { x: width + "px", y: height + "px", z: tiles + "px" } };
-    },
-    physicalDimensions: (image) => {
-      const { physicalScale, physicalUnitSymbol, normalizedPhysicalSize } = image;
-      const [x, y, z] = normalizedPhysicalSize.toArray().map((dim: number) => dim * physicalScale + physicalUnitSymbol);
-      return { "Physical size": { x, y, z } };
-    },
-    pixelPhysicalSize: (image) => {
-      const { pixel_size, physicalUnitSymbol } = image;
-      const [x, y, z] = pixel_size.map((dim) => dim + physicalUnitSymbol);
-      return { "Physical size per pixel": { x, y, z } };
-    },
-    channels: (image) => ({ Channels: image.num_channels }),
-    timeSeriesFrames: (_image) => ({ "Time series frames": 1 }), // TODO
-    userData: (image) => image.imageInfo.userData as MetadataRecord,
-  };
-
   getMetadata(): MetadataRecord {
-    const { metadata, metadataConfig } = this.props;
+    const { metadata, metadataFormatter } = this.props;
     const { image } = this.state;
 
-    let customMetadata = {};
-    if (image && metadataConfig && metadataConfig.length > 0) {
-      metadataConfig.forEach((category) => {
-        if (category in this.metadataSelectors) {
-          const newMetadata = this.metadataSelectors[category](image);
-          customMetadata = { ...customMetadata, ...newMetadata };
-        }
-      });
-      return { Image: customMetadata, ...metadata };
+    let imageMetadata = image?.imageMetadata as MetadataRecord;
+    if (imageMetadata && metadataFormatter) {
+      imageMetadata = metadataFormatter(imageMetadata);
+    }
+
+    if (imageMetadata && Object.keys(imageMetadata).length > 0) {
+      return { Image: imageMetadata, ...metadata };
     } else {
       return metadata || {};
     }

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -97,7 +97,7 @@ const defaultProps: AppProps = {
     resetCameraButton: true,
     showAxesButton: true,
     showBoundingBoxButton: true,
-    metadataViewer: false,
+    metadataViewer: true,
   },
   viewerConfig: {
     showAxes: false,
@@ -1131,6 +1131,7 @@ export default class App extends React.Component<AppProps, AppState> {
         >
           <ControlPanel
             renderConfig={renderConfig}
+            metadata={this.props.metadata}
             // image state
             imageName={this.state.image?.name}
             hasImage={!!this.state.image}

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -1132,6 +1132,7 @@ export default class App extends React.Component<AppProps, AppState> {
           <ControlPanel
             renderConfig={renderConfig}
             metadata={this.props.metadata}
+            metadataFormat={this.props.metadataFormat}
             // image state
             imageName={this.state.image?.name}
             hasImage={!!this.state.image}

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -1178,7 +1178,7 @@ export default class App extends React.Component<AppProps, AppState> {
     },
     physicalDimensions: (image) => {
       const { physicalScale, physicalUnitSymbol, normalizedPhysicalSize } = image;
-      const [x, y, z] = normalizedPhysicalSize.toArray().map((dim) => dim * physicalScale + physicalUnitSymbol);
+      const [x, y, z] = normalizedPhysicalSize.toArray().map((dim: number) => dim * physicalScale + physicalUnitSymbol);
       return { "Physical size": { x, y, z } };
     },
     pixelPhysicalSize: (image) => {

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -35,6 +35,7 @@ export interface AppProps {
     showAxesButton: boolean;
     showBoundingBoxButton: boolean;
     metadataViewer: boolean;
+    dimensionsInMetadataViewer: boolean;
   };
   viewerConfig: {
     showAxes: boolean;

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -4,6 +4,17 @@ import { MetadataRecord } from "../../shared/types";
 import { ColorArray } from "../../shared/utils/colorRepresentations";
 import { ChannelGrouping, ChannelState, ViewerChannelSettings } from "../../shared/utils/viewerChannelSettings";
 
+export type MetadataCategory =
+  | "dimensions"
+  | "originalDimensions"
+  | "physicalDimensions"
+  | "pixelPhysicalSize"
+  | "channels"
+  | "timeSeriesFrames"
+  | "userData";
+
+export type MetadataSelectors = { [C in MetadataCategory]: (image: Volume) => MetadataRecord };
+
 export interface AppProps {
   // rawData has a "dtype" which is expected to be "uint8", a "shape":[c,z,y,x] and a "buffer" which is a DataView
   rawData?: { dtype: "uint8"; shape: [number, number, number, number]; buffer: DataView };
@@ -17,7 +28,6 @@ export interface AppProps {
   cellId: string;
   cellPath: string;
   fovPath: string;
-  metadata?: MetadataRecord;
   renderConfig: {
     alphaMask: boolean;
     autoRotateButton: boolean;
@@ -35,7 +45,6 @@ export interface AppProps {
     showAxesButton: boolean;
     showBoundingBoxButton: boolean;
     metadataViewer: boolean;
-    dimensionsInMetadataViewer: boolean;
   };
   viewerConfig: {
     showAxes: boolean;
@@ -53,6 +62,8 @@ export interface AppProps {
     region?: [number, number, number, number, number, number]; //[0,1,0,1,0,1], // or ignored if slice is specified with a non-3D mode
     slice?: number; // or integer slice to show in view mode XY, YZ, or XZ.  mut. ex with region
   };
+  metadata?: MetadataRecord;
+  metadataConfig?: MetadataCategory[];
   baseUrl: string;
   nextImgPath: string;
   prevImgPath: string;

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -1,6 +1,6 @@
 import { View3d, Volume, ImageInfo } from "@aics/volume-viewer";
 import { ImageType, ViewMode } from "../../shared/enums";
-import { MetadataRecord } from "../../shared/types";
+import { MetadataFormatRecord, MetadataRecord } from "../../shared/types";
 import { ColorArray } from "../../shared/utils/colorRepresentations";
 import { ChannelGrouping, ChannelState, ViewerChannelSettings } from "../../shared/utils/viewerChannelSettings";
 
@@ -18,6 +18,7 @@ export interface AppProps {
   cellPath: string;
   fovPath: string;
   metadata?: MetadataRecord;
+  metadataFormat?: MetadataFormatRecord;
   renderConfig: {
     alphaMask: boolean;
     autoRotateButton: boolean;

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -1,6 +1,6 @@
 import { View3d, Volume, ImageInfo } from "@aics/volume-viewer";
 import { ImageType, ViewMode } from "../../shared/enums";
-import { MetadataFormatRecord, MetadataRecord } from "../../shared/types";
+import { MetadataRecord } from "../../shared/types";
 import { ColorArray } from "../../shared/utils/colorRepresentations";
 import { ChannelGrouping, ChannelState, ViewerChannelSettings } from "../../shared/utils/viewerChannelSettings";
 
@@ -18,7 +18,6 @@ export interface AppProps {
   cellPath: string;
   fovPath: string;
   metadata?: MetadataRecord;
-  metadataFormat?: MetadataFormatRecord;
   renderConfig: {
     alphaMask: boolean;
     autoRotateButton: boolean;

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -31,6 +31,7 @@ export interface AppProps {
     resetCameraButton: boolean;
     showAxesButton: boolean;
     showBoundingBoxButton: boolean;
+    metadataViewer: boolean;
   };
   viewerConfig: {
     showAxes: boolean;

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -4,17 +4,6 @@ import { MetadataRecord } from "../../shared/types";
 import { ColorArray } from "../../shared/utils/colorRepresentations";
 import { ChannelGrouping, ChannelState, ViewerChannelSettings } from "../../shared/utils/viewerChannelSettings";
 
-export type MetadataCategory =
-  | "dimensions"
-  | "originalDimensions"
-  | "physicalDimensions"
-  | "pixelPhysicalSize"
-  | "channels"
-  | "timeSeriesFrames"
-  | "userData";
-
-export type MetadataSelectors = { [C in MetadataCategory]: (image: Volume) => MetadataRecord };
-
 export interface AppProps {
   // rawData has a "dtype" which is expected to be "uint8", a "shape":[c,z,y,x] and a "buffer" which is a DataView
   rawData?: { dtype: "uint8"; shape: [number, number, number, number]; buffer: DataView };
@@ -62,8 +51,6 @@ export interface AppProps {
     region?: [number, number, number, number, number, number]; //[0,1,0,1,0,1], // or ignored if slice is specified with a non-3D mode
     slice?: number; // or integer slice to show in view mode XY, YZ, or XZ.  mut. ex with region
   };
-  metadata?: MetadataRecord;
-  metadataConfig?: MetadataCategory[];
   baseUrl: string;
   nextImgPath: string;
   prevImgPath: string;
@@ -76,7 +63,9 @@ export interface AppProps {
     translation: [number, number, number];
     rotation: [number, number, number];
   };
+  metadata?: MetadataRecord;
 
+  metadataFormatter?: (metadata: MetadataRecord) => MetadataRecord;
   onControlPanelToggle?: (collapsed: boolean) => void;
 }
 

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -1,5 +1,6 @@
 import { View3d, Volume, ImageInfo } from "@aics/volume-viewer";
 import { ImageType, ViewMode } from "../../shared/enums";
+import { MetadataRecord } from "../../shared/types";
 import { ColorArray } from "../../shared/utils/colorRepresentations";
 import { ChannelGrouping, ChannelState, ViewerChannelSettings } from "../../shared/utils/viewerChannelSettings";
 
@@ -16,6 +17,7 @@ export interface AppProps {
   cellId: string;
   cellPath: string;
   fovPath: string;
+  metadata?: MetadataRecord;
   renderConfig: {
     alphaMask: boolean;
     autoRotateButton: boolean;

--- a/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
+++ b/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
@@ -43,7 +43,7 @@ export default class ViewerWrapper extends React.Component<ViewerWrapperProps, V
 
   componentDidMount(): void {
     if (!this.view3D) {
-      this.view3D = new View3d(this.view3dviewerRef.current!);
+      this.view3D = new View3d({ parentElement: this.view3dviewerRef.current! });
       this.props.onView3DCreated(this.view3D);
       this.view3D.setAutoRotate(this.props.autorotate);
     }

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -6,23 +6,21 @@ import { ClickParam } from "antd/lib/menu";
 import ChannelsWidget, { ChannelsWidgetProps } from "../ChannelsWidget";
 import GlobalVolumeControls, { GlobalVolumeControlsProps } from "../GlobalVolumeControls";
 import CustomizeWidget, { CustomizeWidgetProps } from "../CustomizeWidget";
-import MetadataViewer, { MetadataViewerProps } from "../MetadataViewer";
+import MetadataViewer from "../MetadataViewer";
 
 import { PRESET_COLOR_MAP } from "../../shared/constants";
 
 import "./styles.css";
 import ViewerIcon from "../shared/ViewerIcon";
+import { MetadataRecord } from "../../shared/types";
 
-interface ControlPanelProps
-  extends ChannelsWidgetProps,
-    GlobalVolumeControlsProps,
-    CustomizeWidgetProps,
-    MetadataViewerProps {
+interface ControlPanelProps extends ChannelsWidgetProps, GlobalVolumeControlsProps, CustomizeWidgetProps {
   hasImage: boolean;
   renderConfig: GlobalVolumeControlsProps["renderConfig"] & {
     colorPresetsDropdown: boolean;
     metadataViewer: boolean;
   };
+  getMetadata: () => MetadataRecord;
   collapsed: boolean;
   setCollapsed: (value: boolean) => void;
 }
@@ -36,7 +34,7 @@ const enum ControlTab {
 const ControlTabNames = {
   [ControlTab.Channels]: "Channel Settings",
   [ControlTab.Advanced]: "Advanced Settings",
-  [ControlTab.Metadata]: "Image Metadata",
+  [ControlTab.Metadata]: "Metadata",
 };
 
 export default function ControlPanel(props: ControlPanelProps): React.ReactElement {
@@ -147,9 +145,7 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
                   />
                 </>
               )}
-              {tab === ControlTab.Metadata && (
-                <MetadataViewer metadata={props.metadata} getExtraMetadata={props.getExtraMetadata} />
-              )}
+              {tab === ControlTab.Metadata && <MetadataViewer metadata={props.getMetadata()} />}
             </div>
           )}
         </Card>

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -146,7 +146,9 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
                   />
                 </>
               )}
-              {tab === ControlTab.Metadata && props.metadata && <MetadataViewer metadata={props.metadata} />}
+              {tab === ControlTab.Metadata && props.metadata && (
+                <MetadataViewer metadata={props.metadata} metadataFormat={props.metadataFormat} />
+              )}
             </div>
           )}
         </Card>

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -17,7 +17,7 @@ interface ControlPanelProps
   extends ChannelsWidgetProps,
     GlobalVolumeControlsProps,
     CustomizeWidgetProps,
-    Partial<MetadataViewerProps> {
+    MetadataViewerProps {
   hasImage: boolean;
   renderConfig: GlobalVolumeControlsProps["renderConfig"] & {
     colorPresetsDropdown: boolean;
@@ -148,11 +148,7 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
                 </>
               )}
               {tab === ControlTab.Metadata && (
-                <MetadataViewer
-                  metadata={props.metadata}
-                  metadataFormat={props.metadataFormat}
-                  getExtraMetadata={props.getExtraMetadata}
-                />
+                <MetadataViewer metadata={props.metadata} getExtraMetadata={props.getExtraMetadata} />
               )}
             </div>
           )}

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -11,6 +11,7 @@ import { PRESET_COLOR_MAP } from "../../shared/constants";
 
 import "./styles.css";
 import ViewerIcon from "../shared/ViewerIcon";
+import MetadataViewer from "../MetadataViewer";
 
 interface ControlPanelProps extends ChannelsWidgetProps, GlobalVolumeControlsProps, CustomizeWidgetProps {
   hasImage: boolean;
@@ -88,7 +89,7 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
 
         {renderTab(ControlTab.Channels, <ViewerIcon type="channels" />)}
         {renderTab(ControlTab.Advanced, <ViewerIcon type="preferences" />)}
-        {props.renderConfig.metadataViewer && renderTab(ControlTab.Metadata, <Icon type="unordered-list" />)}
+        {props.renderConfig.metadataViewer && renderTab(ControlTab.Metadata, <Icon type="info" />)}
       </div>
       <div className="control-panel-col" style={{ flex: "0 0 450px" }}>
         <h2 className="control-panel-title">{ControlTabNames[tab]}</h2>
@@ -141,6 +142,7 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
                   />
                 </>
               )}
+              {tab === ControlTab.Metadata && <MetadataViewer data={{}} />}
             </div>
           )}
         </Card>

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -16,6 +16,7 @@ interface ControlPanelProps extends ChannelsWidgetProps, GlobalVolumeControlsPro
   hasImage: boolean;
   renderConfig: GlobalVolumeControlsProps["renderConfig"] & {
     colorPresetsDropdown: boolean;
+    metadataViewer: boolean;
   };
   collapsed: boolean;
   setCollapsed: (value: boolean) => void;
@@ -24,11 +25,13 @@ interface ControlPanelProps extends ChannelsWidgetProps, GlobalVolumeControlsPro
 const enum ControlTab {
   Channels,
   Advanced,
+  Metadata,
 }
 
 const ControlTabNames = {
   [ControlTab.Channels]: "Channel Settings",
   [ControlTab.Advanced]: "Advanced Settings",
+  [ControlTab.Metadata]: "Image Metadata",
 };
 
 export default function ControlPanel(props: ControlPanelProps): React.ReactElement {
@@ -59,6 +62,18 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
     );
   };
 
+  const renderTab = (thisTab: ControlTab, icon: React.ReactNode | string): React.ReactNode => (
+    <Tooltip title={ControlTabNames[thisTab]} placement="right" {...(!props.collapsed && { visible: false })}>
+      <Button
+        className={tab === thisTab ? "ant-btn-icon-only btn-tabactive" : "ant-btn-icon-only"}
+        onClick={() => setTab(thisTab)}
+        icon={typeof icon === "string" ? icon : undefined}
+      >
+        {typeof icon === "object" && icon}
+      </Button>
+    </Tooltip>
+  );
+
   return (
     <div className="control-panel-col-container">
       <div className="control-panel-tab-col" style={{ flex: "0 0 50px" }}>
@@ -71,31 +86,9 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
 
         <div className="tab-divider" />
 
-        <Tooltip
-          title={ControlTabNames[ControlTab.Channels]}
-          placement="right"
-          {...(!props.collapsed && { visible: false })}
-        >
-          <Button
-            className={tab === ControlTab.Channels ? "ant-btn-icon-only btn-tabactive" : "ant-btn-icon-only"}
-            onClick={() => setTab(ControlTab.Channels)}
-          >
-            <ViewerIcon type="channels" />
-          </Button>
-        </Tooltip>
-
-        <Tooltip
-          title={ControlTabNames[ControlTab.Advanced]}
-          placement="right"
-          {...(!props.collapsed && { visible: false })}
-        >
-          <Button
-            className={tab === ControlTab.Advanced ? "ant-btn-icon-only btn-tabactive" : "ant-btn-icon-only"}
-            onClick={() => setTab(ControlTab.Advanced)}
-          >
-            <ViewerIcon type="preferences" />
-          </Button>
-        </Tooltip>
+        {renderTab(ControlTab.Channels, <ViewerIcon type="channels" />)}
+        {renderTab(ControlTab.Advanced, <ViewerIcon type="preferences" />)}
+        {props.renderConfig.metadataViewer && renderTab(ControlTab.Metadata, <Icon type="unordered-list" />)}
       </div>
       <div className="control-panel-col" style={{ flex: "0 0 450px" }}>
         <h2 className="control-panel-title">{ControlTabNames[tab]}</h2>

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -147,7 +147,11 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
                 </>
               )}
               {tab === ControlTab.Metadata && props.metadata && (
-                <MetadataViewer metadata={props.metadata} metadataFormat={props.metadataFormat} />
+                <MetadataViewer
+                  metadata={props.metadata}
+                  metadataFormat={props.metadataFormat}
+                  getExtraMetadata={props.getExtraMetadata}
+                />
               )}
             </div>
           )}

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 
 import { Card, Button, Dropdown, Icon, Menu, Tooltip } from "antd";
 import { ClickParam } from "antd/lib/menu";
@@ -6,14 +6,18 @@ import { ClickParam } from "antd/lib/menu";
 import ChannelsWidget, { ChannelsWidgetProps } from "../ChannelsWidget";
 import GlobalVolumeControls, { GlobalVolumeControlsProps } from "../GlobalVolumeControls";
 import CustomizeWidget, { CustomizeWidgetProps } from "../CustomizeWidget";
+import MetadataViewer, { MetadataViewerProps } from "../MetadataViewer";
 
 import { PRESET_COLOR_MAP } from "../../shared/constants";
 
 import "./styles.css";
 import ViewerIcon from "../shared/ViewerIcon";
-import MetadataViewer from "../MetadataViewer";
 
-interface ControlPanelProps extends ChannelsWidgetProps, GlobalVolumeControlsProps, CustomizeWidgetProps {
+interface ControlPanelProps
+  extends ChannelsWidgetProps,
+    GlobalVolumeControlsProps,
+    CustomizeWidgetProps,
+    Partial<MetadataViewerProps> {
   hasImage: boolean;
   renderConfig: GlobalVolumeControlsProps["renderConfig"] & {
     colorPresetsDropdown: boolean;
@@ -36,7 +40,7 @@ const ControlTabNames = {
 };
 
 export default function ControlPanel(props: ControlPanelProps): React.ReactElement {
-  const [tab, setTab] = useState(ControlTab.Channels);
+  const [tab, setTab] = React.useState(ControlTab.Channels);
 
   const { viewerChannelSettings, renderConfig, hasImage } = props;
 
@@ -142,7 +146,7 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
                   />
                 </>
               )}
-              {tab === ControlTab.Metadata && <MetadataViewer data={{}} />}
+              {tab === ControlTab.Metadata && props.metadata && <MetadataViewer metadata={props.metadata} />}
             </div>
           )}
         </Card>

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -65,7 +65,7 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
     );
   };
 
-  const renderTab = (thisTab: ControlTab, icon: React.ReactNode | string): React.ReactNode => (
+  const renderTab = (thisTab: ControlTab, icon: React.ReactNode): React.ReactNode => (
     <Tooltip title={ControlTabNames[thisTab]} placement="right" {...(!props.collapsed && { visible: false })}>
       <Button
         className={tab === thisTab ? "ant-btn-icon-only btn-tabactive" : "ant-btn-icon-only"}

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -147,7 +147,7 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
                   />
                 </>
               )}
-              {tab === ControlTab.Metadata && props.metadata && (
+              {tab === ControlTab.Metadata && (
                 <MetadataViewer
                   metadata={props.metadata}
                   metadataFormat={props.metadataFormat}

--- a/src/aics-image-viewer/components/GlobalVolumeControls.tsx
+++ b/src/aics-image-viewer/components/GlobalVolumeControls.tsx
@@ -64,7 +64,6 @@ export default class GlobalVolumeControls extends React.Component<GlobalVolumeCo
   );
 
   render(): React.ReactNode {
-    if (!this.props.imageName) return null;
     const { renderConfig, alphaMaskSliderLevel, brightnessSliderLevel, densitySliderLevel, gammaSliderLevel } =
       this.props;
     return (

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -1,51 +1,28 @@
-import { Table } from "antd";
 import React from "react";
+import { MetadataRecord } from "../../shared/types";
 import "./styles.css";
 
-type MetadataEntry = string | number | boolean | MetadataRecord;
-type MetadataRecord = { [key: string]: MetadataEntry };
-
-interface MetadataViewerProps {
-  data: MetadataRecord;
+export interface MetadataViewerProps {
+  metadata: MetadataRecord;
 }
 
-const columns = ["key", "value"].map((key) => ({ key, title: key, dataIndex: key }));
-
-type AntFormattedMetadata = {
-  key: string;
-  value: string | number | undefined;
-  children: MetadataRecord | undefined;
-};
-const formatMetadata = (record: MetadataRecord): AntFormattedMetadata[] => {
-  return Object.keys(record).map((key) => {
-    const content = record[key];
-    if (typeof content === "object") {
-      return { key, value: undefined, children: content };
-    } else {
-      return { key, value: typeof content === "boolean" ? content.toString() : content, children: undefined };
-    }
-  });
-};
-
-const expandedRowRender = ({ children }: AntFormattedMetadata): React.ReactNode => {
-  if (children) {
-    return <MetadataViewer data={children} />;
-  } else {
-    return undefined;
-  }
-};
-
-const MetadataViewer: React.FC<MetadataViewerProps> = ({ data }: MetadataViewerProps) => (
-  <Table
-    className="viewer-metadata-table"
-    showHeader={false}
-    columns={columns}
-    dataSource={formatMetadata(data)}
-    pagination={false}
-    size="small"
-    bordered={false}
-    expandedRowRender={expandedRowRender}
-  />
+const MetadataViewer: React.FC<MetadataViewerProps> = ({ metadata: data }) => (
+  <table className="viewer-metadata-table">
+    <colgroup>
+      <col />
+      <col />
+      <col />
+    </colgroup>
+    <tbody>
+      {Object.keys(data).map((key, idx) => (
+        <tr key={idx}>
+          <td className="metadata-expand"></td>
+          <td>{key}</td>
+          <td>{data[key]}</td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
 );
 
 export default MetadataViewer;

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -65,7 +65,7 @@ const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows
 
             return (
               <MetadataCollapsibleCategory
-                key={idx}
+                key={key}
                 metadata={metadataValue}
                 title={key}
                 categoryFollows={categoryBelow}
@@ -73,7 +73,7 @@ const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows
             );
           } else {
             return (
-              <tr key={idx}>
+              <tr key={key}>
                 <td className="metadata-key">{key}</td>
                 <td className="metadata-value">{metadataValue + ""}</td>
               </tr>

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -36,7 +36,7 @@ const MetadataCollapsibleRow: React.FC<CollapsibleRowProps> = ({ metadata, metad
     <>
       <tr className="metadata-collapse-title" onClick={() => setCollapsed(!collapsed)}>
         <td className="metadata-collapse-caret">
-          <Icon type="caret-right" style={{ transform: `rotate(${collapsed ? 0 : 90}deg)` }} />
+          <Icon type="right" style={{ transform: `rotate(${collapsed ? 0 : 90}deg)` }} />
         </td>
         {addTooltipIfPresent(titleFormat?.tooltip, <td colSpan={3}>{titleFormat?.displayName || title}</td>)}
       </tr>

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -3,12 +3,12 @@ import React from "react";
 import { MetadataEntry, MetadataRecord } from "../../shared/types";
 import "./styles.css";
 
-interface MetadataProps {
+interface MetadataTableProps {
   metadata: MetadataRecord;
-}
-
-interface MetadataTableProps extends MetadataProps {
-  // track whether categories will abut a category below when closed, for rendering borders properly
+  // Track whether a category title will abut another category title below when in the collapsed state.
+  // If so, this category title should not render a bottom border when collapsed, otherwise the border will double
+  // up with the top border of the lower category and create the appearance of a single thick, uneven border.
+  // (there is not a way to prevent this with pure CSS to my knowledge)
   categoryFollows: boolean;
 }
 
@@ -16,7 +16,8 @@ interface CollapsibleCategoryProps extends MetadataTableProps {
   title: string;
 }
 
-export interface MetadataViewerProps extends Partial<MetadataProps> {
+export interface MetadataViewerProps {
+  metadata: MetadataRecord;
   getExtraMetadata?: () => MetadataRecord;
 }
 
@@ -59,6 +60,9 @@ const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows
           const metadataValue = metadata[key];
 
           if (isCategory(metadataValue)) {
+            // Determine whether this category is followed by another category, ignoring data hierarchy:
+            // If this is the last element in the table, this category has another category below if the table does.
+            // Otherwise, just check if the next element in this table is a category.
             const nextItem = metadata[metadataKeys[idx + 1]];
             const categoryBelow = nextItem ? isCategory(nextItem) : categoryFollows;
 

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -31,13 +31,15 @@ const MetadataCollapsibleCategory: React.FC<CollapsibleCategoryProps> = ({ metad
         }
         onClick={toggleCollapsed}
       >
-        <td className="metadata-collapse-caret">
-          <Icon type="right" style={{ transform: `rotate(${collapsed ? 0 : 90}deg)` }} />
+        <td colSpan={2}>
+          <span className="metadata-collapse-caret">
+            <Icon type="right" style={{ transform: `rotate(${collapsed ? 0 : 90}deg)` }} />
+          </span>
+          {title}
         </td>
-        <td colSpan={2}>{title}</td>
       </tr>
       <tr className={"metadata-collapse-content-row" + (collapsed ? " metadata-collapse-collapsed" : "")}>
-        <td className="metadata-collapse-content" colSpan={3}>
+        <td className="metadata-collapse-content" colSpan={2}>
           <MetadataTable metadata={metadata} categoryFollows={categoryFollows} />
         </td>
       </tr>
@@ -56,8 +58,8 @@ const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows
 
           if (isCategory(metadataValue)) {
             // Determine whether this category is followed by another category, ignoring data hierarchy:
-            // If this is the last element in the table, this category has another category below if the table does.
-            // Otherwise, just check if the next element in this table is a category.
+            // - If this is the last element in the table, this category has another category below if the table does.
+            // - Otherwise, just check if the next element in this table is a category.
             const nextItem = metadata[metadataKeys[idx + 1]];
             const categoryBelow = nextItem ? isCategory(nextItem) : categoryFollows;
 
@@ -72,9 +74,7 @@ const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows
           } else {
             return (
               <tr key={idx}>
-                <td className="metadata-key" colSpan={2}>
-                  {key}
-                </td>
+                <td className="metadata-key">{key}</td>
                 <td className="metadata-value">{metadataValue}</td>
               </tr>
             );

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -59,13 +59,8 @@ const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows
           const metadataValue = metadata[key];
 
           if (isCategory(metadataValue)) {
-            let categoryBelow: boolean;
-            if (idx + 1 >= metadataKeys.length) {
-              categoryBelow = categoryFollows;
-            } else {
-              categoryBelow = isCategory(metadata[metadataKeys[idx + 1]]);
-              console.log(key, metadataKeys[idx + 1]);
-            }
+            const nextItem = metadata[metadataKeys[idx + 1]];
+            const categoryBelow = nextItem ? isCategory(nextItem) : categoryFollows;
 
             return (
               <MetadataCollapsibleCategory

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -69,8 +69,12 @@ const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, metadataFormat 
         } else {
           return (
             <tr key={idx}>
-              <td className="metadata-collapse-caret"></td>
-              {addTooltipIfPresent(format?.tooltip, <td>{format?.displayName || key}</td>)}
+              {addTooltipIfPresent(
+                format?.tooltip,
+                <td className="metadata-key" colSpan={2}>
+                  {format?.displayName || key}
+                </td>
+              )}
               <td className="metadata-value" colSpan={hasUnit ? 1 : 2}>
                 {metadataValue}
               </td>

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -75,7 +75,7 @@ const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows
             return (
               <tr key={idx}>
                 <td className="metadata-key">{key}</td>
-                <td className="metadata-value">{metadataValue}</td>
+                <td className="metadata-value">{metadataValue + ""}</td>
               </tr>
             );
           }

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -1,0 +1,51 @@
+import { Table } from "antd";
+import React from "react";
+import "./styles.css";
+
+type MetadataEntry = string | number | boolean | MetadataRecord;
+type MetadataRecord = { [key: string]: MetadataEntry };
+
+interface MetadataViewerProps {
+  data: MetadataRecord;
+}
+
+const columns = ["key", "value"].map((key) => ({ key, title: key, dataIndex: key }));
+
+type AntFormattedMetadata = {
+  key: string;
+  value: string | number | undefined;
+  children: MetadataRecord | undefined;
+};
+const formatMetadata = (record: MetadataRecord): AntFormattedMetadata[] => {
+  return Object.keys(record).map((key) => {
+    const content = record[key];
+    if (typeof content === "object") {
+      return { key, value: undefined, children: content };
+    } else {
+      return { key, value: typeof content === "boolean" ? content.toString() : content, children: undefined };
+    }
+  });
+};
+
+const expandedRowRender = ({ children }: AntFormattedMetadata): React.ReactNode => {
+  if (children) {
+    return <MetadataViewer data={children} />;
+  } else {
+    return undefined;
+  }
+};
+
+const MetadataViewer: React.FC<MetadataViewerProps> = ({ data }: MetadataViewerProps) => (
+  <Table
+    className="viewer-metadata-table"
+    showHeader={false}
+    columns={columns}
+    dataSource={formatMetadata(data)}
+    pagination={false}
+    size="small"
+    bordered={false}
+    expandedRowRender={expandedRowRender}
+  />
+);
+
+export default MetadataViewer;

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -49,18 +49,19 @@ const MetadataCollapsibleCategory: React.FC<CollapsibleCategoryProps> = ({ metad
 
 const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows }) => {
   const metadataKeys = Object.keys(metadata);
+  const metadataIsArray = Array.isArray(metadata);
 
   return (
     <table className="viewer-metadata-table">
       <tbody>
         {metadataKeys.map((key, idx) => {
-          const metadataValue = metadata[key];
+          const metadataValue = metadataIsArray ? metadata[idx] : metadata[key];
 
           if (isCategory(metadataValue)) {
             // Determine whether this category is followed by another category, ignoring data hierarchy:
             // - If this is the last element in the table, this category has another category below if the table does.
             // - Otherwise, just check if the next element in this table is a category.
-            const nextItem = metadata[metadataKeys[idx + 1]];
+            const nextItem = metadataIsArray ? metadata[idx + 1] : metadata[metadataKeys[idx + 1]];
             const categoryBelow = idx + 1 >= metadataKeys.length ? isCategory(nextItem) : categoryFollows;
 
             return (

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -3,28 +3,38 @@ import React from "react";
 import { MetadataEntry, MetadataRecord } from "../../shared/types";
 import "./styles.css";
 
-interface MetadataTableProps {
+interface MetadataProps {
   metadata: MetadataRecord;
+}
+
+interface MetadataTableProps extends MetadataProps {
+  // track whether categories will abut a category below when closed, for rendering borders properly
+  categoryFollows: boolean;
 }
 
 interface CollapsibleCategoryProps extends MetadataTableProps {
   title: string;
-  className?: string;
 }
 
-export interface MetadataViewerProps extends Partial<MetadataTableProps> {
+export interface MetadataViewerProps extends Partial<MetadataProps> {
   getExtraMetadata?: () => MetadataRecord;
 }
 
 const isCategory = (val: MetadataEntry): val is MetadataRecord => typeof val === "object" && val !== null;
 
 /** Component to hold collapse state */
-const MetadataCollapsibleCategory: React.FC<CollapsibleCategoryProps> = ({ metadata, title }) => {
+const MetadataCollapsibleCategory: React.FC<CollapsibleCategoryProps> = ({ metadata, title, categoryFollows }) => {
   const [collapsed, setCollapsed] = React.useState(true);
+  const toggleCollapsed = () => setCollapsed(!collapsed);
 
   return (
     <>
-      <tr className="metadata-collapse-title" onClick={() => setCollapsed(!collapsed)}>
+      <tr
+        className={
+          "metadata-collapse-title" + (categoryFollows && collapsed ? " metadata-collapse-no-bottom-border" : "")
+        }
+        onClick={toggleCollapsed}
+      >
         <td className="metadata-collapse-caret">
           <Icon type="right" style={{ transform: `rotate(${collapsed ? 0 : 90}deg)` }} />
         </td>
@@ -32,38 +42,58 @@ const MetadataCollapsibleCategory: React.FC<CollapsibleCategoryProps> = ({ metad
       </tr>
       <tr className={"metadata-collapse-content-row" + (collapsed ? " metadata-collapse-collapsed" : "")}>
         <td className="metadata-collapse-content" colSpan={3}>
-          <MetadataTable metadata={metadata} />
+          <MetadataTable metadata={metadata} categoryFollows={categoryFollows} />
         </td>
       </tr>
     </>
   );
 };
 
-const MetadataTable: React.FC<MetadataTableProps> = ({ metadata }) => (
-  <table className="viewer-metadata-table">
-    <tbody>
-      {Object.keys(metadata).map((key, idx) => {
-        const metadataValue = metadata[key];
-        if (isCategory(metadataValue)) {
-          return <MetadataCollapsibleCategory key={idx} metadata={metadataValue} title={key} />;
-        } else {
-          return (
-            <tr key={idx}>
-              <td className="metadata-key" colSpan={2}>
-                {key}
-              </td>
-              <td className="metadata-value">{metadataValue}</td>
-            </tr>
-          );
-        }
-      })}
-    </tbody>
-  </table>
-);
+const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows }) => {
+  const metadataKeys = Object.keys(metadata);
+
+  return (
+    <table className="viewer-metadata-table">
+      <tbody>
+        {metadataKeys.map((key, idx) => {
+          const metadataValue = metadata[key];
+
+          if (isCategory(metadataValue)) {
+            let categoryBelow: boolean;
+            if (idx + 1 >= metadataKeys.length) {
+              categoryBelow = categoryFollows;
+            } else {
+              categoryBelow = isCategory(metadata[metadataKeys[idx + 1]]);
+              console.log(key, metadataKeys[idx + 1]);
+            }
+
+            return (
+              <MetadataCollapsibleCategory
+                key={idx}
+                metadata={metadataValue}
+                title={key}
+                categoryFollows={categoryBelow}
+              />
+            );
+          } else {
+            return (
+              <tr key={idx}>
+                <td className="metadata-key" colSpan={2}>
+                  {key}
+                </td>
+                <td className="metadata-value">{metadataValue}</td>
+              </tr>
+            );
+          }
+        })}
+      </tbody>
+    </table>
+  );
+};
 
 const MetadataViewer: React.FC<MetadataViewerProps> = ({ metadata, getExtraMetadata }) => {
   const extraMetadata = getExtraMetadata ? getExtraMetadata() : {};
-  return <MetadataTable metadata={{ ...extraMetadata, ...metadata }} />;
+  return <MetadataTable metadata={{ ...extraMetadata, ...metadata }} categoryFollows={false} />;
 };
 
 export default MetadataViewer;

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -1,26 +1,80 @@
+import { Icon, Tooltip } from "antd";
 import React from "react";
-import { MetadataRecord } from "../../shared/types";
+import { MetadataFormat, MetadataFormatRecord, MetadataRecord } from "../../shared/types";
 import "./styles.css";
 
 export interface MetadataViewerProps {
   metadata: MetadataRecord;
+  metadataFormat?: MetadataFormatRecord;
 }
 
-const MetadataViewer: React.FC<MetadataViewerProps> = ({ metadata: data }) => (
+interface CollapsibleRowProps extends MetadataViewerProps {
+  title: string;
+  titleFormat?: MetadataFormat;
+}
+
+const addTooltipIfPresent = (tooltip: any, component: React.ReactElement): React.ReactElement => {
+  if (typeof tooltip === "string" && tooltip.length > 0) {
+    return (
+      <Tooltip title={tooltip} placement="right">
+        {component}
+      </Tooltip>
+    );
+  }
+  return component;
+};
+
+/** Component to hold collapse state */
+const MetadataCollapsibleRow: React.FC<CollapsibleRowProps> = ({ metadata, metadataFormat, title, titleFormat }) => {
+  const [collapsed, setCollapsed] = React.useState(true);
+
+  return (
+    <>
+      <tr className="metadata-collapse-title" onClick={() => setCollapsed(!collapsed)}>
+        <td className="metadata-collapse-caret">
+          <Icon type="caret-right" style={{ transform: `rotate(${collapsed ? 0 : 90}deg)` }} />
+        </td>
+        {addTooltipIfPresent(titleFormat?.tooltip, <td colSpan={3}>{titleFormat?.displayName || title}</td>)}
+      </tr>
+      <tr className={"metadata-collapse-content-row" + (collapsed ? " metadata-collapse-collapsed" : "")}>
+        <td className="metadata-collapse-content" colSpan={4}>
+          <MetadataViewer metadata={metadata} metadataFormat={metadataFormat} />
+        </td>
+      </tr>
+    </>
+  );
+};
+
+const MetadataViewer: React.FC<MetadataViewerProps> = ({ metadata, metadataFormat }) => (
   <table className="viewer-metadata-table">
-    <colgroup>
-      <col />
-      <col />
-      <col />
-    </colgroup>
     <tbody>
-      {Object.keys(data).map((key, idx) => (
-        <tr key={idx}>
-          <td className="metadata-expand"></td>
-          <td>{key}</td>
-          <td>{data[key]}</td>
-        </tr>
-      ))}
+      {Object.keys(metadata).map((key, idx) => {
+        const format = metadataFormat && metadataFormat[key];
+        const hasUnit = typeof format?.unit === "string" && format.unit.length > 0;
+        const metadataValue = metadata[key];
+        if (typeof metadataValue === "object" && metadataValue !== null) {
+          return (
+            <MetadataCollapsibleRow
+              key={idx}
+              metadata={metadataValue}
+              metadataFormat={metadataFormat}
+              title={key}
+              titleFormat={format}
+            />
+          );
+        } else {
+          return (
+            <tr key={idx}>
+              <td className="metadata-collapse-caret"></td>
+              {addTooltipIfPresent(format?.tooltip, <td>{format?.displayName || key}</td>)}
+              <td className="metadata-value" colSpan={hasUnit ? 1 : 2}>
+                {metadataValue}
+              </td>
+              {hasUnit && <td className="metadata-unit">{format?.unit}</td>}
+            </tr>
+          );
+        }
+      })}
     </tbody>
   </table>
 );

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -25,7 +25,7 @@ const isCategory = (val: MetadataEntry): val is MetadataRecord => typeof val ===
 /** Component to hold collapse state */
 const MetadataCollapsibleCategory: React.FC<CollapsibleCategoryProps> = ({ metadata, title, categoryFollows }) => {
   const [collapsed, setCollapsed] = React.useState(true);
-  const toggleCollapsed = () => setCollapsed(!collapsed);
+  const toggleCollapsed = (): void => setCollapsed(!collapsed);
 
   return (
     <>

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -13,7 +13,7 @@ interface CollapsibleRowProps extends MetadataTableProps {
   titleFormat?: MetadataFormat;
 }
 
-export interface MetadataViewerProps extends MetadataTableProps {
+export interface MetadataViewerProps extends Partial<MetadataTableProps> {
   getExtraMetadata?: () => MetadataTableProps;
 }
 

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -1,4 +1,4 @@
-import { Icon, Tooltip } from "antd";
+import { Icon } from "antd";
 import React from "react";
 import { MetadataEntry, MetadataRecord } from "../../shared/types";
 import "./styles.css";
@@ -9,10 +9,11 @@ interface MetadataTableProps {
 
 interface CollapsibleCategoryProps extends MetadataTableProps {
   title: string;
+  className?: string;
 }
 
 export interface MetadataViewerProps extends Partial<MetadataTableProps> {
-  getExtraMetadata?: () => MetadataTableProps;
+  getExtraMetadata?: () => MetadataRecord;
 }
 
 const isCategory = (val: MetadataEntry): val is MetadataRecord => typeof val === "object" && val !== null;

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -3,14 +3,18 @@ import React from "react";
 import { MetadataFormat, MetadataFormatRecord, MetadataRecord } from "../../shared/types";
 import "./styles.css";
 
-export interface MetadataViewerProps {
+interface MetadataTableProps {
   metadata: MetadataRecord;
   metadataFormat?: MetadataFormatRecord;
 }
 
-interface CollapsibleRowProps extends MetadataViewerProps {
+interface CollapsibleRowProps extends MetadataTableProps {
   title: string;
   titleFormat?: MetadataFormat;
+}
+
+export interface MetadataViewerProps extends MetadataTableProps {
+  getExtraMetadata?: () => MetadataTableProps;
 }
 
 const addTooltipIfPresent = (tooltip: any, component: React.ReactElement): React.ReactElement => {
@@ -38,14 +42,14 @@ const MetadataCollapsibleRow: React.FC<CollapsibleRowProps> = ({ metadata, metad
       </tr>
       <tr className={"metadata-collapse-content-row" + (collapsed ? " metadata-collapse-collapsed" : "")}>
         <td className="metadata-collapse-content" colSpan={4}>
-          <MetadataViewer metadata={metadata} metadataFormat={metadataFormat} />
+          <MetadataTable metadata={metadata} metadataFormat={metadataFormat} />
         </td>
       </tr>
     </>
   );
 };
 
-const MetadataViewer: React.FC<MetadataViewerProps> = ({ metadata, metadataFormat }) => (
+const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, metadataFormat }) => (
   <table className="viewer-metadata-table">
     <tbody>
       {Object.keys(metadata).map((key, idx) => {
@@ -78,5 +82,16 @@ const MetadataViewer: React.FC<MetadataViewerProps> = ({ metadata, metadataForma
     </tbody>
   </table>
 );
+
+const MetadataViewer: React.FC<MetadataViewerProps> = ({ metadata, metadataFormat, getExtraMetadata }) => {
+  const extraMetadata = getExtraMetadata ? getExtraMetadata() : { metadata: {}, metadataFormat: {} };
+  console.log(getExtraMetadata, extraMetadata);
+  return (
+    <MetadataTable
+      metadata={{ ...extraMetadata.metadata, ...metadata }}
+      metadataFormat={{ ...extraMetadata.metadataFormat, ...metadataFormat }}
+    />
+  );
+};
 
 export default MetadataViewer;

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -85,7 +85,6 @@ const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, metadataFormat 
 
 const MetadataViewer: React.FC<MetadataViewerProps> = ({ metadata, metadataFormat, getExtraMetadata }) => {
   const extraMetadata = getExtraMetadata ? getExtraMetadata() : { metadata: {}, metadataFormat: {} };
-  console.log(getExtraMetadata, extraMetadata);
   return (
     <MetadataTable
       metadata={{ ...extraMetadata.metadata, ...metadata }}

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -61,7 +61,7 @@ const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows
             // - If this is the last element in the table, this category has another category below if the table does.
             // - Otherwise, just check if the next element in this table is a category.
             const nextItem = metadata[metadataKeys[idx + 1]];
-            const categoryBelow = nextItem ? isCategory(nextItem) : categoryFollows;
+            const categoryBelow = idx + 1 >= metadataKeys.length ? isCategory(nextItem) : categoryFollows;
 
             return (
               <MetadataCollapsibleCategory

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -16,11 +16,6 @@ interface CollapsibleCategoryProps extends MetadataTableProps {
   title: string;
 }
 
-export interface MetadataViewerProps {
-  metadata: MetadataRecord;
-  getExtraMetadata?: () => MetadataRecord;
-}
-
 const isCategory = (val: MetadataEntry): val is MetadataRecord => typeof val === "object" && val !== null;
 
 /** Component to hold collapse state */
@@ -90,9 +85,8 @@ const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows
   );
 };
 
-const MetadataViewer: React.FC<MetadataViewerProps> = ({ metadata, getExtraMetadata }) => {
-  const extraMetadata = getExtraMetadata ? getExtraMetadata() : {};
-  return <MetadataTable metadata={{ ...extraMetadata, ...metadata }} categoryFollows={false} />;
-};
+const MetadataViewer: React.FC<{ metadata: MetadataRecord }> = ({ metadata }) => (
+  <MetadataTable metadata={metadata} categoryFollows={false} />
+);
 
 export default MetadataViewer;

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -7,18 +7,55 @@
 
   tr {
     border-bottom: 1px solid #6e6e6e;
+    transition: height 0.1s linear;
 
     &:nth-child(odd) {
+      background-color: #3a3a3a;
+    }
+
+    &.metadata-collapse-collapsed {
+      visibility: collapse;
+      height: 0px;
+    }
+
+    &.metadata-collapse-title {
+      font-weight: bold;
       background-color: #4b4b4b;
+    }
+
+    &.metadata-collapse-content-row {
+      &:last-child,
+      &:not(:last-child) tr:last-child {
+        border-bottom: none;
+      }
     }
   }
 
   td {
     padding: 6px;
 
-    &.metadata-expand {
-      width: 40px;
-      max-width: 40px;
+    &.metadata-collapse-caret {
+      width: 20px;
+      max-width: 20px;
+      padding-right: 0;
+    }
+
+    &.metadata-value {
+      text-align: right;
+    }
+
+    &:last-child {
+      padding-right: 12px;
+    }
+
+    &.metadata-collapse-content {
+      padding: 0;
+      padding-left: 15px;
+      border-bottom: none;
+    }
+
+    i {
+      transition: transform 0.1s linear;
     }
   }
 }

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -44,6 +44,11 @@
       text-align: right;
     }
 
+    &.metadata-unit {
+      width: 75px;
+      max-width: 75px;
+    }
+
     &:last-child {
       padding-right: 12px;
     }

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -5,9 +5,8 @@
     padding: 10px;
   }
 
+  /* Table rows */
   tr {
-    transition: height 0.1s linear;
-
     &:nth-child(odd) {
       background-color: #3a3a3a;
     }
@@ -18,10 +17,12 @@
     }
 
     &.metadata-collapse-title {
-      font-weight: bold;
+      color: white;
       background-color: #4b4b4b;
-      border-top: 1px solid #6e6e6e;
       border-bottom: 1px solid #6e6e6e;
+      &:not(:first-child) {
+        border-top: 1px solid #6e6e6e;
+      }
     }
 
     &.metadata-collapse-content-row {
@@ -29,22 +30,24 @@
     }
   }
 
-  tr.metadata-collapse-title:first-child,
-  tr.metadata-collapse-collapsed + tr.metadata-collapse-title {
-    border-top: none;
-  }
-
+  /* Table cells */
   td {
-    padding: 6px;
+    padding: 6px 0;
 
     &.metadata-collapse-caret {
-      width: 20px;
-      max-width: 20px;
-      padding-right: 0;
+      width: 40px;
+      padding-left: 16px;
+      padding-right: 10px;
+    }
+
+    &.metadata-key {
+      padding-left: 24px;
     }
 
     &.metadata-value {
       text-align: right;
+      padding-left: 20px;
+      padding-right: 16px;
     }
 
     &.metadata-unit {
@@ -53,12 +56,12 @@
     }
 
     &:last-child {
-      padding-right: 12px;
+      padding-right: 16px;
     }
 
     &.metadata-collapse-content {
       padding: 0;
-      padding-left: 15px;
+      padding-left: 16px;
       border-bottom: none;
     }
 

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -19,7 +19,12 @@
     &.metadata-collapse-title {
       color: white;
       background-color: #4b4b4b;
-      border-bottom: 1px solid #6e6e6e;
+      &:not(.metadata-collapse-no-bottom-border) {
+        border-bottom: 1px solid #6e6e6e;
+      }
+      &.metadata-collapse-no-bottom-border > td {
+        padding-bottom: 5px;
+      }
       &:not(:first-child) {
         border-top: 1px solid #6e6e6e;
       }

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -1,7 +1,24 @@
-.channel-rows-list .ant-table {
-  border: none;
+.viewer-metadata-table {
+  width: 100%;
+
+  tbody {
+    padding: 10px;
+  }
+
+  tr {
+    border-bottom: 1px solid #6e6e6e;
+
+    &:nth-child(odd) {
+      background-color: #4b4b4b;
+    }
+  }
 
   td {
-    border-bottom-color: #6e6e6e;
+    padding: 6px;
+
+    &.metadata-expand {
+      width: 40px;
+      max-width: 40px;
+    }
   }
 }

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -24,6 +24,8 @@
     }
 
     &.metadata-collapse-content-row {
+      background-color: #313131;
+
       &:last-child,
       &:not(:last-child) tr:last-child {
         border-bottom: none;

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -50,11 +50,6 @@
       padding-right: 16px;
     }
 
-    &.metadata-unit {
-      width: 75px;
-      max-width: 75px;
-    }
-
     &:last-child {
       padding-right: 16px;
     }

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -41,7 +41,7 @@
     padding: 6px 0;
     overflow-wrap: break-word;
 
-    &.metadata-collapse-caret {
+    .metadata-collapse-caret {
       width: 40px;
       padding-left: 16px;
       padding-right: 10px;

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -1,5 +1,6 @@
 .viewer-metadata-table {
   width: 100%;
+  table-layout: fixed;
 
   tbody {
     padding: 10px;
@@ -38,6 +39,7 @@
   /* Table cells */
   td {
     padding: 6px 0;
+    overflow-wrap: break-word;
 
     &.metadata-collapse-caret {
       width: 40px;

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -6,7 +6,6 @@
   }
 
   tr {
-    border-bottom: 1px solid #6e6e6e;
     transition: height 0.1s linear;
 
     &:nth-child(odd) {
@@ -21,16 +20,18 @@
     &.metadata-collapse-title {
       font-weight: bold;
       background-color: #4b4b4b;
+      border-top: 1px solid #6e6e6e;
+      border-bottom: 1px solid #6e6e6e;
     }
 
     &.metadata-collapse-content-row {
       background-color: #313131;
-
-      &:last-child,
-      &:not(:last-child) tr:last-child {
-        border-bottom: none;
-      }
     }
+  }
+
+  tr.metadata-collapse-title:first-child,
+  tr.metadata-collapse-collapsed + tr.metadata-collapse-title {
+    border-top: none;
   }
 
   td {

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -42,7 +42,7 @@
     overflow-wrap: break-word;
 
     .metadata-collapse-caret {
-      width: 40px;
+      cursor: pointer;
       padding-left: 16px;
       padding-right: 10px;
     }

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -1,0 +1,7 @@
+.channel-rows-list .ant-table {
+  border: none;
+
+  td {
+    border-bottom-color: #6e6e6e;
+  }
+}

--- a/src/aics-image-viewer/shared/types.ts
+++ b/src/aics-image-viewer/shared/types.ts
@@ -6,7 +6,7 @@ export type IsosurfaceFormat = "GLTF" | "STL";
 
 export type Styles = { [key: string]: React.CSSProperties };
 
-export type MetadataEntry = string | number | boolean | MetadataRecord;
+export type MetadataEntry = string | number | boolean | null | MetadataRecord;
 export type MetadataRecord = { [key: string]: MetadataEntry };
 
 export interface MetadataFormat {

--- a/src/aics-image-viewer/shared/types.ts
+++ b/src/aics-image-viewer/shared/types.ts
@@ -7,4 +7,4 @@ export type IsosurfaceFormat = "GLTF" | "STL";
 export type Styles = { [key: string]: React.CSSProperties };
 
 export type MetadataEntry = string | number | boolean | MetadataRecord | null | undefined;
-export type MetadataRecord = { [key: string]: MetadataEntry };
+export type MetadataRecord = { [key: string]: MetadataEntry } | MetadataEntry[];

--- a/src/aics-image-viewer/shared/types.ts
+++ b/src/aics-image-viewer/shared/types.ts
@@ -8,3 +8,10 @@ export type Styles = { [key: string]: React.CSSProperties };
 
 export type MetadataEntry = string | number | boolean | MetadataRecord;
 export type MetadataRecord = { [key: string]: MetadataEntry };
+
+export interface MetadataFormat {
+  unit?: string;
+  tooltip?: string;
+  displayName?: string;
+}
+export type MetadataFormatRecord = { [key: string]: MetadataFormat | MetadataFormatRecord };

--- a/src/aics-image-viewer/shared/types.ts
+++ b/src/aics-image-viewer/shared/types.ts
@@ -6,12 +6,5 @@ export type IsosurfaceFormat = "GLTF" | "STL";
 
 export type Styles = { [key: string]: React.CSSProperties };
 
-export type MetadataEntry = string | number | boolean | null | MetadataRecord;
+export type MetadataEntry = string | number | boolean | MetadataRecord | null | undefined;
 export type MetadataRecord = { [key: string]: MetadataEntry };
-
-export interface MetadataFormat {
-  unit?: string;
-  tooltip?: string;
-  displayName?: string;
-}
-export type MetadataFormatRecord = { [key: string]: MetadataFormat | MetadataFormatRecord };

--- a/src/aics-image-viewer/shared/types.ts
+++ b/src/aics-image-viewer/shared/types.ts
@@ -5,3 +5,6 @@ export type AxisName = "x" | "y" | "z";
 export type IsosurfaceFormat = "GLTF" | "STL";
 
 export type Styles = { [key: string]: React.CSSProperties };
+
+export type MetadataEntry = string | number | boolean | MetadataRecord;
+export type MetadataRecord = { [key: string]: MetadataEntry };

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,6 @@
     "moduleResolution": "Node",
     "noImplicitAny": true,
     "noImplicitReturns": true,
-    "preserveConstEnums": true,
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
Resolves #38: creates a new "Metadata" tab in the control panel, which can display image metadata as key-value pairs and render data nested in subcategories.

Adds the following props to configure and populate the metadata panel:
- `renderConfig.metadataViewer`: boolean, whether to show the panel at all
- `metadata`: a JSON object whose values are either string, number, boolean, or nested objects of these types
- `metadataConfig`: an array of strings specifying which categories of metadata to derive from the underlying image, and in what order. If this prop is specified, the app will add an "Image" category at the top of the metadata table containing the categories specified. Available categories are currently `dimensions`, `originalDimensions`, `physicalDimensions`, `pixelPhysicalSize`, `channels`, `timeSeriesFrames`, `userData`. (Some of these may need more consideration, or removal altogether. For that matter, I'm fine changing the structure of this API entirely.)

Also, removes a null-check for `imageName` in the render function of `GlobalVolumeControls`. The image doesn't need to have a name in order to have rendering properties to adjust. This resolves #115.

### Screenshot
(from CFE)
![image](https://user-images.githubusercontent.com/53030214/219791829-697ebe7a-1c01-458e-b734-41e5e2aba6cc.png)

