### PR TITLE
Fix/prune app state

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -162,19 +162,10 @@ export default class App extends React.Component<AppProps, AppState> {
     this.state = {
       image: null,
       view3d: null,
-      files: null,
-      cellId: props.cellId,
-      fovPath: props.fovPath,
-      cellPath: props.cellPath,
-      queryErrorMessage: null,
       sendingQueryRequest: false,
-      openFilesOnly: false,
-      channelDataReady: {},
       // channelGroupedByType is an object where channel indexes are grouped by type (observed, segmenations, and countours)
       // {observed: channelIndex[], segmentations: channelIndex[], contours: channelIndex[], other: channelIndex[] }
       channelGroupedByType: {},
-      // did the requested image have a cell id (in queryInput)?
-      hasCellId: !!props.cellId,
       // state set by the UI:
       userSelections: {
         imageType: ImageType.segmentedCell,
@@ -201,7 +192,6 @@ export default class App extends React.Component<AppProps, AppState> {
       },
       currentlyLoadedImagePath: undefined,
       cachingInProgress: false,
-      path: "",
     };
 
     this.openImage = this.openImage.bind(this);
@@ -247,8 +237,7 @@ export default class App extends React.Component<AppProps, AppState> {
     const debouncedResizeHandler = debounce(() => this.onWindowResize(), 500);
     window.addEventListener("resize", debouncedResizeHandler);
 
-    const { cellId } = this.props;
-    if (cellId) {
+    if (this.props.cellId) {
       this.beginRequestImage();
     }
   }
@@ -328,8 +317,6 @@ export default class App extends React.Component<AppProps, AppState> {
     this.setState({
       image: aimg,
       currentlyLoadedImagePath: imageDirectory,
-      channelDataReady: {},
-      queryErrorMessage: null,
       cachingInProgress: false,
       userSelections: {
         ...this.state.userSelections,
@@ -1004,13 +991,10 @@ export default class App extends React.Component<AppProps, AppState> {
   }
 
   beginRequestImage(type?: ImageType): void {
-    const { fovPath, cellPath, cellId } = this.props;
+    const { fovPath, cellPath } = this.props;
     let imageType = type || this.state.userSelections.imageType;
     let path = imageType === ImageType.fullField ? fovPath : cellPath;
     this.setState({
-      cellId,
-      path,
-      hasCellId: !!cellId,
       sendingQueryRequest: true,
       userSelections: {
         ...this.state.userSelections,
@@ -1096,7 +1080,6 @@ export default class App extends React.Component<AppProps, AppState> {
             pixelSize={this.state.image ? this.state.image.pixel_size : [1, 1, 1]}
             channelDataChannels={this.state.image?.channels}
             channelGroupedByType={this.state.channelGroupedByType}
-            channelDataReady={this.state.channelDataReady}
             // user selections
             maxProjectOn={userSelections.maxProject}
             pathTraceOn={userSelections.pathTrace}
@@ -1134,8 +1117,8 @@ export default class App extends React.Component<AppProps, AppState> {
               autorotate={userSelections.autorotate}
               pathTraceOn={userSelections.pathTrace}
               imageType={userSelections.imageType}
-              hasParentImage={!!this.state.fovPath}
-              hasCellId={this.state.hasCellId}
+              hasParentImage={!!this.props.fovPath}
+              hasCellId={!!this.props.cellId}
               canPathTrace={this.state.view3d ? this.state.view3d.hasWebGL2() : false}
               showAxes={userSelections.showAxes}
               showBoundingBox={userSelections.showBoundingBox}

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -92,22 +92,13 @@ export type UserSelectionChangeHandlers = {
 export interface AppState {
   view3d: View3d | null;
   image: Volume | null;
-  files: null;
-  cellId?: string;
-  fovPath: string;
-  cellPath: string;
-  queryErrorMessage: null | string;
+
   sendingQueryRequest: boolean;
-  openFilesOnly: boolean;
-  channelDataReady: { [key: string]: boolean };
+  currentlyLoadedImagePath?: string;
+  cachingInProgress: boolean;
   // channelGroupedByType is an object where channel indexes are grouped by type (observed, segmenations, and countours)
   // {observed: channelIndex[], segmentations: channelIndex[], contours: channelIndex[], other: channelIndex[] }
   channelGroupedByType: ChannelGrouping;
-  // did the requested image have a cell id (in queryInput)?
-  hasCellId: boolean;
   // state set by the UI:
   userSelections: UserSelectionState;
-  currentlyLoadedImagePath?: string;
-  cachingInProgress: boolean;
-  path: string;
 }

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -50,11 +50,8 @@ export interface AppProps {
     slice?: number; // or integer slice to show in view mode XY, YZ, or XZ.  mut. ex with region
   };
   baseUrl: string;
-  nextImgPath: string;
-  prevImgPath: string;
   cellDownloadHref: string;
   fovDownloadHref: string;
-  preLoad: boolean;
   pixelSize?: [number, number, number];
   canvasMargin: string;
   transform?: {
@@ -95,8 +92,6 @@ export type UserSelectionChangeHandlers = {
 export interface AppState {
   view3d: View3d | null;
   image: Volume | null;
-  nextImg: Volume | null;
-  prevImg: Volume | null;
   files: null;
   cellId?: string;
   fovPath: string;

--- a/src/aics-image-viewer/components/ChannelsWidget/index.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidget/index.tsx
@@ -22,7 +22,6 @@ export interface ChannelsWidgetProps {
   channelDataChannels: Channel[] | undefined;
   channelSettings: ChannelState[];
   channelGroupedByType: ChannelGrouping;
-  channelDataReady: { [key: string]: boolean };
   viewerChannelSettings?: ViewerChannelSettings;
 
   saveIsosurface: (channelIndex: number, type: IsosurfaceFormat) => void;

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -113,7 +113,6 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
                   channelDataChannels={props.channelDataChannels}
                   channelGroupedByType={props.channelGroupedByType}
                   changeChannelSettings={props.changeChannelSettings}
-                  channelDataReady={props.channelDataReady}
                   saveIsosurface={props.saveIsosurface}
                   updateChannelTransferFunction={props.updateChannelTransferFunction}
                   changeOneChannelSetting={props.changeOneChannelSetting}


### PR DESCRIPTION
## Problem

We still have a now-unused mechanism for displaying images as a "slideshow," which maintains a concept of a previous/next image in a sequence. Additionally, a number of other top-level state values are unused or can be derived from props, which is the preferred pattern in React.

## Solution

Remove unused slideshow feature, unused state, and associated methods.

Removed props:
- `nextImgPath`, `prevImgPath`, `preLoad`; from slideshow feature

Removed state:
- `nextImg`, `prevImg`; from slideshow feature
- `cellId`, `hasCellId`, `cellPath`, `fovPath`, `path`; derivable from props
- `channelDataReady`, `files`, `openFilesOnly`, `queryErrorMessage`; unused (`files` was typed as `null`, e.g.)

Removed `App` class properties:
- `stateKey`, from slideshow feature
- `openImageInterval`, unused