### PR TITLE
Feature/functionize app

### DIFF
--- a/public/index.tsx
+++ b/public/index.tsx
@@ -9,6 +9,7 @@ import "./App.css";
 
 import { ImageViewerApp, RenderMode, ViewerChannelSettings, ViewMode } from "../src";
 import FirebaseRequest from "./firebase";
+import { GlobalViewerSettings } from "../src/aics-image-viewer/components/App/types";
 
 export const VIEWER_3D_SETTINGS: ViewerChannelSettings = {
   groups: [
@@ -77,7 +78,7 @@ const args = {
   cellDownloadHref: "https://files.allencell.org/api/2.0/file/download?collection=cellviewer-1-4/?id=C2025",
   initialChannelSettings: VIEWER_3D_SETTINGS,
 };
-const viewerSettings = {
+const viewerSettings: Partial<GlobalViewerSettings> = {
   showAxes: false,
   showBoundingBox: false,
   autorotate: false,

--- a/src/aics-image-viewer/components/App/ChannelUpdater.tsx
+++ b/src/aics-image-viewer/components/App/ChannelUpdater.tsx
@@ -70,6 +70,9 @@ const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, channelState, vi
 
   useImageEffect(
     (image) => {
+      if (controlPoints.length < 2) {
+        return;
+      }
       const gradient = controlPointsToLut(controlPoints);
       image.setLut(index, gradient);
       view3d.updateLuts(image);

--- a/src/aics-image-viewer/components/App/ChannelUpdater.tsx
+++ b/src/aics-image-viewer/components/App/ChannelUpdater.tsx
@@ -8,27 +8,27 @@ import { UseImageEffectType } from "./types";
 
 interface ChannelUpdaterProps {
   index: number;
-  state: ChannelState;
+  channelState: ChannelState;
   view3d: View3d;
   image: Volume | null;
-  imageLoaded: boolean;
+  channelLoaded: boolean;
 }
 
 /**
  * A component that doesn't render anything, but reacts to the provided `ChannelState`
  * and keeps it in sync with the viewer.
  */
-const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, state, view3d, image, imageLoaded }) => {
+const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, channelState, view3d, image, channelLoaded }) => {
   const { volumeEnabled, isosurfaceEnabled, isovalue, colorizeEnabled, colorizeAlpha, opacity, color, controlPoints } =
-    state;
+    channelState;
 
-  // Effects to update channel settings should check if image is present and loaded first
+  // Effects to update channel settings should check if image is present and channel is loaded first
   const useImageEffect: UseImageEffectType = (effect, deps) => {
     useEffect(() => {
-      if (image && imageLoaded) {
+      if (image && channelLoaded) {
         return effect(image);
       }
-    }, [...deps, image, imageLoaded]);
+    }, [...deps, image, channelLoaded]);
   };
 
   useImageEffect(

--- a/src/aics-image-viewer/components/App/ChannelUpdater.tsx
+++ b/src/aics-image-viewer/components/App/ChannelUpdater.tsx
@@ -32,58 +32,64 @@ const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, channelState, vi
   };
 
   useImageEffect(
-    (image) => {
-      view3d.setVolumeChannelEnabled(image, index, volumeEnabled);
-      view3d.updateLuts(image);
+    (currentImage) => {
+      view3d.setVolumeChannelEnabled(currentImage, index, volumeEnabled);
+      view3d.updateLuts(currentImage);
     },
     [volumeEnabled]
   );
 
-  useImageEffect((image) => view3d.setVolumeChannelOptions(image, index, { isosurfaceEnabled }), [isosurfaceEnabled]);
+  useImageEffect(
+    (currentImage) => view3d.setVolumeChannelOptions(currentImage, index, { isosurfaceEnabled }),
+    [isosurfaceEnabled]
+  );
 
-  useImageEffect((image) => view3d.setVolumeChannelOptions(image, index, { isovalue }), [isovalue]);
-
-  useImageEffect((image) => view3d.setVolumeChannelOptions(image, index, { isosurfaceOpacity: opacity }), [opacity]);
+  useImageEffect((currentImage) => view3d.setVolumeChannelOptions(currentImage, index, { isovalue }), [isovalue]);
 
   useImageEffect(
-    (image) => {
-      view3d.setVolumeChannelOptions(image, index, { color });
-      view3d.updateLuts(image);
+    (currentImage) => view3d.setVolumeChannelOptions(currentImage, index, { isosurfaceOpacity: opacity }),
+    [opacity]
+  );
+
+  useImageEffect(
+    (currentImage) => {
+      view3d.setVolumeChannelOptions(currentImage, index, { color });
+      view3d.updateLuts(currentImage);
     },
     [color]
   );
 
   useImageEffect(
-    (image) => {
+    (currentImage) => {
       if (colorizeEnabled) {
         // TODO get the labelColors from the tf editor component
-        const lut = image.getHistogram(index).lutGenerator_labelColors();
-        image.setColorPalette(index, lut.lut);
-        image.setColorPaletteAlpha(index, colorizeAlpha);
+        const lut = currentImage.getHistogram(index).lutGenerator_labelColors();
+        currentImage.setColorPalette(index, lut.lut);
+        currentImage.setColorPaletteAlpha(index, colorizeAlpha);
       } else {
-        image.setColorPaletteAlpha(index, 0);
+        currentImage.setColorPaletteAlpha(index, 0);
       }
-      view3d.updateLuts(image);
+      view3d.updateLuts(currentImage);
     },
     [colorizeEnabled]
   );
 
   useImageEffect(
-    (image) => {
+    (currentImage) => {
       if (controlPoints.length < 2) {
         return;
       }
       const gradient = controlPointsToLut(controlPoints);
-      image.setLut(index, gradient);
-      view3d.updateLuts(image);
+      currentImage.setLut(index, gradient);
+      view3d.updateLuts(currentImage);
     },
     [controlPoints]
   );
 
   useImageEffect(
-    (image) => {
-      image.setColorPaletteAlpha(index, colorizeEnabled ? colorizeAlpha : 0);
-      view3d.updateLuts(image);
+    (currentImage) => {
+      currentImage.setColorPaletteAlpha(index, colorizeEnabled ? colorizeAlpha : 0);
+      view3d.updateLuts(currentImage);
     },
     [colorizeAlpha]
   );

--- a/src/aics-image-viewer/components/App/ChannelUpdater.tsx
+++ b/src/aics-image-viewer/components/App/ChannelUpdater.tsx
@@ -8,7 +8,7 @@ import { UseImageEffectType } from "./types";
 
 interface ChannelUpdaterProps {
   index: number;
-  state: ChannelState;
+  channelState: ChannelState;
   view3d: View3d;
   image: Volume | null;
   imageLoaded: boolean;
@@ -18,9 +18,9 @@ interface ChannelUpdaterProps {
  * A component that doesn't render anything, but reacts to the provided `ChannelState`
  * and keeps it in sync with the viewer.
  */
-const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, state, view3d, image, imageLoaded }) => {
+const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, channelState, view3d, image, imageLoaded }) => {
   const { volumeEnabled, isosurfaceEnabled, isovalue, colorizeEnabled, colorizeAlpha, opacity, color, controlPoints } =
-    state;
+    channelState;
 
   // Effects to update channel settings should check if image is present and loaded first
   const useImageEffect: UseImageEffectType = (effect, deps) => {

--- a/src/aics-image-viewer/components/App/ChannelUpdater.tsx
+++ b/src/aics-image-viewer/components/App/ChannelUpdater.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect } from "react";
+
+import { View3d, Volume } from "@aics/volume-viewer";
+
+import { controlPointsToLut } from "../../shared/utils/controlPointsToLut";
+import { ChannelState } from "../../shared/utils/viewerChannelSettings";
+import { UseImageEffectType } from "./types";
+
+interface ChannelUpdaterProps {
+  index: number;
+  state: ChannelState;
+  view3d: View3d;
+  image: Volume | null;
+  imageLoaded: boolean;
+}
+
+/**
+ * A component that doesn't render anything, but reacts to the provided `ChannelState`
+ * and keeps it in sync with the viewer.
+ */
+const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, state, view3d, image, imageLoaded }) => {
+  const { volumeEnabled, isosurfaceEnabled, isovalue, colorizeEnabled, colorizeAlpha, opacity, color, controlPoints } =
+    state;
+
+  // Effects to update channel settings should check if image is present and loaded first
+  const useImageEffect: UseImageEffectType = (effect, deps) => {
+    useEffect(() => {
+      if (image && imageLoaded) {
+        return effect(image);
+      }
+    }, [...deps, image, imageLoaded]);
+  };
+
+  useImageEffect(
+    (image) => {
+      view3d.setVolumeChannelEnabled(image, index, volumeEnabled);
+      view3d.updateLuts(image);
+    },
+    [volumeEnabled]
+  );
+
+  useImageEffect((image) => view3d.setVolumeChannelOptions(image, index, { isosurfaceEnabled }), [isosurfaceEnabled]);
+
+  useImageEffect((image) => view3d.setVolumeChannelOptions(image, index, { isovalue }), [isovalue]);
+
+  useImageEffect((image) => view3d.setVolumeChannelOptions(image, index, { isosurfaceOpacity: opacity }), [opacity]);
+
+  useImageEffect(
+    (image) => {
+      view3d.setVolumeChannelOptions(image, index, { color });
+      view3d.updateLuts(image);
+    },
+    [color]
+  );
+
+  useImageEffect(
+    (image) => {
+      if (colorizeEnabled) {
+        // TODO get the labelColors from the tf editor component
+        const lut = image.getHistogram(index).lutGenerator_labelColors();
+        image.setColorPalette(index, lut.lut);
+        image.setColorPaletteAlpha(index, colorizeAlpha);
+      } else {
+        image.setColorPaletteAlpha(index, 0);
+      }
+      view3d.updateLuts(image);
+    },
+    [colorizeEnabled]
+  );
+
+  useImageEffect(
+    (image) => {
+      const gradient = controlPointsToLut(controlPoints);
+      image.setLut(index, gradient);
+      view3d.updateLuts(image);
+    },
+    [controlPoints]
+  );
+
+  useImageEffect(
+    (image) => {
+      image.setColorPaletteAlpha(index, colorizeEnabled ? colorizeAlpha : 0);
+      view3d.updateLuts(image);
+    },
+    [colorizeAlpha]
+  );
+
+  return null;
+};
+
+export default ChannelUpdater;

--- a/src/aics-image-viewer/components/App/ChannelUpdater.tsx
+++ b/src/aics-image-viewer/components/App/ChannelUpdater.tsx
@@ -8,7 +8,7 @@ import { UseImageEffectType } from "./types";
 
 interface ChannelUpdaterProps {
   index: number;
-  channelState: ChannelState;
+  state: ChannelState;
   view3d: View3d;
   image: Volume | null;
   imageLoaded: boolean;
@@ -18,9 +18,9 @@ interface ChannelUpdaterProps {
  * A component that doesn't render anything, but reacts to the provided `ChannelState`
  * and keeps it in sync with the viewer.
  */
-const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, channelState, view3d, image, imageLoaded }) => {
+const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, state, view3d, image, imageLoaded }) => {
   const { volumeEnabled, isosurfaceEnabled, isovalue, colorizeEnabled, colorizeAlpha, opacity, color, controlPoints } =
-    channelState;
+    state;
 
   // Effects to update channel settings should check if image is present and loaded first
   const useImageEffect: UseImageEffectType = (effect, deps) => {

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -1,7 +1,6 @@
 // 3rd Party Imports
-import React from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Layout } from "antd";
-import { includes, isEqual, find, map, debounce } from "lodash";
 import {
   ControlPoint,
   IVolumeLoader,
@@ -15,24 +14,18 @@ import {
   Volume,
 } from "@aics/volume-viewer";
 
-import {
-  AppProps,
-  AppState,
-  ShowControls,
-  ViewerSettingChangeHandlers,
-  ViewerSettingsKey,
-  GlobalViewerSettings,
-} from "./types";
+import { AppProps, ShowControls, ViewerSettingsKey, GlobalViewerSettings, ViewerSettingUpdater } from "./types";
 import { controlPointsToLut } from "../../shared/utils/controlPointsToLut";
 import {
   ChannelState,
   findFirstChannelMatch,
   makeChannelIndexGrouping,
-  ChannelStateKey,
-  ChannelStateChangeHandlers,
   ChannelGrouping,
+  ViewerChannelSettings,
+  ChannelSettingUpdater,
+  MultipleChannelSettingsUpdater,
 } from "../../shared/utils/viewerChannelSettings";
-import { activeAxisMap, AxisName, IsosurfaceFormat, MetadataRecord } from "../../shared/types";
+import { activeAxisMap, AxisName, IsosurfaceFormat, MetadataRecord, PerAxis } from "../../shared/types";
 import { ImageType, RenderMode, ViewMode } from "../../shared/enums";
 import {
   PRESET_COLORS_0,
@@ -64,12 +57,7 @@ import {
   brightnessSliderToImageValue,
   alphaSliderToImageValue,
 } from "../../shared/utils/sliderValuesToImageValues";
-import {
-  ColorArray,
-  colorArrayToFloats,
-  ColorObject,
-  colorObjectToArray,
-} from "../../shared/utils/colorRepresentations";
+import { ColorArray, colorArrayToFloats } from "../../shared/utils/colorRepresentations";
 
 import "./styles.css";
 
@@ -143,392 +131,203 @@ const defaultProps: AppProps = {
   canvasMargin: "0 0 0 0",
 };
 
-export default class App extends React.Component<AppProps, AppState> {
-  static defaultProps = defaultProps;
-  constructor(props: AppProps) {
-    super(props);
+type ViewerSettingsChangeHandlers = {
+  [K in ViewerSettingsKey]?: (settings: GlobalViewerSettings, value: GlobalViewerSettings[K]) => GlobalViewerSettings;
+};
 
-    const { viewerSettings } = props;
-
-    this.state = {
-      image: null,
-      view3d: new View3d(),
-      currentlyLoadedImagePath: undefined,
-      cachingInProgress: false,
-      sendingQueryRequest: false,
-      controlPanelClosed: window.innerWidth < CONTROL_PANEL_CLOSE_WIDTH,
-      // channelGroupedByType is an object where channel indexes are grouped by type (observed, segmenations, and countours)
-      // {observed: channelIndex[], segmentations: channelIndex[], contours: channelIndex[], other: channelIndex[] }
-      channelGroupedByType: {},
-      // channelSettings is a flat list of objects of this type:
-      // { name, enabled, volumeEnabled, isosurfaceEnabled, isovalue, opacity, color, dataReady}
-      channelSettings: [],
-      // global (not per-channel) state set by the UI:
-      viewerSettings: {
-        ...defaultViewerSettings,
-        ...viewerSettings,
-      },
+// Some viewer settings require custom change handlers to guard against entering an illegal state.
+// (e.g. autorotate must not be on in pathtrace mode.) Those handlers go here.
+// TODO should these be in their own file?
+const viewerSettingsChangeHandlers: ViewerSettingsChangeHandlers = {
+  viewMode: (prevSettings, viewMode) => {
+    if (viewMode === prevSettings.viewMode) {
+      return prevSettings;
+    }
+    const newSettings: GlobalViewerSettings = {
+      ...prevSettings,
+      viewMode,
+      region: { x: [0, 1], y: [0, 1], z: [0, 1] },
     };
+    const activeAxis = activeAxisMap[viewMode];
 
-    const { view3d } = this.state;
-    view3d.setBackgroundColor(colorArrayToFloats(this.state.viewerSettings.backgroundColor));
-    view3d.setShowAxis(this.state.viewerSettings.showAxes);
-    view3d.setAxisPosition(...AXIS_MARGIN_DEFAULT);
-    view3d.setScaleBarPosition(...SCALE_BAR_MARGIN_DEFAULT);
+    // TODO the following behavior/logic is very specific to a particular application's needs
+    // and is not necessarily appropriate for a general viewer.
+    // Why should the alpha setting matter whether we are viewing the primary image
+    // or its parent?
 
-    this.openImage = this.openImage.bind(this);
-    this.loadFromRaw = this.loadFromRaw.bind(this);
-    this.onChannelDataLoaded = this.onChannelDataLoaded.bind(this);
+    // If switching between 2D and 3D reset alpha mask to default (off in in 2D, 50% in 3D)
+    // If full field, dont mask
 
-    this.onViewModeChange = this.onViewModeChange.bind(this);
-    this.updateChannelTransferFunction = this.updateChannelTransferFunction.bind(this);
-    this.onAutorotateChange = this.onAutorotateChange.bind(this);
-    this.onSwitchFovCell = this.onSwitchFovCell.bind(this);
-    this.handleOpenImageException = this.handleOpenImageException.bind(this);
-    this.toggleControlPanel = this.toggleControlPanel.bind(this);
-    this.onUpdateImageMaskAlpha = this.onUpdateImageMaskAlpha.bind(this);
-    this.setImageAxisClip = this.setImageAxisClip.bind(this);
-    this.onApplyColorPresets = this.onApplyColorPresets.bind(this);
-    this.getNumberOfSlices = this.getNumberOfSlices.bind(this);
-    this.makeUpdatePixelSizeFn = this.makeUpdatePixelSizeFn.bind(this);
-    this.setViewerSettingsInState = this.setViewerSettingsInState.bind(this);
-    this.changeChannelSettings = this.changeChannelSettings.bind(this);
-    this.changeOneChannelSetting = this.changeOneChannelSetting.bind(this);
-    this.changeViewerSetting = this.changeViewerSetting.bind(this);
-    this.updateStateOnLoadImage = this.updateStateOnLoadImage.bind(this);
-    this.initializeNewImage = this.initializeNewImage.bind(this);
-    this.onClippingPanelVisibleChange = this.onClippingPanelVisibleChange.bind(this);
-    this.onClippingPanelVisibleChangeEnd = this.onClippingPanelVisibleChangeEnd.bind(this);
-    this.createChannelGrouping = this.createChannelGrouping.bind(this);
-    this.beginRequestImage = this.beginRequestImage.bind(this);
-    this.getOneChannelSetting = this.getOneChannelSetting.bind(this);
-    this.onChangeRenderingAlgorithm = this.onChangeRenderingAlgorithm.bind(this);
-    this.onResetCamera = this.onResetCamera.bind(this);
-    this.changeBackgroundColor = this.changeBackgroundColor.bind(this);
-    this.changeBoundingBoxColor = this.changeBoundingBoxColor.bind(this);
-    this.saveScreenshot = this.saveScreenshot.bind(this);
-    this.saveIsosurface = this.saveIsosurface.bind(this);
-  }
-
-  componentDidMount(): void {
-    if (this.state.controlPanelClosed && this.props.onControlPanelToggle) {
-      this.props.onControlPanelToggle(true);
+    if (activeAxis) {
+      // switching to 2d
+      // TODO this shows the whole volume and not a single slice
+      newSettings.region[activeAxis] = [0, 1];
+      if (prevSettings.viewMode === ViewMode.threeD) {
+        // Switching from 3D to 2D
+        newSettings.maskAlpha = ALPHA_MASK_SLIDER_2D_DEFAULT;
+        // if path trace was enabled in 3D turn it off when switching to 2D.
+        if (newSettings.renderMode === RenderMode.pathTrace) {
+          newSettings.renderMode = RenderMode.volumetric;
+        }
+      }
+    } else if (prevSettings.viewMode !== ViewMode.threeD && prevSettings.imageType === ImageType.segmentedCell) {
+      newSettings.maskAlpha = ALPHA_MASK_SLIDER_3D_DEFAULT;
     }
+    return newSettings;
+  },
+  renderMode: (prevSettings, renderMode) => ({
+    ...prevSettings,
+    renderMode,
+    autorotate: renderMode === RenderMode.pathTrace ? false : prevSettings.autorotate,
+  }),
+  autorotate: (prevSettings, autorotate) => ({
+    ...prevSettings,
+    // The button should theoretically be unclickable while in pathtrace mode, but this provides extra security
+    autorotate: prevSettings.renderMode === RenderMode.pathTrace ? false : autorotate,
+  }),
+};
 
-    const debouncedResizeHandler = debounce(() => this.onWindowResize(), 500);
-    window.addEventListener("resize", debouncedResizeHandler);
+// TODO move to utils file?
+function initializeLut(aimg: Volume, channelIndex: number, channelSettings?: ViewerChannelSettings): ControlPoint[] {
+  const histogram = aimg.getHistogram(channelIndex);
 
-    if (this.props.cellId) {
-      this.beginRequestImage();
-    }
-  }
+  // find channelIndex among viewerChannelSettings.
+  const name = aimg.channel_names[channelIndex];
+  // default to percentiles
+  let lutObject = histogram.lutGenerator_percentiles(LUT_MIN_PERCENTILE, LUT_MAX_PERCENTILE);
+  // and if init settings dictate, recompute it:
+  if (channelSettings) {
+    const initSettings = findFirstChannelMatch(name, channelIndex, channelSettings);
+    if (initSettings) {
+      if (initSettings.lut !== undefined && initSettings.lut.length === 2) {
+        let lutmod = "";
+        let lvalue = 0;
+        let lutvalues = [0, 0];
+        for (let i = 0; i < 2; ++i) {
+          const lstr = initSettings.lut[i];
+          // look at first char of string.
+          let firstchar = lstr.charAt(0);
+          if (firstchar === "m" || firstchar === "p") {
+            lutmod = firstchar;
+            lvalue = parseFloat(lstr.substring(1)) / 100.0;
+          } else {
+            lutmod = "";
+            lvalue = parseFloat(lstr);
+          }
+          if (lutmod === "m") {
+            lutvalues[i] = histogram.maxBin * lvalue;
+          } else if (lutmod === "p") {
+            lutvalues[i] = histogram.findBinOfPercentile(lvalue);
+          }
+        }
 
-  componentDidUpdate(prevProps: AppProps, prevState: AppState): void {
-    const { cellId, rawDims, rawData } = this.props;
-    const { channelSettings, view3d, image } = this.state;
-
-    if (rawDims && rawData && view3d && !prevState.view3d && !image) {
-      this.loadFromRaw();
-    }
-
-    // delayed for the animation to finish
-    if (prevState.controlPanelClosed !== this.state.controlPanelClosed) {
-      setTimeout(() => {
-        window.dispatchEvent(new Event("resize"));
-      }, 200);
-    }
-    const newRequest = cellId !== prevProps.cellId;
-    if (newRequest) {
-      this.beginRequestImage();
-    }
-
-    if (!isEqual(prevProps.transform, this.props.transform)) {
-      const { view3d, image } = this.state;
-      if (view3d && image) {
-        view3d.setVolumeTranslation(image, this.props.transform?.translation || [0, 0, 0]);
-        view3d.setVolumeRotation(image, this.props.transform?.rotation || [0, 0, 0]);
+        lutObject = histogram.lutGenerator_minMax(
+          Math.min(lutvalues[0], lutvalues[1]),
+          Math.max(lutvalues[0], lutvalues[1])
+        );
       }
     }
-
-    const channelsChanged = !isEqual(channelSettings, prevState.channelSettings);
-    const newImage = this.state.image && !prevState.image;
-    const imageChanged = this.state.image && prevState.image && this.state.image.name !== prevState.image.name;
-    if (newImage || channelsChanged || imageChanged) {
-      this.updateImageVolumeAndSurfacesEnabledFromAppState();
-    }
   }
 
-  setInitialChannelConfig(channelNames: string[], channelColors: ColorArray[]): ChannelState[] {
-    return channelNames.map((channel, index) => {
-      let color = (channelColors[index] ? channelColors[index].slice() : [226, 205, 179]) as ColorArray; // guard for unexpectedly longer channel list
+  const newControlPoints = lutObject.controlPoints.map((controlPoint) => ({
+    ...controlPoint,
+    color: TFEDITOR_DEFAULT_COLOR,
+  }));
+  aimg.setLut(channelIndex, lutObject.lut);
+  return newControlPoints;
+}
 
-      return this.initializeOneChannelSetting(null, channel, index, color);
-    });
-  }
+const App: React.FC<AppProps> = (props) => {
+  props = { ...defaultProps, ...props };
 
-  createChannelGrouping(channels: string[]): ChannelGrouping {
+  // State management /////////////////////////////////////////////////////////
+
+  // TODO is there a better API for values that never change?
+  const [view3d, _setView3d] = useState(() => new View3d());
+  const [image, setImage] = useState<Volume | null>(null);
+
+  const [sendingQueryRequest, setSendingQueryRequest] = useState(false);
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const [currentlyLoadedImagePath, setCurrentlyLoadedImagePath] = useState<string | undefined>(undefined);
+  const [controlPanelClosed, setControlPanelClosed] = useState(() => window.innerWidth < CONTROL_PANEL_CLOSE_WIDTH);
+
+  const [channelGroupedByType, setChannelGroupedByType] = useState<ChannelGrouping>({});
+
+  // These are the major parts of `App` state
+  // `viewerSettings` represents global state, while `channelSettings` represents per-channel state
+  // TODO this is a second application of defaults... which one should remain?
+  const [viewerSettings, setViewerSettings] = useState(() => ({ ...defaultViewerSettings, ...props.viewerSettings }));
+  const changeViewerSetting = useCallback<ViewerSettingUpdater>(
+    (key, value) => {
+      const changeHandler = viewerSettingsChangeHandlers[key];
+      if (changeHandler) {
+        setViewerSettings(changeHandler(viewerSettings, value));
+      } else {
+        setViewerSettings({ ...viewerSettings, [key]: value });
+      }
+    },
+    [viewerSettings]
+  );
+
+  const [channelSettings, setChannelSettings] = useState<ChannelState[]>([]);
+  const changeChannelSetting = useCallback<ChannelSettingUpdater>(
+    (index, key, value) => {
+      const newChannelSettings = channelSettings.slice();
+      newChannelSettings[index] = { ...newChannelSettings[index], [key]: value };
+      setChannelSettings(newChannelSettings);
+    },
+    [channelSettings]
+  );
+
+  const applyColorPresets = useCallback(
+    (presets: ColorArray[]): void => {
+      const newChannelSettings = channelSettings.map((channel, idx) =>
+        presets[idx] ? { ...channel, color: presets[idx] } : channel
+      );
+      setChannelSettings(newChannelSettings);
+    },
+    [channelSettings]
+  );
+  const changeMultipleChannelSettings = useCallback<MultipleChannelSettingsUpdater>(
+    (indices, key, value) => {
+      const newChannelSettings = channelSettings.map((settings, idx) =>
+        indices.includes(idx) ? { ...settings, [key]: value } : settings
+      );
+      setChannelSettings(newChannelSettings);
+    },
+    [channelSettings]
+  );
+
+  // Image loading/initialization functions ///////////////////////////////////
+
+  const getOneChannelSetting = (channelName: string, settings?: ChannelState[]): ChannelState | undefined => {
+    return (settings || channelSettings).find((channel) => channel.name === channelName);
+  };
+
+  // TODO: ...can this be derived? would we want it to be if so?
+  const createChannelGrouping = (channels: string[]): ChannelGrouping => {
     if (!channels) {
       return {};
     }
-    const { viewerChannelSettings } = this.props;
-    if (!viewerChannelSettings) {
+    if (!props.viewerChannelSettings) {
       // return all channels
-      return {
-        [SINGLE_GROUP_CHANNEL_KEY]: channels.map((_val, index) => index),
-      };
+      return { [SINGLE_GROUP_CHANNEL_KEY]: channels.map((_val, index) => index) };
     }
+    return makeChannelIndexGrouping(channels, props.viewerChannelSettings);
+  };
 
-    return makeChannelIndexGrouping(channels, viewerChannelSettings);
-  }
-
-  onNewVolumeCreated(aimg: Volume, imageDirectory: string, doResetViewMode: boolean): void {
-    // FIXME this calls setState followed almost immediately by another setState... :-(
-    const newChannelSettings = this.updateStateOnLoadImage(aimg.imageInfo.channel_names);
-
-    this.setState({
-      image: aimg,
-      currentlyLoadedImagePath: imageDirectory,
-      cachingInProgress: false,
-      viewerSettings: {
-        ...this.state.viewerSettings,
-        viewMode: doResetViewMode ? ViewMode.threeD : this.state.viewerSettings.viewMode,
-      },
-    });
-    this.initializeNewImage(aimg, newChannelSettings);
-  }
-
-  onNewChannelData(_url: string, v: Volume, channelIndex: number, keepLuts: boolean | undefined): void {
-    // const thisChannelSettings = this.getOneChannelSetting(channel.name, newChannelSettings, (channel) => channel.name === obj.channel_names[channelIndex].split('_')[0]);
-    const thisChannelSettings = this.getOneChannelSetting(
-      v.imageInfo.channel_names[channelIndex],
-      // race condition with updateStateOnLoadImage below?
-      this.state.channelSettings
-    );
-    this.onChannelDataLoaded(v, thisChannelSettings!, channelIndex, keepLuts);
-  }
-
-  handleOpenImageException(_resp: any): void {
-    /** can uncomment when we are actually using this message var
-    let message = "Unknown Error";
-    if (resp.data && resp.data.message) {
-      message = resp.data.message;
-    }
-    else if (resp.stack) {
-      message = resp.stack;
-    }
-    else if (resp.message) {
-      message = resp.message;
-    }
-    else {
-      message = JSON.stringify(resp);
-    }
-    **/
-    // console.log(message);
-  }
-
-  openImage(imageDirectory: string, doResetViewMode: boolean, keepLuts?: boolean): void {
-    if (imageDirectory === this.state.currentlyLoadedImagePath) {
-      return;
-    }
-    const { baseUrl } = this.props;
-
-    const fullUrl = `${baseUrl}${imageDirectory}`;
-
-    const loadSpec = new LoadSpec();
-    loadSpec.url = fullUrl;
-    loadSpec.subpath = imageDirectory;
-
-    let loader: IVolumeLoader;
-    // if this does NOT end with tif or json,
-    // then we assume it's zarr.
-    if (fullUrl.endsWith(".json")) {
-      loader = new JsonImageInfoLoader();
-    } else if (fullUrl.endsWith(".tif") || fullUrl.endsWith(".tiff")) {
-      loader = new TiffLoader();
-    } else {
-      loader = new OMEZarrLoader();
-    }
-
-    loader
-      .createVolume(loadSpec, (url, v, channelIndex) => {
-        this.onNewChannelData(url, v, channelIndex, keepLuts);
-      })
-      .then((aimg) => {
-        this.onNewVolumeCreated(aimg, imageDirectory, doResetViewMode);
-      })
-      .catch((resp) => this.handleOpenImageException(resp));
-  }
-
-  initializeNewImage(aimg: Volume, newChannelSettings?: ChannelState[]): void {
-    // set alpha slider first time image is loaded to something that makes sense
-    let maskAlpha = this.getInitialAlphaLevel();
-    this.setViewerSettingsInState({ maskAlpha });
-
-    // Here is where we officially hand the image to the volume-viewer
-    this.placeImageInViewer(aimg, newChannelSettings);
-  }
-
-  private getInitialAlphaLevel(): number {
-    const viewerSettingsState = this.state.viewerSettings;
-    const viewerSettingsProps = this.props.viewerSettings;
-    let alphaLevel =
-      viewerSettingsState.imageType === ImageType.segmentedCell && viewerSettingsState.viewMode === ViewMode.threeD
-        ? ALPHA_MASK_SLIDER_3D_DEFAULT
-        : ALPHA_MASK_SLIDER_2D_DEFAULT;
-    // if maskAlpha is defined in viewerConfig then it will override the above
-    if (viewerSettingsProps?.maskAlpha !== undefined) {
-      alphaLevel = viewerSettingsProps.maskAlpha;
-    }
-    return alphaLevel;
-  }
-
-  // set up the Volume into the Viewer using the current initial settings
-  private placeImageInViewer(aimg: Volume, newChannelSettings?: ChannelState[]): void {
-    const { viewerSettings, channelSettings, view3d } = this.state;
-    if (!view3d) {
-      return;
-    }
-    const channelSetting = newChannelSettings || channelSettings;
-    view3d.removeAllVolumes();
-    view3d.addVolume(aimg, {
-      channels: aimg.channel_names.map((name) => {
-        const ch = this.getOneChannelSetting(name, channelSetting);
-        if (!ch) {
-          return {};
-        }
-        return {
-          enabled: ch.volumeEnabled,
-          isosurfaceEnabled: ch.isosurfaceEnabled,
-          isovalue: ch.isovalue,
-          isosurfaceOpacity: ch.opacity,
-          color: ch.color,
-        };
-      }),
-    });
-
-    const alphaLevel = this.getInitialAlphaLevel();
-    const imageMask = alphaSliderToImageValue(alphaLevel);
-    view3d.updateMaskAlpha(aimg, imageMask);
-
-    view3d.setMaxProjectMode(aimg, viewerSettings.renderMode === RenderMode.maxProject);
-
-    const isPathTracing = viewerSettings.renderMode === RenderMode.pathTrace;
-    const imageBrightness = brightnessSliderToImageValue(viewerSettings.brightness, isPathTracing);
-    view3d.updateExposure(imageBrightness);
-
-    const imageDensity = densitySliderToImageValue(viewerSettings.density, isPathTracing);
-    view3d.updateDensity(aimg, imageDensity);
-
-    const imageValues = gammaSliderToImageValues(viewerSettings.levels);
-    view3d.setGamma(aimg, imageValues.min, imageValues.scale, imageValues.max);
-
-    // update current camera mode to make sure the image gets the update
-    view3d.setCameraMode(viewerSettings.viewMode);
-    view3d.setShowBoundingBox(aimg, viewerSettings.showBoundingBox);
-    view3d.setBoundingBoxColor(aimg, colorArrayToFloats(viewerSettings.boundingBoxColor));
-    // interpolation defaults to enabled in volume-viewer
-    if (!viewerSettings.interpolationEnabled) {
-      view3d.setInterpolationEnabled(aimg, false);
-    }
-
-    Object.keys(viewerSettings.region).forEach((axis) => {
-      const [min, max] = viewerSettings.region[axis as AxisName];
-      if (min > 0 || max < 1) {
-        const isOrthoAxis = activeAxisMap[viewerSettings.viewMode] === axis;
-        view3d.setAxisClip(aimg, axis as AxisName, min - 0.5, max - 0.5, isOrthoAxis);
-      }
-    });
-
-    view3d.setVolumeTranslation(aimg, this.props.transform?.translation || [0, 0, 0]);
-    view3d.setVolumeRotation(aimg, this.props.transform?.rotation || [0, 0, 0]);
-    // tell view that things have changed for this image
-    view3d.updateActiveChannels(aimg);
-  }
-
-  updateStateOnLoadImage(channelNames: string[]): ChannelState[] {
-    const { channelSettings } = this.state;
-
-    const prevChannelNames = map(channelSettings, (ele) => ele.name);
-    let newChannelSettings = isEqual(prevChannelNames, channelNames)
-      ? channelSettings
-      : this.setInitialChannelConfig(channelNames, INIT_COLORS);
-
-    let channelGroupedByType = this.createChannelGrouping(channelNames);
-    this.setState({
-      channelSettings: newChannelSettings,
-    });
-    this.setState({
-      channelGroupedByType,
-    });
-    return newChannelSettings;
-  }
-
-  initializeLut(aimg: Volume, channelIndex: number): ControlPoint[] {
-    const histogram = aimg.getHistogram(channelIndex);
-
-    const initViewerSettings = this.props.viewerChannelSettings;
-    // find channelIndex among viewerChannelSettings.
-    const name = aimg.channel_names[channelIndex];
-    // default to percentiles
-    let lutObject = histogram.lutGenerator_percentiles(LUT_MIN_PERCENTILE, LUT_MAX_PERCENTILE);
-    // and if init settings dictate, recompute it:
-    if (initViewerSettings) {
-      const initSettings = findFirstChannelMatch(name, channelIndex, initViewerSettings);
-      if (initSettings) {
-        if (initSettings.lut !== undefined && initSettings.lut.length === 2) {
-          let lutmod = "";
-          let lvalue = 0;
-          let lutvalues = [0, 0];
-          for (let i = 0; i < 2; ++i) {
-            const lstr = initSettings.lut[i];
-            // look at first char of string.
-            let firstchar = lstr.charAt(0);
-            if (firstchar === "m" || firstchar === "p") {
-              lutmod = firstchar;
-              lvalue = parseFloat(lstr.substring(1)) / 100.0;
-            } else {
-              lutmod = "";
-              lvalue = parseFloat(lstr);
-            }
-            if (lutmod === "m") {
-              lutvalues[i] = histogram.maxBin * lvalue;
-            } else if (lutmod === "p") {
-              lutvalues[i] = histogram.findBinOfPercentile(lvalue);
-            }
-          }
-
-          lutObject = histogram.lutGenerator_minMax(
-            Math.min(lutvalues[0], lutvalues[1]),
-            Math.max(lutvalues[0], lutvalues[1])
-          );
-        }
-      }
-    }
-
-    const newControlPoints = lutObject.controlPoints.map((controlPoint) => ({
-      ...controlPoint,
-      color: TFEDITOR_DEFAULT_COLOR,
-    }));
-    aimg.setLut(channelIndex, lutObject.lut);
-    return newControlPoints;
-  }
-
-  onChannelDataLoaded(
+  const onChannelDataLoaded = (
     aimg: Volume,
     thisChannelsSettings: ChannelState,
     channelIndex: number,
-    keepLuts: boolean | undefined
-  ): void {
-    const { image, view3d } = this.state;
-    if (!view3d || aimg !== image) {
-      return;
-    }
-    const volenabled = thisChannelsSettings.volumeEnabled;
-    const isoenabled = thisChannelsSettings.isosurfaceEnabled;
+    keepLuts?: boolean
+  ): ChannelState => {
+    let updatedChannelSettings = thisChannelsSettings;
+    // TODO necessary?
     view3d.setVolumeChannelOptions(aimg, channelIndex, {
-      enabled: volenabled,
+      enabled: thisChannelsSettings.volumeEnabled,
       color: thisChannelsSettings.color,
-      isosurfaceEnabled: isoenabled,
+      isosurfaceEnabled: thisChannelsSettings.isosurfaceEnabled,
       isovalue: thisChannelsSettings.isovalue,
       isosurfaceOpacity: thisChannelsSettings.opacity,
     });
@@ -540,38 +339,37 @@ export default class App extends React.Component<AppProps, AppState> {
       view3d.updateLuts(aimg);
     } else {
       // need to choose initial LUT
-      const newControlPoints = this.initializeLut(aimg, channelIndex);
-      this.changeOneChannelSetting(thisChannelsSettings.name, channelIndex, "controlPoints", newControlPoints);
+      const newControlPoints = initializeLut(aimg, channelIndex, props.viewerChannelSettings);
+      updatedChannelSettings = { ...thisChannelsSettings, controlPoints: newControlPoints };
     }
 
-    if (view3d) {
-      if (aimg.channelNames()[channelIndex] === this.props.viewerChannelSettings?.maskChannelName) {
-        view3d.setVolumeChannelAsMask(aimg, channelIndex);
-      }
+    if (aimg.channelNames()[channelIndex] === props.viewerChannelSettings?.maskChannelName) {
+      view3d.setVolumeChannelAsMask(aimg, channelIndex);
     }
 
     // when any channel data has arrived:
-    if (this.state.sendingQueryRequest) {
-      this.setState({ sendingQueryRequest: false });
-    }
+    setSendingQueryRequest(false);
     if (aimg.isLoaded()) {
       view3d.updateActiveChannels(aimg);
+      setImageLoaded(true);
     }
-  }
 
-  initializeOneChannelSetting(
+    return updatedChannelSettings;
+  };
+
+  const initializeOneChannelSetting = (
     aimg: Volume | null,
     channel: string,
     index: number,
     defaultColor: ColorArray
-  ): ChannelState {
-    const { viewerChannelSettings } = this.props;
+  ): ChannelState => {
+    const { viewerChannelSettings } = props;
     let color = defaultColor;
     let volumeEnabled = false;
     let surfaceEnabled = false;
 
     // note that this modifies aimg also
-    const newControlPoints = aimg ? this.initializeLut(aimg, index) : undefined;
+    const newControlPoints = aimg ? initializeLut(aimg, index) : undefined;
 
     if (viewerChannelSettings) {
       // search for channel in settings using groups, names and match values
@@ -601,343 +399,147 @@ export default class App extends React.Component<AppProps, AppState> {
       isovalue: 188,
       opacity: 1.0,
       color: color,
-      dataReady: false,
       controlPoints: newControlPoints || [],
     };
-  }
+  };
 
-  loadFromRaw(): void {
-    const { rawDims, rawData } = this.props;
-    if (!rawData || !rawDims) {
-      console.error("ERROR loadFromRaw called without rawData or rawDims being set");
+  const setChannelStateForNewImage = (channelNames: string[]): ChannelState[] | undefined => {
+    const settingsAreEqual = channelNames.every((name, idx) => name === channelSettings[idx]?.name);
+    if (settingsAreEqual) {
+      return undefined;
+    }
+
+    // TODO this function's behavior has changed to not recreate channel groupings on every load
+    //   verify that this doesn't impact anything
+    //   in fact... should creating channel groupings be its own effect, to change on `viewerChannelSettings`?
+    setChannelGroupedByType(createChannelGrouping(channelNames));
+
+    const newChannelSettings = channelNames.map((channel, index) => {
+      const color = (INIT_COLORS[index] ? INIT_COLORS[index].slice() : [226, 205, 179]) as ColorArray;
+      return initializeOneChannelSetting(null, channel, index, color);
+    });
+    // TODO could be this shouldn't set state...? leave it to per-channel setters?
+    setChannelSettings(newChannelSettings);
+    return newChannelSettings;
+  };
+
+  const placeImageInViewer = (aimg: Volume, newChannelSettings?: ChannelState[]): void => {
+    // TODO old code imperatively set `maskAlpha` to 2D or 3D default.
+    //   I think the reducer should take care of this now, but should test to verify
+    const channelSetting = newChannelSettings || channelSettings;
+    view3d.removeAllVolumes();
+    view3d.addVolume(aimg, {
+      channels: aimg.channel_names.map((name) => {
+        // TODO why this check?
+        const ch = getOneChannelSetting(name, channelSetting);
+        if (!ch) {
+          return {};
+        }
+        return {
+          enabled: ch.volumeEnabled,
+          isosurfaceEnabled: ch.isosurfaceEnabled,
+          isovalue: ch.isovalue,
+          isosurfaceOpacity: ch.opacity,
+          color: ch.color,
+        };
+      }),
+    });
+  };
+
+  const onNewVolumeCreated = (aimg: Volume, imageDirectory: string, doResetViewMode: boolean): ChannelState[] => {
+    const newChannelSettings = setChannelStateForNewImage(aimg.imageInfo.channel_names);
+
+    setImage(aimg);
+    setCurrentlyLoadedImagePath(imageDirectory);
+    changeViewerSetting("viewMode", doResetViewMode ? ViewMode.threeD : viewerSettings.viewMode);
+
+    placeImageInViewer(aimg, newChannelSettings);
+    return newChannelSettings!;
+  };
+
+  const openImage = async (): Promise<void> => {
+    const { fovPath, cellPath, baseUrl } = props;
+    const path = viewerSettings.imageType === ImageType.fullField ? fovPath : cellPath;
+    const fullUrl = `${baseUrl}${path}`;
+
+    if (path === currentlyLoadedImagePath) {
       return;
     }
 
-    const aimg = new Volume(rawDims);
-    const volsize = rawData.shape[1] * rawData.shape[2] * rawData.shape[3];
-    for (var i = 0; i < rawDims.channels; ++i) {
-      aimg.setChannelDataFromVolume(i, new Uint8Array(rawData.buffer.buffer, i * volsize, volsize));
+    setSendingQueryRequest(true);
+    setImageLoaded(false);
+
+    const loadSpec = new LoadSpec();
+    loadSpec.url = fullUrl;
+    loadSpec.subpath = path;
+
+    let loader: IVolumeLoader;
+    // if this does NOT end with tif or json,
+    // then we assume it's zarr.
+    if (fullUrl.endsWith(".json")) {
+      loader = new JsonImageInfoLoader();
+    } else if (fullUrl.endsWith(".tif") || fullUrl.endsWith(".tiff")) {
+      loader = new TiffLoader();
+    } else {
+      loader = new OMEZarrLoader();
     }
 
-    let newChannelSettings = rawDims.channel_names.map((channel, index) => {
-      let color = (INIT_COLORS[index] ? INIT_COLORS[index].slice() : [226, 205, 179]) as ColorArray; // guard for unexpectedly longer channel list
-      return this.initializeOneChannelSetting(aimg, channel, index, color);
-    });
+    const settingsRef = { current: [] as ChannelState[] };
 
-    let channelGroupedByType = this.createChannelGrouping(rawDims.channel_names);
-
-    const channelSetting = newChannelSettings;
-
-    let alphaLevel = this.getInitialAlphaLevel();
-
-    // Here is where we officially hand the image to the volume-viewer
-    this.placeImageInViewer(aimg, newChannelSettings);
-
-    this.setState({
-      channelGroupedByType,
-      image: aimg,
-      channelSettings: channelSetting,
-      viewerSettings: {
-        ...this.state.viewerSettings,
-        maskAlpha: alphaLevel,
-      },
-    });
-  }
-
-  private channelStateChangeHandlers: ChannelStateChangeHandlers = {
-    isovalue: (isovalue, index, view3d, image) => view3d.setVolumeChannelOptions(image, index, { isovalue }),
-    colorizeEnabled: (enabled, index, view3d, image) => {
-      if (enabled) {
-        // TODO get the labelColors from the tf editor component
-        const lut = image.getHistogram(index).lutGenerator_labelColors();
-        image.setColorPalette(index, lut.lut);
-        image.setColorPaletteAlpha(index, this.state.channelSettings[index].colorizeAlpha);
-      } else {
-        image.setColorPaletteAlpha(index, 0);
+    const aimg = await loader.createVolume(loadSpec, (_url, v, channelIndex) => {
+      const thisChannelSettings = getOneChannelSetting(v.imageInfo.channel_names[channelIndex], settingsRef.current);
+      const newChannelSettings = onChannelDataLoaded(v, thisChannelSettings!, channelIndex);
+      if (thisChannelSettings !== newChannelSettings) {
+        const newSettings = settingsRef.current!.slice();
+        newSettings[channelIndex] = newChannelSettings;
+        settingsRef.current = newSettings;
+        setChannelSettings(newSettings);
       }
-      view3d.updateLuts(image);
-    },
-    colorizeAlpha: (alpha, index, view3d, image) => {
-      const { colorizeEnabled } = this.state.channelSettings[index];
-      image.setColorPaletteAlpha(index, colorizeEnabled ? alpha : 0);
-      view3d.updateLuts(image);
-    },
-    opacity: (isosurfaceOpacity, index, view3d, image) =>
-      view3d.setVolumeChannelOptions(image, index, { isosurfaceOpacity }),
-    color: (color, index, view3d, image) => view3d.setVolumeChannelOptions(image, index, { color }),
+      // TODO: original behavior is to reset view mode on completely new image only
+      //   add state to enact this behavior
+    });
+
+    settingsRef.current = onNewVolumeCreated(aimg, path, false);
   };
 
-  private handleChangeChannelSetting<K extends ChannelStateKey>(
-    key: K,
-    newValue: ChannelState[K],
-    index: number
-  ): void {
-    const { view3d, image } = this.state;
-    if (!view3d || !image) {
-      return;
-    }
-    const handler = this.channelStateChangeHandlers[key];
-    if (handler) {
-      handler(newValue, index, view3d, image);
-    }
-  }
+  // TODO TODO TODO
+  const loadFromRaw = () => {};
 
-  changeOneChannelSetting<K extends ChannelStateKey>(
-    channelName: string,
-    channelIndex: number,
-    keyToChange: K,
-    newValue: ChannelState[K]
-  ): void {
-    const { channelSettings } = this.state;
-    const newChannels = channelSettings.map((channel) => {
-      return channel.name === channelName ? { ...channel, [keyToChange]: newValue } : channel;
-    });
+  // Imperative callbacks /////////////////////////////////////////////////////
 
-    this.setState({ channelSettings: newChannels });
-    this.handleChangeChannelSetting(keyToChange, newValue, channelIndex);
-  }
-
-  changeChannelSettings<K extends ChannelStateKey>(indices: number[], keyToChange: K, newValue: ChannelState[K]): void {
-    const { channelSettings } = this.state;
-    const newChannels = channelSettings.map((channel, index) => {
-      return {
-        ...channel,
-        [keyToChange]: includes(indices, index) ? newValue : channel[keyToChange],
-      };
-    });
-    this.setState({ channelSettings: newChannels });
-  }
-
-  setViewerSettingsInState(newState: Partial<GlobalViewerSettings>): void {
-    this.setState({
-      viewerSettings: {
-        ...this.state.viewerSettings,
-        ...newState,
-      },
-    });
-  }
-
-  private viewerSettingChangeHandlers: ViewerSettingChangeHandlers = {
-    viewMode: (mode, view3d, _image) => view3d.setCameraMode(mode),
-    renderMode: (mode, view3d, image) => {
-      view3d.setMaxProjectMode(image, mode === RenderMode.maxProject);
-      view3d.setVolumeRenderMode(mode === RenderMode.pathTrace ? RENDERMODE_PATHTRACE : RENDERMODE_RAYMARCH);
-      view3d.updateActiveChannels(image);
+  const saveIsosurface = useCallback(
+    (channelIndex: number, type: IsosurfaceFormat): void => {
+      if (image) view3d.saveChannelIsosurface(image, channelIndex, type);
     },
+    [image]
+  );
 
-    showAxes: (showing, view3d, _image) => view3d.setShowAxis(showing),
-    showBoundingBox: (showing, view3d, image) => view3d.setShowBoundingBox(image, showing),
-    boundingBoxColor: (color, view3d, image) => view3d.setBoundingBoxColor(image, colorArrayToFloats(color)),
-    backgroundColor: (color, view3d, _image) => view3d.setBackgroundColor(colorArrayToFloats(color)),
-
-    maskAlpha: (value, view3d, image) => {
-      view3d.updateMaskAlpha(image, alphaSliderToImageValue(value));
-      view3d.updateActiveChannels(image);
+  // TODO should this be a per-channel effect?
+  const updateChannelTransferFunction = useCallback(
+    (index: number, lut: Uint8Array): void => {
+      if (image) {
+        image.setLut(index, lut);
+        view3d?.updateLuts(image);
+      }
     },
-    brightness: (value, view3d, _image) => {
-      const isPathTracing = this.state.viewerSettings.renderMode === RenderMode.pathTrace;
-      const brightness = brightnessSliderToImageValue(value, isPathTracing);
-      view3d.updateExposure(brightness);
-    },
-    density: (value, view3d, image) => {
-      const isPathTracing = this.state.viewerSettings.renderMode === RenderMode.pathTrace;
-      const density = densitySliderToImageValue(value, isPathTracing);
-      view3d.updateDensity(image, density);
-    },
-    levels: (value, view3d, image) => {
-      const imageValues = gammaSliderToImageValues(value);
-      view3d.setGamma(image, imageValues.min, imageValues.scale, imageValues.max);
-    },
-    interpolationEnabled: (enabled, view3d, image) => view3d.setInterpolationEnabled(image, enabled),
-  };
+    [image]
+  );
 
-  /**
-   * Should only be called by internal methods that need to change multiple properties at once
-   * without calling multiple `setState`s. Prefer `changeViewerSetting` whenever possible.
-   */
-  private handleChangeViewerSetting<K extends ViewerSettingsKey>(key: K, newValue: GlobalViewerSettings[K]): void {
-    const { view3d, image } = this.state;
-    if (!view3d || !image) {
-      return;
-    }
-    const handler = this.viewerSettingChangeHandlers[key];
-    if (handler) {
-      handler(newValue, view3d, image);
-    }
-  }
+  const resetCamera = useCallback((): void => view3d.resetCamera(), []);
 
-  changeViewerSetting<K extends ViewerSettingsKey>(key: K, newValue: GlobalViewerSettings[K]): void {
-    this.setViewerSettingsInState({ [key]: newValue });
-    this.handleChangeViewerSetting(key, newValue);
-  }
-
-  saveIsosurface(channelIndex: number, type: IsosurfaceFormat): void {
-    const { view3d, image } = this.state;
-    if (!view3d || !image) {
-      return;
-    }
-    view3d.saveChannelIsosurface(image, channelIndex, type);
-  }
-
-  saveScreenshot(): void {
-    if (!this.state.view3d) {
-      return;
-    }
-    this.state.view3d.capture((dataUrl: string) => {
+  const saveScreenshot = useCallback((): void => {
+    view3d.capture((dataUrl: string) => {
       const anchor = document.createElement("a");
       anchor.href = dataUrl;
       anchor.download = "screenshot.png";
       anchor.click();
     });
-  }
+  }, []);
 
-  onWindowResize(): void {
-    if (window.innerWidth < CONTROL_PANEL_CLOSE_WIDTH) {
-      this.toggleControlPanel(true);
-    }
-  }
+  const onClippingPanelVisibleChange = useCallback(
+    (open: boolean): void => {
+      const CLIPPING_PANEL_HEIGHT = 130;
 
-  onViewModeChange(newMode: ViewMode): void {
-    const { viewerSettings } = this.state;
-    if (newMode === viewerSettings.viewMode) {
-      return;
-    }
-    let newSelectionState: Partial<GlobalViewerSettings> = {
-      viewMode: newMode,
-      region: { x: [0, 1], y: [0, 1], z: [0, 1] },
-    };
-    const activeAxis = activeAxisMap[newMode] as AxisName;
-
-    // TODO the following behavior/logic is very specific to a particular application's needs
-    // and is not necessarily appropriate for a general viewer.
-    // Why should the alpha setting matter whether we are viewing the primary image
-    // or its parent?
-
-    // If switching between 2D and 3D reset alpha mask to default (off in in 2D, 50% in 3D)
-    // If full field, dont mask
-
-    if (newMode !== ViewMode.threeD) {
-      // Set up single slice in 2d mode
-      newSelectionState.region![activeAxis] = [0, 1 / this.getNumberOfSlices()[activeAxis]];
-
-      if (viewerSettings.viewMode === ViewMode.threeD) {
-        // Switching from 3D to 2D
-        newSelectionState.maskAlpha = ALPHA_MASK_SLIDER_2D_DEFAULT;
-        // if path trace was enabled in 3D turn it off when switching to 2D.
-        if (viewerSettings.renderMode === RenderMode.pathTrace) {
-          newSelectionState.renderMode = RenderMode.volumetric;
-          this.onChangeRenderingAlgorithm(RenderMode.volumetric);
-        }
-      }
-    } else if (
-      viewerSettings.viewMode !== ViewMode.threeD &&
-      this.state.viewerSettings.imageType === ImageType.segmentedCell
-    ) {
-      // switching from 2D to 3D
-      newSelectionState.maskAlpha = ALPHA_MASK_SLIDER_3D_DEFAULT;
-    }
-
-    this.handleChangeViewerSetting("viewMode", newMode);
-    if (newSelectionState.maskAlpha !== undefined) {
-      this.handleChangeViewerSetting("maskAlpha", newSelectionState.maskAlpha);
-    }
-    Object.keys(newSelectionState.region!).forEach((axis) => {
-      const [minval, maxval] = newSelectionState.region![axis as AxisName];
-      this.handleImageAxisClipUpdate(axis as AxisName, minval, maxval, axis === activeAxis);
-    });
-    this.setViewerSettingsInState(newSelectionState);
-  }
-
-  onUpdateImageMaskAlpha(sliderValue: number): void {
-    this.setViewerSettingsInState({ maskAlpha: sliderValue });
-  }
-
-  onAutorotateChange(): void {
-    this.setViewerSettingsInState({
-      autorotate: !this.state.viewerSettings.autorotate,
-    });
-  }
-
-  private handleImageAxisClipUpdate(axis: AxisName, minval: number, maxval: number, isOrthoAxis: boolean): void {
-    const { view3d, image } = this.state;
-    if (view3d && image) {
-      view3d.setAxisClip(image, axis, minval - 0.5, maxval - 0.5, isOrthoAxis);
-    }
-  }
-
-  setImageAxisClip(axis: AxisName, minval: number, maxval: number, isOrthoAxis: boolean): void {
-    const { region } = this.state.viewerSettings;
-    this.setViewerSettingsInState({ region: { ...region, [axis]: [minval, maxval] } });
-    this.handleImageAxisClipUpdate(axis, minval, maxval, isOrthoAxis);
-  }
-
-  makeUpdatePixelSizeFn(i: number): (value: number) => void {
-    const { pixelSize } = this.props;
-    const imagePixelSize = pixelSize ? pixelSize.slice() : [1, 1, 1];
-    return (value: number) => {
-      const pixelSize = imagePixelSize.slice();
-      pixelSize[i] = value;
-      this.state.image?.setVoxelSize(pixelSize);
-    };
-  }
-
-  onChangeRenderingAlgorithm(newAlgorithm: RenderMode): void {
-    const { viewerSettings } = this.state;
-    // already set
-    if (newAlgorithm === viewerSettings.renderMode) {
-      return;
-    }
-    this.setViewerSettingsInState({
-      renderMode: newAlgorithm,
-      autorotate: newAlgorithm === RenderMode.pathTrace ? false : viewerSettings.autorotate,
-    });
-    this.handleChangeViewerSetting("renderMode", newAlgorithm);
-  }
-
-  onSwitchFovCell(value: ImageType): void {
-    const { cellPath, fovPath } = this.props;
-    const path = value === ImageType.fullField ? fovPath : cellPath;
-    this.openImage(path, false, false);
-    this.setState({
-      sendingQueryRequest: true,
-      viewerSettings: {
-        ...this.state.viewerSettings,
-        imageType: value,
-      },
-    });
-  }
-
-  onApplyColorPresets(presets: ColorArray[]): void {
-    const { channelSettings } = this.state;
-    presets.forEach((color, index) => {
-      if (index < channelSettings.length) {
-        this.handleChangeChannelSetting("color", color, index);
-      }
-    });
-    const newChannels = channelSettings.map((channel, channelindex) => {
-      return presets[channelindex] ? { ...channel, color: presets[channelindex] } : channel;
-    });
-    this.setState({ channelSettings: newChannels });
-  }
-
-  changeBoundingBoxColor = (color: ColorObject): void =>
-    this.changeViewerSetting("boundingBoxColor", colorObjectToArray(color));
-
-  changeBackgroundColor = (color: ColorObject): void =>
-    this.changeViewerSetting("backgroundColor", colorObjectToArray(color));
-
-  changeAxisShowing = (showing: boolean): void => this.changeViewerSetting("showAxes", showing);
-  changeBoundingBoxShowing = (showing: boolean): void => this.changeViewerSetting("showBoundingBox", showing);
-
-  onResetCamera(): void {
-    this.state.view3d?.resetCamera();
-  }
-
-  onClippingPanelVisibleChange(open: boolean): void {
-    const CLIPPING_PANEL_HEIGHT = 130;
-
-    const { view3d, viewerSettings } = this.state;
-    if (view3d) {
       let axisY = AXIS_MARGIN_DEFAULT[1];
       let scaleBarY = SCALE_BAR_MARGIN_DEFAULT[1];
       if (open) {
@@ -952,95 +554,22 @@ export default class App extends React.Component<AppProps, AppState> {
       if (viewerSettings.showAxes) {
         view3d.setShowAxis(false);
       }
-    }
-  }
+    },
+    [viewerSettings.showAxes]
+  );
 
-  onClippingPanelVisibleChangeEnd(_open: boolean): void {
-    const { view3d, viewerSettings } = this.state;
-    if (view3d) {
+  const onClippingPanelVisibleChangeEnd = useCallback(
+    (_open: boolean): void => {
       view3d.setShowScaleBar(true);
       if (viewerSettings.showAxes) {
         view3d.setShowAxis(true);
       }
-    }
-  }
+    },
+    [viewerSettings.showAxes]
+  );
 
-  updateChannelTransferFunction(index: number, lut: Uint8Array): void {
-    if (this.state.image) {
-      this.state.image.setLut(index, lut);
-      this.state.view3d?.updateLuts(this.state.image);
-    }
-  }
-
-  beginRequestImage(type?: ImageType): void {
-    const { fovPath, cellPath } = this.props;
-    let imageType = type || this.state.viewerSettings.imageType;
-    let path = imageType === ImageType.fullField ? fovPath : cellPath;
-    this.setState({
-      sendingQueryRequest: true,
-      viewerSettings: {
-        ...this.state.viewerSettings,
-        imageType,
-      },
-    });
-    this.openImage(path, true);
-  }
-
-  getOneChannelSetting(channelName: string, newSettings?: ChannelState[]): ChannelState | undefined {
-    const channelSettings = newSettings || this.state.channelSettings;
-    return find(channelSettings, (channel) => {
-      return channel.name === channelName;
-    });
-  }
-
-  updateImageVolumeAndSurfacesEnabledFromAppState(): void {
-    const { image, view3d } = this.state;
-    // apply channel settings
-    // image.channel_names
-    if (!image || !view3d) {
-      return;
-    }
-    image.channel_names.forEach((channelName, imageIndex) => {
-      if (image.getChannel(imageIndex).loaded) {
-        const channelSetting = this.getOneChannelSetting(channelName);
-        if (!channelSetting) {
-          return;
-        }
-        const volenabled = channelSetting.volumeEnabled;
-        const isoenabled = channelSetting.isosurfaceEnabled;
-
-        view3d.setVolumeChannelOptions(image, imageIndex, {
-          enabled: volenabled,
-          color: channelSetting.color,
-          isosurfaceEnabled: isoenabled,
-          isovalue: channelSetting.isovalue,
-          isosurfaceOpacity: channelSetting.opacity,
-        });
-      }
-    });
-
-    view3d.updateActiveChannels(image);
-  }
-
-  toggleControlPanel(value: boolean): void {
-    if (this.props.onControlPanelToggle) {
-      this.props.onControlPanelToggle(value);
-    }
-
-    this.setState({ controlPanelClosed: value });
-  }
-
-  getNumberOfSlices(): { x: number; y: number; z: number } {
-    if (this.state.image) {
-      const { x, y, z } = this.state.image;
-      return { x, y, z };
-    }
-    return { x: 0, y: 0, z: 0 };
-  }
-
-  getMetadata(): MetadataRecord {
-    const { metadata, metadataFormatter } = this.props;
-    const { image } = this.state;
+  const getMetadata = useCallback((): MetadataRecord => {
+    const { metadata, metadataFormatter } = props;
 
     let imageMetadata = image?.imageMetadata as MetadataRecord;
     if (imageMetadata && metadataFormatter) {
@@ -1052,102 +581,214 @@ export default class App extends React.Component<AppProps, AppState> {
     } else {
       return metadata || {};
     }
-  }
+  }, [props.metadata, props.metadataFormatter, image]);
 
-  render(): React.ReactNode {
-    const { cellDownloadHref, fovDownloadHref, viewerChannelSettings } = this.props;
-    const { viewerSettings } = this.state;
-    const showControls = {
-      ...defaultShownControls,
-      ...this.props.showControls,
-    };
-    return (
-      <Layout className="cell-viewer-app" style={{ height: this.props.appHeight }}>
-        <Sider
-          className="control-panel-holder"
-          collapsible={true}
-          defaultCollapsed={false}
-          collapsedWidth={50}
-          trigger={null}
-          collapsed={this.state.controlPanelClosed}
-          width={500}
-        >
-          <ControlPanel
-            showControls={showControls}
-            getMetadata={() => this.getMetadata()}
-            // image state
-            imageName={this.state.image?.name}
-            hasImage={!!this.state.image}
-            pixelSize={this.state.image ? this.state.image.pixel_size : [1, 1, 1]}
-            channelDataChannels={this.state.image?.channels}
-            channelGroupedByType={this.state.channelGroupedByType}
-            // user selections
-            pathTraceOn={viewerSettings.renderMode === RenderMode.pathTrace}
-            channelSettings={this.state.channelSettings}
-            showBoundingBox={viewerSettings.showBoundingBox}
-            backgroundColor={viewerSettings.backgroundColor}
-            boundingBoxColor={viewerSettings.boundingBoxColor}
-            maskAlpha={viewerSettings.maskAlpha}
-            brightness={viewerSettings.brightness}
-            density={viewerSettings.density}
-            levels={viewerSettings.levels}
-            interpolationEnabled={viewerSettings.interpolationEnabled}
-            collapsed={this.state.controlPanelClosed}
-            // functions
-            setCollapsed={this.toggleControlPanel}
-            saveIsosurface={this.saveIsosurface}
-            changeViewerSetting={this.changeViewerSetting}
-            updateChannelTransferFunction={this.updateChannelTransferFunction}
-            onApplyColorPresets={this.onApplyColorPresets}
-            makeUpdatePixelSizeFn={this.makeUpdatePixelSizeFn}
-            changeChannelSettings={this.changeChannelSettings}
-            changeOneChannelSetting={this.changeOneChannelSetting}
-            changeBackgroundColor={this.changeBackgroundColor}
-            changeBoundingBoxColor={this.changeBoundingBoxColor}
-            viewerChannelSettings={viewerChannelSettings}
-          />
-        </Sider>
-        <Layout className="cell-viewer-wrapper" style={{ margin: this.props.canvasMargin }}>
-          <Content>
-            <Toolbar
-              viewMode={viewerSettings.viewMode}
-              fovDownloadHref={fovDownloadHref}
-              cellDownloadHref={cellDownloadHref}
-              autorotate={viewerSettings.autorotate}
-              imageType={viewerSettings.imageType}
-              hasParentImage={!!this.props.fovPath}
-              hasCellId={!!this.props.cellId}
-              canPathTrace={this.state.view3d ? this.state.view3d.hasWebGL2() : false}
-              showAxes={viewerSettings.showAxes}
-              showBoundingBox={viewerSettings.showBoundingBox}
-              renderMode={viewerSettings.renderMode}
-              onViewModeChange={this.onViewModeChange}
-              onResetCamera={this.onResetCamera}
-              onAutorotateChange={this.onAutorotateChange}
-              onSwitchFovCell={this.onSwitchFovCell}
-              onChangeRenderingAlgorithm={this.onChangeRenderingAlgorithm}
-              changeAxisShowing={this.changeAxisShowing}
-              changeBoundingBoxShowing={this.changeBoundingBoxShowing}
-              downloadScreenshot={this.saveScreenshot}
-              showControls={showControls}
-            />
-            <CellViewerCanvasWrapper
-              view3d={this.state.view3d}
-              image={this.state.image}
-              setAxisClip={this.setImageAxisClip}
-              viewMode={viewerSettings.viewMode}
-              autorotate={viewerSettings.autorotate}
-              loadingImage={this.state.sendingQueryRequest}
-              numSlices={this.getNumberOfSlices()}
-              region={viewerSettings.region}
-              appHeight={this.props.appHeight}
-              showControls={showControls}
-              onClippingPanelVisibleChange={this.onClippingPanelVisibleChange}
-              onClippingPanelVisibleChangeEnd={this.onClippingPanelVisibleChangeEnd}
-            />
-          </Content>
-        </Layout>
-      </Layout>
+  // TODO wrap in useCallback?
+  const getNumberOfSlices = (): PerAxis<number> => {
+    if (image) {
+      const { x, y, z } = image;
+      return { x, y, z };
+    }
+    return { x: 0, y: 0, z: 0 };
+  };
+
+  // Effects //////////////////////////////////////////////////////////////////
+
+  // Hook to trigger image load: on mount, when `cellId` changes, when `imageType` changes
+  // TODO this should have some logic to trigger `loadFromRaw`
+  useEffect(() => void openImage(), [props.cellId, viewerSettings.imageType]);
+
+  useEffect(
+    () => props.onControlPanelToggle && props.onControlPanelToggle(controlPanelClosed),
+    [controlPanelClosed, props.onControlPanelToggle]
+  );
+
+  useEffect(() => {
+    // delayed for the animation to finish
+    void setTimeout(() => {
+      window.dispatchEvent(new Event("resize"));
+    }, 200);
+  }, [controlPanelClosed]);
+
+  // Custom hook for updating settings to view3d
+  const useViewerEffect: typeof useEffect = (effect, deps) => {
+    useEffect(() => {
+      if (imageLoaded) {
+        return effect();
+      }
+    }, [...deps!, imageLoaded]);
+  };
+
+  // Another custom hook for viewer updates that depend on `image`, so we don't have to repeatedly null-check it
+  const useImageEffect = (effect: (image: Volume) => void | (() => void), deps: ReadonlyArray<any>) => {
+    useViewerEffect(() => {
+      if (image) {
+        return effect(image);
+      }
+    }, [...deps, image]);
+  };
+
+  // Effects to imperatively sync `viewerSettings` to `view3d`
+  // TODO should all these be ImageEffects, even if not required by the API?
+
+  useViewerEffect(() => view3d.setCameraMode(viewerSettings.viewMode), [viewerSettings.viewMode]);
+  useViewerEffect(() => view3d.setAutoRotate(viewerSettings.autorotate), [viewerSettings.autorotate]);
+  useViewerEffect(() => view3d.setShowAxis(viewerSettings.showAxes), [viewerSettings.showAxes]);
+  useViewerEffect(
+    () => view3d.setBackgroundColor(colorArrayToFloats(viewerSettings.backgroundColor)),
+    [viewerSettings.backgroundColor]
+  );
+
+  useImageEffect(
+    (image) => view3d.setBoundingBoxColor(image, colorArrayToFloats(viewerSettings.boundingBoxColor)),
+    [viewerSettings.boundingBoxColor]
+  );
+  useImageEffect(
+    (image) => view3d.setShowBoundingBox(image, viewerSettings.showBoundingBox),
+    [viewerSettings.showBoundingBox]
+  );
+  useImageEffect(
+    (image) => {
+      const { renderMode } = viewerSettings;
+      view3d.setMaxProjectMode(image, renderMode === RenderMode.maxProject);
+      view3d.setVolumeRenderMode(renderMode === RenderMode.pathTrace ? RENDERMODE_PATHTRACE : RENDERMODE_RAYMARCH);
+      view3d.updateActiveChannels(image);
+    },
+    [viewerSettings.renderMode]
+  );
+  useImageEffect(
+    (image) => {
+      view3d.updateMaskAlpha(image, alphaSliderToImageValue(viewerSettings.maskAlpha));
+      view3d.updateActiveChannels(image);
+    },
+    [viewerSettings.maskAlpha]
+  );
+  useImageEffect(
+    (_image) => {
+      const isPathTracing = viewerSettings.renderMode === RenderMode.pathTrace;
+      const brightness = brightnessSliderToImageValue(viewerSettings.brightness, isPathTracing);
+      view3d.updateExposure(brightness);
+    },
+    [viewerSettings.brightness]
+  );
+  useImageEffect(
+    (image) => {
+      const isPathTracing = viewerSettings.renderMode === RenderMode.pathTrace;
+      const density = densitySliderToImageValue(viewerSettings.density, isPathTracing);
+      view3d.updateDensity(image, density);
+    },
+    [viewerSettings.density]
+  );
+  useImageEffect(
+    (image) => {
+      const imageValues = gammaSliderToImageValues(viewerSettings.levels);
+      view3d.setGamma(image, imageValues.min, imageValues.scale, imageValues.max);
+    },
+    [viewerSettings.levels]
+  );
+  useImageEffect(
+    (image) => view3d.setInterpolationEnabled(image, viewerSettings.interpolationEnabled),
+    [viewerSettings.interpolationEnabled]
+  );
+
+  const usePerAxisClippingUpdater = (axis: AxisName, [minval, maxval]: [number, number]) => {
+    useImageEffect(
+      (image) => {
+        const isOrthoAxis = activeAxisMap[viewerSettings.viewMode] === axis;
+        view3d.setAxisClip(image, axis, minval - 0.5, maxval - 0.5, isOrthoAxis);
+      },
+      [minval, maxval]
     );
-  }
-}
+  };
+  usePerAxisClippingUpdater("x", viewerSettings.region.x);
+  usePerAxisClippingUpdater("y", viewerSettings.region.y);
+  usePerAxisClippingUpdater("z", viewerSettings.region.z);
+
+  // Rendering ////////////////////////////////////////////////////////////////
+
+  const showControls = { ...defaultShownControls, ...props.showControls };
+
+  return (
+    <Layout className="cell-viewer-app" style={{ height: props.appHeight }}>
+      <Sider
+        className="control-panel-holder"
+        collapsible={true}
+        defaultCollapsed={false}
+        collapsedWidth={50}
+        trigger={null}
+        collapsed={controlPanelClosed}
+        width={500}
+      >
+        <ControlPanel
+          showControls={showControls}
+          // image state
+          imageName={image?.name}
+          imageLoaded={imageLoaded}
+          hasImage={!!image}
+          pixelSize={image ? image.pixel_size : [1, 1, 1]}
+          channelDataChannels={image?.channels}
+          channelGroupedByType={channelGroupedByType}
+          // user selections
+          pathTraceOn={viewerSettings.renderMode === RenderMode.pathTrace}
+          channelSettings={channelSettings}
+          showBoundingBox={viewerSettings.showBoundingBox}
+          backgroundColor={viewerSettings.backgroundColor}
+          boundingBoxColor={viewerSettings.boundingBoxColor}
+          maskAlpha={viewerSettings.maskAlpha}
+          brightness={viewerSettings.brightness}
+          density={viewerSettings.density}
+          levels={viewerSettings.levels}
+          interpolationEnabled={viewerSettings.interpolationEnabled}
+          collapsed={controlPanelClosed}
+          // functions
+          changeViewerSetting={changeViewerSetting}
+          setCollapsed={setControlPanelClosed}
+          saveIsosurface={saveIsosurface}
+          updateChannelTransferFunction={updateChannelTransferFunction}
+          onApplyColorPresets={applyColorPresets}
+          changeChannelSetting={changeChannelSetting}
+          changeMultipleChannelSettings={changeMultipleChannelSettings}
+          viewerChannelSettings={props.viewerChannelSettings}
+          getMetadata={getMetadata}
+        />
+      </Sider>
+      <Layout className="cell-viewer-wrapper" style={{ margin: props.canvasMargin }}>
+        <Content>
+          <Toolbar
+            viewMode={viewerSettings.viewMode}
+            fovDownloadHref={props.fovDownloadHref}
+            cellDownloadHref={props.cellDownloadHref}
+            autorotate={viewerSettings.autorotate}
+            imageType={viewerSettings.imageType}
+            hasParentImage={!!props.fovPath}
+            hasCellId={!!props.cellId}
+            canPathTrace={view3d ? view3d.hasWebGL2() : false}
+            showAxes={viewerSettings.showAxes}
+            showBoundingBox={viewerSettings.showBoundingBox}
+            renderMode={viewerSettings.renderMode}
+            resetCamera={resetCamera}
+            downloadScreenshot={saveScreenshot}
+            changeViewerSetting={changeViewerSetting}
+            showControls={showControls}
+          />
+          <CellViewerCanvasWrapper
+            view3d={view3d}
+            image={image}
+            viewMode={viewerSettings.viewMode}
+            autorotate={viewerSettings.autorotate}
+            loadingImage={sendingQueryRequest}
+            numSlices={getNumberOfSlices()}
+            region={viewerSettings.region}
+            appHeight={props.appHeight}
+            showControls={showControls}
+            changeViewerSetting={changeViewerSetting}
+            onClippingPanelVisibleChange={onClippingPanelVisibleChange}
+            onClippingPanelVisibleChangeEnd={onClippingPanelVisibleChangeEnd}
+          />
+        </Content>
+      </Layout>
+    </Layout>
+  );
+};
+
+export default App;

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -316,7 +316,6 @@ const App: React.FC<AppProps> = (props) => {
     keepLuts = false
   ): void => {
     // if we want to keep the current control points
-    // TODO this function is never called with `keepLuts = true`. Should it ever be? On FOV switch e.g.?
     if (thisChannelsSettings.controlPoints && keepLuts) {
       const lut = controlPointsToLut(thisChannelsSettings.controlPoints);
       aimg.setLut(channelIndex, lut);
@@ -388,7 +387,8 @@ const App: React.FC<AppProps> = (props) => {
   };
 
   const setChannelStateForNewImage = (channelNames: string[]): ChannelState[] | undefined => {
-    setChannelGroupedByType(makeChannelIndexGrouping(channelNames, props.viewerChannelSettings));
+    const grouping = makeChannelIndexGrouping(channelNames, props.viewerChannelSettings);
+    setChannelGroupedByType(grouping);
 
     const settingsAreEqual = channelNames.every((name, idx) => name === channelSettings[idx]?.name);
     if (settingsAreEqual) {
@@ -404,6 +404,7 @@ const App: React.FC<AppProps> = (props) => {
   };
 
   const placeImageInViewer = (aimg: Volume, newChannelSettings?: ChannelState[]): void => {
+    setImage(aimg);
     changeViewerSetting("maskAlpha", getInitialAlphaLevel());
 
     const channelSetting = newChannelSettings || channelSettings;
@@ -430,7 +431,6 @@ const App: React.FC<AppProps> = (props) => {
     const channelNames = aimg.imageInfo.channel_names;
     const newChannelSettings = setChannelStateForNewImage(channelNames);
 
-    setImage(aimg);
     setLoadedChannels(new Array(channelNames.length).fill(false));
     setCurrentlyLoadedImagePath(imageDirectory);
     changeViewerSetting("viewMode", doResetViewMode ? ViewMode.threeD : viewerSettings.viewMode);
@@ -493,12 +493,11 @@ const App: React.FC<AppProps> = (props) => {
       return initializeOneChannelSetting(aimg, channel, index, color);
     });
 
-    // Here is where we officially hand the image to the volume-viewer
-    placeImageInViewer(aimg, channelSetting);
-
-    setImage(aimg);
     setChannelGroupedByType(makeChannelIndexGrouping(rawDims.channel_names, props.viewerChannelSettings));
     setChannelSettings(channelSetting);
+
+    // Here is where we officially hand the image to the volume-viewer
+    placeImageInViewer(aimg, channelSetting);
   };
 
   // Imperative callbacks /////////////////////////////////////////////////////

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -152,8 +152,7 @@ const App: React.FC<AppProps> = (props) => {
   // State management /////////////////////////////////////////////////////////
 
   // TODO is there a better API for values that never change?
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [view3d, _setView3d] = useState(() => new View3d());
+  const [view3d] = useState(() => new View3d());
   const [image, setImage] = useState<Volume | null>(null);
 
   const getNumberOfSlices = (): PerAxis<number> => {
@@ -620,52 +619,52 @@ const App: React.FC<AppProps> = (props) => {
   // Effects to imperatively sync `viewerSettings` to `view3d`
 
   useImageEffect(
-    (_image) => {
+    (_loadedImage) => {
       view3d.setCameraMode(viewerSettings.viewMode);
       view3d.resize(null);
     },
     [viewerSettings.viewMode]
   );
 
-  useImageEffect((_image) => view3d.setAutoRotate(viewerSettings.autorotate), [viewerSettings.autorotate]);
+  useImageEffect((_currentImage) => view3d.setAutoRotate(viewerSettings.autorotate), [viewerSettings.autorotate]);
 
-  useImageEffect((_image) => view3d.setShowAxis(viewerSettings.showAxes), [viewerSettings.showAxes]);
+  useImageEffect((_currentImage) => view3d.setShowAxis(viewerSettings.showAxes), [viewerSettings.showAxes]);
 
   useImageEffect(
-    (_image) => view3d.setBackgroundColor(colorArrayToFloats(viewerSettings.backgroundColor)),
+    (_currentImage) => view3d.setBackgroundColor(colorArrayToFloats(viewerSettings.backgroundColor)),
     [viewerSettings.backgroundColor]
   );
 
   useImageEffect(
-    (image) => view3d.setBoundingBoxColor(image, colorArrayToFloats(viewerSettings.boundingBoxColor)),
+    (currentImage) => view3d.setBoundingBoxColor(currentImage, colorArrayToFloats(viewerSettings.boundingBoxColor)),
     [viewerSettings.boundingBoxColor]
   );
 
   useImageEffect(
-    (image) => view3d.setShowBoundingBox(image, viewerSettings.showBoundingBox),
+    (currentImage) => view3d.setShowBoundingBox(currentImage, viewerSettings.showBoundingBox),
     [viewerSettings.showBoundingBox]
   );
 
   useImageEffect(
-    (image) => {
+    (currentImage) => {
       const { renderMode } = viewerSettings;
-      view3d.setMaxProjectMode(image, renderMode === RenderMode.maxProject);
+      view3d.setMaxProjectMode(currentImage, renderMode === RenderMode.maxProject);
       view3d.setVolumeRenderMode(renderMode === RenderMode.pathTrace ? RENDERMODE_PATHTRACE : RENDERMODE_RAYMARCH);
-      view3d.updateActiveChannels(image);
+      view3d.updateActiveChannels(currentImage);
     },
     [viewerSettings.renderMode]
   );
 
   useImageEffect(
-    (image) => {
-      view3d.updateMaskAlpha(image, alphaSliderToImageValue(viewerSettings.maskAlpha));
-      view3d.updateActiveChannels(image);
+    (currentImage) => {
+      view3d.updateMaskAlpha(currentImage, alphaSliderToImageValue(viewerSettings.maskAlpha));
+      view3d.updateActiveChannels(currentImage);
     },
     [viewerSettings.maskAlpha]
   );
 
   useImageEffect(
-    (_image) => {
+    (_currentImage) => {
       const isPathTracing = viewerSettings.renderMode === RenderMode.pathTrace;
       const brightness = brightnessSliderToImageValue(viewerSettings.brightness, isPathTracing);
       view3d.updateExposure(brightness);
@@ -674,42 +673,42 @@ const App: React.FC<AppProps> = (props) => {
   );
 
   useImageEffect(
-    (image) => {
+    (currentImage) => {
       const isPathTracing = viewerSettings.renderMode === RenderMode.pathTrace;
       const density = densitySliderToImageValue(viewerSettings.density, isPathTracing);
-      view3d.updateDensity(image, density);
+      view3d.updateDensity(currentImage, density);
     },
     [viewerSettings.density]
   );
 
   useImageEffect(
-    (image) => {
+    (currentImage) => {
       const imageValues = gammaSliderToImageValues(viewerSettings.levels);
-      view3d.setGamma(image, imageValues.min, imageValues.scale, imageValues.max);
+      view3d.setGamma(currentImage, imageValues.min, imageValues.scale, imageValues.max);
     },
     [viewerSettings.levels]
   );
 
   useImageEffect(
-    (image) => view3d.setInterpolationEnabled(image, viewerSettings.interpolationEnabled),
+    (currentImage) => view3d.setInterpolationEnabled(currentImage, viewerSettings.interpolationEnabled),
     [viewerSettings.interpolationEnabled]
   );
 
   useImageEffect(
-    (image) => view3d.setVolumeTranslation(image, props.transform?.translation || [0, 0, 0]),
+    (currentImage) => view3d.setVolumeTranslation(currentImage, props.transform?.translation || [0, 0, 0]),
     [props.transform?.translation]
   );
 
   useImageEffect(
-    (image) => view3d.setVolumeRotation(image, props.transform?.rotation || [0, 0, 0]),
+    (currentImage) => view3d.setVolumeRotation(currentImage, props.transform?.rotation || [0, 0, 0]),
     [props.transform?.rotation]
   );
 
   const usePerAxisClippingUpdater = (axis: AxisName, [minval, maxval]: [number, number]): void => {
     useImageEffect(
-      (image) => {
+      (currentImage) => {
         const isOrthoAxis = activeAxisMap[viewerSettings.viewMode] === axis;
-        view3d.setAxisClip(image, axis, minval - 0.5, maxval - 0.5, isOrthoAxis);
+        view3d.setAxisClip(currentImage, axis, minval - 0.5, maxval - 0.5, isOrthoAxis);
       },
       [minval, maxval]
     );

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -315,7 +315,7 @@ const App: React.FC<AppProps> = (props) => {
     thisChannelsSettings: ChannelState,
     channelIndex: number,
     keepLuts = false
-  ) => {
+  ): void => {
     // if we want to keep the current control points
     // TODO this function is never called with `keepLuts = true`. Should it ever be? On FOV switch e.g.?
     if (thisChannelsSettings.controlPoints && keepLuts) {

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -262,7 +262,18 @@ const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, state, view3d, i
     }, [...deps, image, imageLoaded]);
   };
 
+  useImageEffect(
+    (image) => {
+      view3d.setVolumeChannelEnabled(image, index, volumeEnabled);
+      view3d.updateLuts(image);
+    },
+    [volumeEnabled]
+  );
+
+  useImageEffect((image) => view3d.setVolumeChannelOptions(image, index, { isosurfaceEnabled }), [isosurfaceEnabled]);
+
   useImageEffect((image) => view3d.setVolumeChannelOptions(image, index, { isovalue }), [isovalue]);
+
   useImageEffect((image) => view3d.setVolumeChannelOptions(image, index, { isosurfaceOpacity: opacity }), [opacity]);
 
   useImageEffect(

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -151,11 +151,19 @@ const App: React.FC<AppProps> = (props) => {
     return { x: 0, y: 0, z: 0 };
   };
 
-  const [sendingQueryRequest, setSendingQueryRequest] = useState(false);
-  const [imageLoaded, setImageLoaded] = useState(false);
-  const [currentlyLoadedImagePath, setCurrentlyLoadedImagePath] = useState<string | undefined>(undefined);
-  const [controlPanelClosed, setControlPanelClosed] = useState(() => window.innerWidth < CONTROL_PANEL_CLOSE_WIDTH);
+  // State for image loading/reloading
 
+  // `true` when image data has been requested, but no data has been received yet
+  const [sendingQueryRequest, setSendingQueryRequest] = useState(false);
+  // `true` when all channels of the current image are loaded
+  const [imageLoaded, setImageLoaded] = useState(false);
+  // `true` when the image being loaded is related to the previous one, so some settings should be preserved
+  const [switchingFov, setSwitchingFov] = useState(false);
+  // tracks the index of the most recently loaded channel, to trigger settings initialization
+  const [loadedChannel, setLoadedChannel] = useState<number | null>(null);
+  const [currentlyLoadedImagePath, setCurrentlyLoadedImagePath] = useState<string | undefined>(undefined);
+
+  const [controlPanelClosed, setControlPanelClosed] = useState(() => window.innerWidth < CONTROL_PANEL_CLOSE_WIDTH);
   const [channelGroupedByType, setChannelGroupedByType] = useState<ChannelGrouping>({});
 
   // These are the major parts of `App` state
@@ -210,6 +218,10 @@ const App: React.FC<AppProps> = (props) => {
       renderMode,
       autorotate: renderMode === RenderMode.pathTrace ? false : prevSettings.autorotate,
     }),
+    imageType: (prevSettings, imageType) => {
+      setSwitchingFov(true);
+      return { ...prevSettings, imageType };
+    },
     autorotate: (prevSettings, autorotate) => ({
       ...prevSettings,
       // The button should theoretically be unclickable while in pathtrace mode, but this provides extra security
@@ -258,15 +270,10 @@ const App: React.FC<AppProps> = (props) => {
     [channelSettings]
   );
 
-  const setOneChannelSetting = (
-    index: number,
-    settings: ChannelState,
-    currentChannelSettings?: ChannelState[]
-  ): ChannelState[] => {
-    const newSettings = (currentChannelSettings || channelSettings).slice();
+  const resetChannelSetting = (index: number, settings: ChannelState): void => {
+    const newSettings = channelSettings.slice();
     newSettings[index] = settings;
     setChannelSettings(newSettings);
-    return newSettings;
   };
 
   // Image loading/initialization functions ///////////////////////////////////
@@ -278,13 +285,12 @@ const App: React.FC<AppProps> = (props) => {
   const onChannelDataLoaded = (
     aimg: Volume,
     thisChannelsSettings: ChannelState,
-    channelIndex: number,
-    keepLuts?: boolean
+    channelIndex: number
   ): ChannelState => {
     let updatedChannelSettings = thisChannelsSettings;
 
     // if we want to keep the current control points
-    if (thisChannelsSettings.controlPoints && keepLuts) {
+    if (thisChannelsSettings.controlPoints && switchingFov) {
       const lut = controlPointsToLut(thisChannelsSettings.controlPoints);
       aimg.setLut(channelIndex, lut);
       view3d.updateLuts(aimg);
@@ -300,9 +306,12 @@ const App: React.FC<AppProps> = (props) => {
 
     // when any channel data has arrived:
     setSendingQueryRequest(false);
+
     if (aimg.isLoaded()) {
       view3d.updateActiveChannels(aimg);
       setImageLoaded(true);
+      setLoadedChannel(null);
+      setSwitchingFov(false);
     }
 
     return updatedChannelSettings;
@@ -394,15 +403,14 @@ const App: React.FC<AppProps> = (props) => {
     });
   };
 
-  const onNewVolumeCreated = (aimg: Volume, imageDirectory: string, doResetViewMode: boolean): ChannelState[] => {
+  const onNewVolumeCreated = (aimg: Volume, imageDirectory: string) => {
     const newChannelSettings = setChannelStateForNewImage(aimg.imageInfo.channel_names);
 
     setImage(aimg);
     setCurrentlyLoadedImagePath(imageDirectory);
-    changeViewerSetting("viewMode", doResetViewMode ? ViewMode.threeD : viewerSettings.viewMode);
+    changeViewerSetting("viewMode", switchingFov ? viewerSettings.viewMode : ViewMode.threeD);
 
     placeImageInViewer(aimg, newChannelSettings);
-    return newChannelSettings!;
   };
 
   const openImage = async (): Promise<void> => {
@@ -432,22 +440,10 @@ const App: React.FC<AppProps> = (props) => {
       loader = new OMEZarrLoader();
     }
 
-    // This keeps hold of the current channel state for the loaded channel callbacks below
-    // (because the closure captures this value at time of creation, subsequent calls wouldn't
-    // receive updates properly otherwise)
-    const settingsRef = { current: [] as ChannelState[] };
+    // NOTE: this callback runs *after* `onNewVolumeCreated` below, for every loaded channel
+    const aimg = await loader.createVolume(loadSpec, (_url, _v, channelIndex) => setLoadedChannel(channelIndex));
 
-    const aimg = await loader.createVolume(loadSpec, (_url, v, channelIndex) => {
-      // NOTE: this callback runs *after* `onNewVolumeCreated` below, for every loaded channel
-      const thisChannelSettings = getOneChannelSetting(v.imageInfo.channel_names[channelIndex], settingsRef.current);
-      const newChannelSettings = onChannelDataLoaded(v, thisChannelSettings!, channelIndex);
-      if (thisChannelSettings === newChannelSettings) return;
-      settingsRef.current = setOneChannelSetting(channelIndex, newChannelSettings, settingsRef.current);
-      // TODO: original behavior is to reset view mode on completely new image only
-      //   add state to enact this behavior
-    });
-
-    settingsRef.current = onNewVolumeCreated(aimg, path, false);
+    onNewVolumeCreated(aimg, path);
   };
 
   const loadFromRaw = (): void => {
@@ -568,6 +564,16 @@ const App: React.FC<AppProps> = (props) => {
     }
   }, [props.cellId, viewerSettings.imageType, props.rawDims, props.rawData]);
 
+  // Triggered when a single channel is loaded during the image load process
+  useEffect(() => {
+    if (image && loadedChannel !== null) {
+      const thisChannelSettings = getOneChannelSetting(image.imageInfo.channel_names[loadedChannel]);
+      const newChannelSettings = onChannelDataLoaded(image, thisChannelSettings!, loadedChannel);
+      if (thisChannelSettings === newChannelSettings) return;
+      resetChannelSetting(loadedChannel, newChannelSettings);
+    }
+  }, [image, loadedChannel]);
+
   useEffect(
     () => props.onControlPanelToggle && props.onControlPanelToggle(controlPanelClosed),
     [controlPanelClosed, props.onControlPanelToggle]
@@ -686,10 +692,10 @@ const App: React.FC<AppProps> = (props) => {
 
   return (
     <Layout className="cell-viewer-app" style={{ height: props.appHeight }}>
-      {channelSettings.map((state, index) => (
+      {channelSettings.map((channelState, index) => (
         <ChannelUpdater
-          key={`${index}_${state.name}`}
-          {...{ state, index }}
+          key={`${index}_${channelState.name}`}
+          {...{ channelState, index }}
           view3d={view3d}
           image={image}
           imageLoaded={imageLoaded}

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -62,6 +62,7 @@ import {
 import { ColorArray, colorArrayToFloats } from "../../shared/utils/colorRepresentations";
 
 import "./styles.css";
+import { debounce } from "lodash";
 
 const { Sider, Content } = Layout;
 
@@ -521,8 +522,6 @@ const App: React.FC<AppProps> = (props) => {
     [image]
   );
 
-  const resetCamera = useCallback((): void => view3d.resetCamera(), []);
-
   const saveScreenshot = useCallback((): void => {
     view3d.capture((dataUrl: string) => {
       const anchor = document.createElement("a");
@@ -531,6 +530,8 @@ const App: React.FC<AppProps> = (props) => {
       anchor.click();
     });
   }, []);
+
+  const resetCamera = useCallback((): void => view3d.resetCamera(), []);
 
   const onClippingPanelVisibleChange = useCallback(
     (open: boolean): void => {
@@ -585,6 +586,16 @@ const App: React.FC<AppProps> = (props) => {
   useEffect(() => {
     view3d.setAxisPosition(...AXIS_MARGIN_DEFAULT);
     view3d.setScaleBarPosition(...SCALE_BAR_MARGIN_DEFAULT);
+
+    const onResize = (): void => {
+      if (window.innerWidth < CONTROL_PANEL_CLOSE_WIDTH) {
+        setControlPanelClosed(true);
+      }
+    };
+    const onResizeDebounced = debounce(onResize, 500);
+
+    window.addEventListener("resize", onResizeDebounced);
+    return () => window.removeEventListener("resize", onResizeDebounced);
   }, []);
 
   // Hook to trigger image load: on mount, when `cellId` changes, when `imageType` changes

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -2,7 +2,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Layout } from "antd";
 import {
-  ControlPoint,
   IVolumeLoader,
   JsonImageInfoLoader,
   LoadSpec,
@@ -28,7 +27,6 @@ import {
   findFirstChannelMatch,
   makeChannelIndexGrouping,
   ChannelGrouping,
-  ViewerChannelSettings,
   ChannelSettingUpdater,
   MultipleChannelSettingsUpdater,
 } from "../../shared/utils/viewerChannelSettings";
@@ -43,9 +41,6 @@ import {
   LEVELS_SLIDER_DEFAULT,
   BACKGROUND_COLOR_DEFAULT,
   BOUNDING_BOX_COLOR_DEFAULT,
-  LUT_MIN_PERCENTILE,
-  LUT_MAX_PERCENTILE,
-  SINGLE_GROUP_CHANNEL_KEY,
   CONTROL_PANEL_CLOSE_WIDTH,
   INTERPOLATION_ENABLED_DEFAULT,
   AXIS_MARGIN_DEFAULT,
@@ -56,7 +51,6 @@ import ChannelUpdater from "./ChannelUpdater";
 import ControlPanel from "../ControlPanel";
 import Toolbar from "../Toolbar";
 import CellViewerCanvasWrapper from "../CellViewerCanvasWrapper";
-import { TFEDITOR_DEFAULT_COLOR } from "../TfEditor";
 
 import "../../assets/styles/globals.css";
 import {
@@ -145,6 +139,7 @@ const App: React.FC<AppProps> = (props) => {
   // State management /////////////////////////////////////////////////////////
 
   // TODO is there a better API for values that never change?
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [view3d, _setView3d] = useState(() => new View3d());
   const [image, setImage] = useState<Volume | null>(null);
 

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -284,7 +284,7 @@ const App: React.FC<AppProps> = (props) => {
   );
 
   // These last state functions are only ever used within this component - no need for a `useCallback`
-  const resetOneChannelSetting = (index: number, settings: ChannelState) => {
+  const resetOneChannelSetting = (index: number, settings: ChannelState): void => {
     const newSettings = getChannelSettings().slice();
     newSettings[index] = settings;
     setChannelSettings(newSettings);
@@ -294,7 +294,7 @@ const App: React.FC<AppProps> = (props) => {
     return (settings || getChannelSettings()).find((channel) => channel.name === channelName);
   };
 
-  const setOneChannelLoaded = (index: number) => {
+  const setOneChannelLoaded = (index: number): void => {
     const newLoadedChannels = getLoadedChannels().slice();
     newLoadedChannels[index] = true;
     setLoadedChannels(newLoadedChannels);

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -173,7 +173,7 @@ const App: React.FC<AppProps> = (props) => {
   const [switchingFov, setSwitchingFov] = useState(false);
   // tracks which channels have been loaded
   const [loadedChannels, setLoadedChannels, getLoadedChannels] = useStateWithGetter<boolean[]>([]);
-  // tracks the url of the current image, to reloading an image that is already open
+  // tracks the url of the current image, to keep us from reloading an image that is already open
   const [currentlyLoadedImagePath, setCurrentlyLoadedImagePath] = useState<string | undefined>(undefined);
 
   const [channelGroupedByType, setChannelGroupedByType] = useState<ChannelGrouping>({});
@@ -185,6 +185,9 @@ const App: React.FC<AppProps> = (props) => {
     ...defaultViewerSettings,
     ...props.viewerSettings,
   }));
+  // `channelSettings` gets a getter to break through stale closures when loading images.
+  // (`openImage` creates a closure to call back whenever a new channel is loaded, which sets this state.
+  // To do this it requires access to the current state value, not the one it closed over)
   const [channelSettings, setChannelSettings, getChannelSettings] = useStateWithGetter<ChannelState[]>([]);
 
   // Some viewer settings require custom change behaviors to guard against entering an illegal state.

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -405,7 +405,6 @@ const App: React.FC<AppProps> = (props) => {
 
   const placeImageInViewer = (aimg: Volume, newChannelSettings?: ChannelState[]): void => {
     setImage(aimg);
-    changeViewerSetting("maskAlpha", getInitialAlphaLevel());
 
     const channelSetting = newChannelSettings || channelSettings;
     view3d.removeAllVolumes();
@@ -425,6 +424,10 @@ const App: React.FC<AppProps> = (props) => {
         };
       }),
     });
+
+    const initialAlpha = getInitialAlphaLevel();
+    changeViewerSetting("maskAlpha", initialAlpha);
+    view3d.updateMaskAlpha(aimg, alphaSliderToImageValue(initialAlpha));
   };
 
   const onNewVolumeCreated = (aimg: Volume, imageDirectory: string, doResetViewMode: boolean): void => {

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -188,7 +188,8 @@ const App: React.FC<AppProps> = (props) => {
 
       if (activeAxis) {
         // switching to 2d
-        newSettings.region[activeAxis] = [0, 1 / getNumberOfSlices()[activeAxis]];
+        const slices = Math.max(1, getNumberOfSlices()[activeAxis]);
+        newSettings.region[activeAxis] = [0, 1 / slices];
         if (prevSettings.viewMode === ViewMode.threeD) {
           // Switching from 3D to 2D
           newSettings.maskAlpha = ALPHA_MASK_SLIDER_2D_DEFAULT;

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -264,7 +264,13 @@ const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, state, view3d, i
 
   useImageEffect((image) => view3d.setVolumeChannelOptions(image, index, { isovalue }), [isovalue]);
   useImageEffect((image) => view3d.setVolumeChannelOptions(image, index, { isosurfaceOpacity: opacity }), [opacity]);
-  useImageEffect((image) => view3d.setVolumeChannelOptions(image, index, { color }), [color]);
+  useImageEffect(
+    (image) => {
+      view3d.setVolumeChannelOptions(image, index, { color });
+      view3d.updateLuts(image);
+    },
+    [color]
+  );
 
   useImageEffect(
     (image) => {
@@ -574,7 +580,7 @@ const App: React.FC<AppProps> = (props) => {
     (index: number, lut: Uint8Array): void => {
       if (image) {
         image.setLut(index, lut);
-        view3d?.updateLuts(image);
+        view3d.updateLuts(image);
       }
     },
     [image]

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -264,6 +264,7 @@ const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, state, view3d, i
 
   useImageEffect((image) => view3d.setVolumeChannelOptions(image, index, { isovalue }), [isovalue]);
   useImageEffect((image) => view3d.setVolumeChannelOptions(image, index, { isosurfaceOpacity: opacity }), [opacity]);
+
   useImageEffect(
     (image) => {
       view3d.setVolumeChannelOptions(image, index, { color });
@@ -285,6 +286,15 @@ const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, state, view3d, i
       view3d.updateLuts(image);
     },
     [colorizeEnabled]
+  );
+
+  useImageEffect(
+    (image) => {
+      const gradient = controlPointsToLut(controlPoints);
+      image.setLut(index, gradient);
+      view3d.updateLuts(image);
+    },
+    [controlPoints]
   );
 
   useImageEffect(
@@ -575,17 +585,6 @@ const App: React.FC<AppProps> = (props) => {
     [image]
   );
 
-  // TODO should this be a per-channel effect?
-  const updateChannelTransferFunction = useCallback(
-    (index: number, lut: Uint8Array): void => {
-      if (image) {
-        image.setLut(index, lut);
-        view3d.updateLuts(image);
-      }
-    },
-    [image]
-  );
-
   const resetCamera = useCallback((): void => view3d.resetCamera(), []);
 
   const saveScreenshot = useCallback((): void => {
@@ -814,7 +813,6 @@ const App: React.FC<AppProps> = (props) => {
           changeViewerSetting={changeViewerSetting}
           setCollapsed={setControlPanelClosed}
           saveIsosurface={saveIsosurface}
-          updateChannelTransferFunction={updateChannelTransferFunction}
           onApplyColorPresets={applyColorPresets}
           changeChannelSetting={changeChannelSetting}
           changeMultipleChannelSettings={changeMultipleChannelSettings}

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -241,11 +241,7 @@ const App: React.FC<AppProps> = (props) => {
     },
     imageType: (prevSettings, imageType) => {
       setSwitchingFov(true);
-      return {
-        ...prevSettings,
-        imageType,
-        maskAlpha: getInitialAlphaLevel(),
-      };
+      return { ...prevSettings, imageType };
     },
     renderMode: (prevSettings, renderMode) => ({
       ...prevSettings,
@@ -422,9 +418,12 @@ const App: React.FC<AppProps> = (props) => {
   };
 
   const placeImageInViewer = (aimg: Volume, newChannelSettings?: ChannelState[]): void => {
+    changeViewerSetting("maskAlpha", getInitialAlphaLevel());
+
     const channelSetting = newChannelSettings || channelSettings;
     view3d.removeAllVolumes();
     view3d.addVolume(aimg, {
+      // TODO this initialization may not be necessary, but should be tested against `loadFromRaw` case before removal
       channels: aimg.channel_names.map((name) => {
         const ch = getOneChannelSetting(name, channelSetting);
         if (!ch) {
@@ -518,7 +517,6 @@ const App: React.FC<AppProps> = (props) => {
     setImage(aimg);
     setChannelGroupedByType(channelGroupedByType);
     setChannelSettings(channelSetting);
-    changeViewerSetting("maskAlpha", getInitialAlphaLevel());
   };
 
   // Imperative callbacks /////////////////////////////////////////////////////

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -614,7 +614,7 @@ const App: React.FC<AppProps> = (props) => {
 
   useEffect(() => {
     // delayed for the animation to finish
-    void setTimeout(() => {
+    window.setTimeout(() => {
       window.dispatchEvent(new Event("resize"));
     }, 200);
   }, [controlPanelClosed]);
@@ -704,6 +704,16 @@ const App: React.FC<AppProps> = (props) => {
   useImageEffect(
     (image) => view3d.setInterpolationEnabled(image, viewerSettings.interpolationEnabled),
     [viewerSettings.interpolationEnabled]
+  );
+
+  useImageEffect(
+    (image) => view3d.setVolumeTranslation(image, props.transform?.translation || [0, 0, 0]),
+    [props.transform?.translation]
+  );
+
+  useImageEffect(
+    (image) => view3d.setVolumeRotation(image, props.transform?.rotation || [0, 0, 0]),
+    [props.transform?.rotation]
   );
 
   const usePerAxisClippingUpdater = (axis: AxisName, [minval, maxval]: [number, number]): void => {

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -82,7 +82,7 @@ export type ViewerSettingsKey = keyof GlobalViewerSettings;
 export type ViewerSettingChangeHandlers = {
   [K in ViewerSettingsKey]?: (settings: GlobalViewerSettings, value: GlobalViewerSettings[K]) => GlobalViewerSettings;
 };
-export type ViewerSettingUpdater = <K extends ViewerSettingsKey>(type: K, value: GlobalViewerSettings[K]) => void;
+export type ViewerSettingUpdater = <K extends ViewerSettingsKey>(key: K, value: GlobalViewerSettings[K]) => void;
 
 export interface AppState {
   view3d: View3d;

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -77,7 +77,7 @@ export interface AppProps {
 
 export type ViewerSettingsKey = keyof GlobalViewerSettings;
 export type ViewerSettingChangeHandlers = {
-  [K in ViewerSettingsKey]?: (value: GlobalViewerSettings[K], view3d: View3d, image: Volume) => void;
+  [K in ViewerSettingsKey]?: (settings: GlobalViewerSettings, value: GlobalViewerSettings[K]) => GlobalViewerSettings;
 };
 export type ViewerSettingUpdater = <K extends ViewerSettingsKey>(type: K, value: GlobalViewerSettings[K]) => void;
 

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -79,6 +79,7 @@ export type ViewerSettingsKey = keyof GlobalViewerSettings;
 export type ViewerSettingChangeHandlers = {
   [K in ViewerSettingsKey]?: (value: GlobalViewerSettings[K], view3d: View3d, image: Volume) => void;
 };
+export type ViewerSettingUpdater = <K extends ViewerSettingsKey>(type: K, value: GlobalViewerSettings[K]) => void;
 
 export interface AppState {
   view3d: View3d;
@@ -94,7 +95,7 @@ export interface AppState {
   // global (not per-channel) state set by the UI:
   viewerSettings: GlobalViewerSettings;
   // channelSettings is a flat list of objects of this type:
-  // { name, enabled, volumeEnabled, isosurfaceEnabled, isovalue, opacity, color, dataReady}
+  // { name, enabled, volumeEnabled, isosurfaceEnabled, isovalue, opacity, color}
   // the list is in the order they were in the raw data.
   channelSettings: ChannelState[];
 }

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -4,6 +4,9 @@ import { PerAxis, MetadataRecord } from "../../shared/types";
 import { ColorArray } from "../../shared/utils/colorRepresentations";
 import { ChannelGrouping, ChannelState, ViewerChannelSettings } from "../../shared/utils/viewerChannelSettings";
 
+/** `typeof useEffect`, but the effect handler takes a `Volume` as an argument */
+export type UseImageEffectType = (effect: (image: Volume) => void | (() => void), deps: ReadonlyArray<any>) => void;
+
 type ControlNames =
   | "alphaMaskSlider"
   | "autoRotateButton"

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -93,8 +93,8 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     const { playing } = this.state;
     const numSlices = this.props.numSlices[axis];
     const clipVals = this.props.region[axis];
-    const sliderVals = [Math.round(clipVals[0] * numSlices), Math.round(clipVals[1] * numSlices)];
-    const range = { min: 0, max: numSlices - 1 };
+    const sliderVals = [Math.floor(clipVals[0] * numSlices), Math.floor(clipVals[1] * numSlices)];
+    const range = { min: 0, max: numSlices };
     const callback = this.makeSliderCallback(axis);
 
     return (
@@ -106,6 +106,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
               range={range}
               start={twoD ? [sliderVals[0]] : sliderVals}
               step={1}
+              margin={1}
               behaviour="drag"
               // round slider output to nearest slice; assume any string inputs represent ints
               format={{ to: Math.round, from: parseInt }}
@@ -117,7 +118,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
           <span className="slider-slices">
             {twoD
               ? `${sliderVals[0]} (${numSlices})`
-              : `${sliderVals[0]}, ${sliderVals[1]} (${sliderVals[1] - sliderVals[0] + 1})`}
+              : `${sliderVals[0]}, ${sliderVals[1]} (${sliderVals[1] - sliderVals[0]})`}
           </span>
         </span>
         {twoD && (
@@ -141,6 +142,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     const { changeViewerSetting, numSlices, region } = this.props;
     // get a value from -0.5..0.5
     const max = numSlices[axis];
+    console.log(minval, maxval, max);
     const start = minval / max;
     const end = maxval / max;
     changeViewerSetting("region", { ...region, [axis]: [start, end] });

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import "./styles.css";
 
 import { ViewMode } from "../../shared/enums";
+import { ViewerSettingUpdater } from "../App/types";
 import { AxisName, PerAxis, activeAxisMap } from "../../shared/types";
 
 const AXES: AxisName[] = ["x", "y", "z"];
@@ -13,7 +14,7 @@ const PLAY_RATE_MS_PER_STEP = 125;
 
 interface AxisClipSlidersProps {
   mode: ViewMode;
-  setAxisClip: (axis: AxisName, minval: number, maxval: number, isOrthoAxis: boolean) => void;
+  changeViewerSetting: ViewerSettingUpdater;
   numSlices: PerAxis<number>;
   region: PerAxis<[number, number]>;
 }
@@ -137,14 +138,12 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
   }
 
   updateClipping(axis: AxisName, minval: number, maxval: number): void {
-    if (this.props.setAxisClip) {
-      // get a value from -0.5..0.5
-      const max = this.props.numSlices[axis];
-      const start = minval / max;
-      const end = (maxval + 1) / max;
-      const isActiveAxis = this.getActiveAxis() === axis;
-      this.props.setAxisClip(axis, start, end, isActiveAxis);
-    }
+    const { changeViewerSetting, numSlices, region } = this.props;
+    // get a value from -0.5..0.5
+    const max = numSlices[axis];
+    const start = minval / max;
+    const end = (maxval + 1) / max;
+    changeViewerSetting("region", { ...region, [axis]: [start, end] });
   }
 
   makeSliderCallback(axis: AxisName): (values: number[]) => void {

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -142,7 +142,6 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     const { changeViewerSetting, numSlices, region } = this.props;
     // get a value from -0.5..0.5
     const max = numSlices[axis];
-    console.log(minval, maxval, max);
     const start = minval / max;
     const end = maxval / max;
     changeViewerSetting("region", { ...region, [axis]: [start, end] });

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -142,7 +142,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     // get a value from -0.5..0.5
     const max = numSlices[axis];
     const start = minval / max;
-    const end = (maxval + 1) / max;
+    const end = maxval / max;
     changeViewerSetting("region", { ...region, [axis]: [start, end] });
   }
 

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -93,8 +93,8 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     const { playing } = this.state;
     const numSlices = this.props.numSlices[axis];
     const clipVals = this.props.region[axis];
-    const sliderVals = [Math.floor(clipVals[0] * numSlices), Math.floor(clipVals[1] * numSlices)];
-    const range = { min: 0, max: numSlices };
+    const sliderVals = [Math.round(clipVals[0] * numSlices), Math.round(clipVals[1] * numSlices)];
+    const range = { min: 0, max: numSlices - (twoD ? 1 : 0) };
     const callback = this.makeSliderCallback(axis);
 
     return (
@@ -148,8 +148,10 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
   }
 
   makeSliderCallback(axis: AxisName): (values: number[]) => void {
-    // Values may be of length 1 (2d, single-slice) or 2 (3d, slice range); ensure we pass 2 values regardless
-    return (values: number[]) => this.updateClipping(axis, values[0], values[values.length - 1]);
+    return (values: number[]) => {
+      const max = values.length < 2 ? values[0] + 1 : values[1];
+      this.updateClipping(axis, values[0], max);
+    };
   }
 
   render(): React.ReactNode {

--- a/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
+++ b/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
@@ -5,6 +5,7 @@ import { Icon } from "antd";
 
 import { AxisName, PerAxis, Styles } from "../../shared/types";
 import { ViewMode } from "../../shared/enums";
+import { ViewerSettingUpdater } from "../App/types";
 
 import AxisClipSliders from "../AxisClipSliders";
 import BottomPanel from "../BottomPanel";
@@ -22,7 +23,7 @@ interface ViewerWrapperProps {
   showControls: {
     axisClipSliders: boolean;
   };
-  setAxisClip: (axis: AxisName, minval: number, maxval: number, isOrthoAxis: boolean) => void;
+  changeViewerSetting: ViewerSettingUpdater;
   onClippingPanelVisibleChange?: (open: boolean) => void;
   onClippingPanelVisibleChangeEnd?: (open: boolean) => void;
 }
@@ -42,14 +43,7 @@ export default class ViewerWrapper extends React.Component<ViewerWrapperProps, V
     this.props.view3d.setAutoRotate(this.props.autorotate);
   }
 
-  componentDidUpdate(prevProps: ViewerWrapperProps, _prevState: ViewerWrapperState): void {
-    if (prevProps.viewMode && prevProps.viewMode !== this.props.viewMode) {
-      this.props.view3d.setCameraMode(this.props.viewMode);
-    }
-    if (prevProps.autorotate !== this.props.autorotate) {
-      this.props.view3d.setAutoRotate(this.props.autorotate);
-    }
-
+  componentDidUpdate(_prevProps: ViewerWrapperProps, _prevState: ViewerWrapperState): void {
     this.props.view3d.resize(null);
   }
 
@@ -69,7 +63,7 @@ export default class ViewerWrapper extends React.Component<ViewerWrapperProps, V
   }
 
   render(): React.ReactNode {
-    const { appHeight, showControls, image, numSlices, viewMode, setAxisClip, region } = this.props;
+    const { appHeight, changeViewerSetting, showControls, image, numSlices, viewMode, region } = this.props;
     return (
       <div className="cell-canvas" style={{ ...STYLES.viewer, height: appHeight }}>
         <div ref={this.view3dviewerRef} style={STYLES.view3d}></div>
@@ -79,7 +73,12 @@ export default class ViewerWrapper extends React.Component<ViewerWrapperProps, V
           onVisibleChangeEnd={this.props.onClippingPanelVisibleChangeEnd}
         >
           {showControls.axisClipSliders && !!image && (
-            <AxisClipSliders mode={viewMode} setAxisClip={setAxisClip} numSlices={numSlices} region={region} />
+            <AxisClipSliders
+              mode={viewMode}
+              changeViewerSetting={changeViewerSetting}
+              numSlices={numSlices}
+              region={region}
+            />
           )}
         </BottomPanel>
         {this.renderOverlay()}

--- a/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
+++ b/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
@@ -3,7 +3,7 @@ import { View3d, Volume } from "@aics/volume-viewer";
 
 import { Icon } from "antd";
 
-import { AxisName, PerAxis, Styles } from "../../shared/types";
+import { PerAxis, Styles } from "../../shared/types";
 import { ViewMode } from "../../shared/enums";
 import { ViewerSettingUpdater } from "../App/types";
 

--- a/src/aics-image-viewer/components/ChannelsWidget/index.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidget/index.tsx
@@ -34,7 +34,6 @@ export interface ChannelsWidgetProps {
 
   saveIsosurface: (channelIndex: number, type: IsosurfaceFormat) => void;
   onApplyColorPresets: (presets: ColorArray[]) => void;
-  updateChannelTransferFunction: (index: number, lut: Uint8Array) => void;
 
   filterFunc?: (key: string) => boolean;
   onColorChangeComplete?: (newRGB: ColorObject, oldRGB?: ColorObject, index?: number) => void;
@@ -131,7 +130,6 @@ export default class ChannelsWidget extends React.Component<ChannelsWidgetProps,
                       colorizeEnabled={thisChannelSettings.colorizeEnabled}
                       colorizeAlpha={thisChannelSettings.colorizeAlpha}
                       color={thisChannelSettings.color}
-                      updateChannelTransferFunction={this.props.updateChannelTransferFunction}
                       changeChannelSetting={this.props.changeChannelSetting}
                       onColorChangeComplete={this.props.onColorChangeComplete}
                       saveIsosurface={this.props.saveIsosurface}

--- a/src/aics-image-viewer/components/ChannelsWidget/index.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidget/index.tsx
@@ -3,7 +3,12 @@ import { map, find } from "lodash";
 import { Card, Collapse, List } from "antd";
 import { Channel } from "@aics/volume-viewer";
 
-import { ChannelGrouping, getDisplayName } from "../../shared/utils/viewerChannelSettings";
+import {
+  ChannelGrouping,
+  ChannelSettingUpdater,
+  getDisplayName,
+  MultipleChannelSettingsUpdater,
+} from "../../shared/utils/viewerChannelSettings";
 
 import colorPalette from "../../shared/colorPalette";
 import SharedCheckBox from "../shared/SharedCheckBox";
@@ -18,24 +23,16 @@ import { ColorArray, ColorObject } from "../../shared/utils/colorRepresentations
 import { IsosurfaceFormat, Styles } from "../../shared/types";
 
 export interface ChannelsWidgetProps {
-  imageName: string | undefined;
+  imageLoaded: boolean;
   channelDataChannels: Channel[] | undefined;
   channelSettings: ChannelState[];
   channelGroupedByType: ChannelGrouping;
   viewerChannelSettings?: ViewerChannelSettings;
 
+  changeChannelSetting: ChannelSettingUpdater;
+  changeMultipleChannelSettings: MultipleChannelSettingsUpdater;
+
   saveIsosurface: (channelIndex: number, type: IsosurfaceFormat) => void;
-  changeChannelSettings: <K extends ChannelStateKey>(
-    indices: number[],
-    keyToChange: K,
-    newValue: ChannelState[K]
-  ) => void;
-  changeOneChannelSetting: <K extends ChannelStateKey>(
-    channelName: string,
-    channelIndex: number,
-    keyToChange: K,
-    newValue: ChannelState[K]
-  ) => void;
   onApplyColorPresets: (presets: ColorArray[]) => void;
   updateChannelTransferFunction: (index: number, lut: Uint8Array) => void;
 
@@ -49,7 +46,7 @@ export default class ChannelsWidget extends React.Component<ChannelsWidgetProps,
   }
 
   createCheckboxHandler = (key: ChannelStateKey, value: boolean) => (channelArray: number[]) => {
-    this.props.changeChannelSettings(channelArray, key, value);
+    this.props.changeMultipleChannelSettings(channelArray, key, value);
   };
 
   showVolumes = this.createCheckboxHandler("volumeEnabled", true);
@@ -97,7 +94,7 @@ export default class ChannelsWidget extends React.Component<ChannelsWidgetProps,
   }
 
   getRows(): React.ReactNode {
-    const { channelGroupedByType, channelSettings, channelDataChannels, filterFunc, imageName, viewerChannelSettings } =
+    const { channelGroupedByType, channelSettings, channelDataChannels, filterFunc, viewerChannelSettings } =
       this.props;
 
     if (channelDataChannels === undefined) {
@@ -126,8 +123,6 @@ export default class ChannelsWidget extends React.Component<ChannelsWidgetProps,
                     <ChannelsWidgetRow
                       key={`${actualIndex}_${thisChannelSettings.name}_${actualIndex}`}
                       index={actualIndex}
-                      imageName={imageName}
-                      channelName={thisChannelSettings.name}
                       channelDataForChannel={channelDataChannels[actualIndex]}
                       name={getDisplayName(thisChannelSettings.name, actualIndex, viewerChannelSettings)}
                       volumeChecked={thisChannelSettings.volumeEnabled}
@@ -137,7 +132,7 @@ export default class ChannelsWidget extends React.Component<ChannelsWidgetProps,
                       colorizeAlpha={thisChannelSettings.colorizeAlpha}
                       color={thisChannelSettings.color}
                       updateChannelTransferFunction={this.props.updateChannelTransferFunction}
-                      changeOneChannelSetting={this.props.changeOneChannelSetting}
+                      changeChannelSetting={this.props.changeChannelSetting}
                       onColorChangeComplete={this.props.onColorChangeComplete}
                       saveIsosurface={this.props.saveIsosurface}
                     />

--- a/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
@@ -37,7 +37,6 @@ interface ChannelsWidgetRowProps {
   changeChannelSetting: ChannelSettingUpdater;
 
   saveIsosurface: (channelIndex: number, type: IsosurfaceFormat) => void;
-  updateChannelTransferFunction: (index: number, lut: Uint8Array) => void;
   onColorChangeComplete?: (newRGB: ColorObject, oldRGB?: ColorObject, index?: number) => void;
 }
 
@@ -146,14 +145,7 @@ export default class ChannelsWidgetRow extends React.Component<ChannelsWidgetRow
   ];
 
   createTFEditor(): React.ReactNode {
-    const {
-      channelControlPoints,
-      channelDataForChannel,
-      colorizeEnabled,
-      colorizeAlpha,
-      updateChannelTransferFunction,
-      index,
-    } = this.props;
+    const { channelControlPoints, channelDataForChannel, colorizeEnabled, colorizeAlpha, index } = this.props;
     return (
       <TfEditor
         id={"TFEditor" + index}
@@ -164,7 +156,6 @@ export default class ChannelsWidgetRow extends React.Component<ChannelsWidgetRow
         volumeData={channelDataForChannel.volumeData}
         channelData={channelDataForChannel}
         controlPoints={channelControlPoints}
-        updateChannelTransferFunction={updateChannelTransferFunction}
         updateChannelLutControlPoints={this.createChannelSettingHandler("controlPoints")}
         updateColorizeMode={this.createChannelSettingHandler("colorizeEnabled")}
         updateColorizeAlpha={this.createChannelSettingHandler("colorizeAlpha")}

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -105,14 +105,14 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
             <div className="channel-rows-list">
               {tab === ControlTab.Channels && (
                 <ChannelsWidget
-                  imageName={props.imageName}
+                  imageLoaded={props.imageLoaded}
                   channelSettings={props.channelSettings}
                   channelDataChannels={props.channelDataChannels}
                   channelGroupedByType={props.channelGroupedByType}
-                  changeChannelSettings={props.changeChannelSettings}
+                  changeMultipleChannelSettings={props.changeMultipleChannelSettings}
                   saveIsosurface={props.saveIsosurface}
                   updateChannelTransferFunction={props.updateChannelTransferFunction}
-                  changeOneChannelSetting={props.changeOneChannelSetting}
+                  changeChannelSetting={props.changeChannelSetting}
                   onColorChangeComplete={props.onColorChangeComplete}
                   onApplyColorPresets={props.onApplyColorPresets}
                   filterFunc={props.filterFunc}
@@ -125,7 +125,6 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
                     imageName={props.imageName}
                     pixelSize={props.pixelSize}
                     changeViewerSetting={props.changeViewerSetting}
-                    makeUpdatePixelSizeFn={props.makeUpdatePixelSizeFn}
                     maskAlpha={props.maskAlpha}
                     brightness={props.brightness}
                     density={props.density}
@@ -138,8 +137,7 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
                     <CustomizeWidget
                       backgroundColor={props.backgroundColor}
                       boundingBoxColor={props.boundingBoxColor}
-                      changeBackgroundColor={props.changeBackgroundColor}
-                      changeBoundingBoxColor={props.changeBoundingBoxColor}
+                      changeViewerSetting={props.changeViewerSetting}
                       showBoundingBox={props.showBoundingBox}
                       showControls={props.showControls}
                     />

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -111,7 +111,6 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
                   channelGroupedByType={props.channelGroupedByType}
                   changeMultipleChannelSettings={props.changeMultipleChannelSettings}
                   saveIsosurface={props.saveIsosurface}
-                  updateChannelTransferFunction={props.updateChannelTransferFunction}
                   changeChannelSetting={props.changeChannelSetting}
                   onColorChangeComplete={props.onColorChangeComplete}
                   onApplyColorPresets={props.onApplyColorPresets}

--- a/src/aics-image-viewer/components/CustomizeWidget.tsx
+++ b/src/aics-image-viewer/components/CustomizeWidget.tsx
@@ -2,19 +2,23 @@ import React from "react";
 import { Card, Collapse } from "antd";
 
 import ColorPicker from "./ColorPicker";
-import { ColorArray, ColorObject, colorArrayToObject } from "../shared/utils/colorRepresentations";
+import { ColorArray, colorArrayToObject, colorObjectToArray } from "../shared/utils/colorRepresentations";
 import { Styles } from "../shared/types";
+import { ViewerSettingUpdater } from "./App/types";
 
-type ColorChangeHandler = (color: ColorObject) => void;
-
-const ColorPickerRow: React.FC<{ color: ColorArray; onColorChange: ColorChangeHandler }> = ({
+const ColorPickerRow: React.FC<{ color: ColorArray; onColorChange: (color: ColorArray) => void }> = ({
   color,
   onColorChange,
   children,
 }) => (
   <div style={STYLES.colorPickerRow}>
     <span style={STYLES.colorPicker}>
-      <ColorPicker color={colorArrayToObject(color)} onColorChange={onColorChange} width={18} disableAlpha={true} />
+      <ColorPicker
+        color={colorArrayToObject(color)}
+        onColorChange={(color) => onColorChange(colorObjectToArray(color))}
+        width={18}
+        disableAlpha={true}
+      />
     </span>
     <span>{children}</span>
   </div>
@@ -25,8 +29,7 @@ export interface CustomizeWidgetProps {
   backgroundColor: ColorArray;
   boundingBoxColor: ColorArray;
 
-  changeBackgroundColor: ColorChangeHandler;
-  changeBoundingBoxColor: ColorChangeHandler;
+  changeViewerSetting: ViewerSettingUpdater;
 
   showControls: {
     backgroundColorPicker: boolean;
@@ -39,12 +42,18 @@ const CustomizeWidget: React.FC<CustomizeWidgetProps> = (props) => (
     <Collapse bordered={false} defaultActiveKey="color-customization">
       <Collapse.Panel key="color-customization" header={null}>
         {props.showControls.backgroundColorPicker && (
-          <ColorPickerRow color={props.backgroundColor} onColorChange={props.changeBackgroundColor}>
+          <ColorPickerRow
+            color={props.backgroundColor}
+            onColorChange={(color) => props.changeViewerSetting("backgroundColor", color)}
+          >
             Background color
           </ColorPickerRow>
         )}
         {props.showControls.boundingBoxColorPicker && (
-          <ColorPickerRow color={props.boundingBoxColor} onColorChange={props.changeBoundingBoxColor}>
+          <ColorPickerRow
+            color={props.boundingBoxColor}
+            onColorChange={(color) => props.changeViewerSetting("boundingBoxColor", color)}
+          >
             Bounding box color
             {!props.showBoundingBox && <i> - bounding box turned off</i>}
           </ColorPickerRow>

--- a/src/aics-image-viewer/components/GlobalVolumeControls.tsx
+++ b/src/aics-image-viewer/components/GlobalVolumeControls.tsx
@@ -3,8 +3,8 @@ import Nouislider from "nouislider-react";
 import "nouislider/distribute/nouislider.css";
 
 import { Card, Collapse, Checkbox } from "antd";
-import { ViewerSettingsKey, GlobalViewerSettings } from "./App/types";
-import { AxisName, Styles } from "../shared/types";
+import { ViewerSettingUpdater } from "./App/types";
+import { Styles } from "../shared/types";
 const Panel = Collapse.Panel;
 
 type GlobalVolumeControlKey = "maskAlpha" | "brightness" | "density" | "levels";
@@ -27,8 +27,7 @@ export interface GlobalVolumeControlsProps {
   levels: [number, number, number];
   interpolationEnabled: boolean;
 
-  changeViewerSetting: <K extends ViewerSettingsKey>(key: K, newValue: GlobalViewerSettings[K]) => void;
-  makeUpdatePixelSizeFn: (i: number) => void;
+  changeViewerSetting: ViewerSettingUpdater;
 }
 
 export default class GlobalVolumeControls extends React.Component<GlobalVolumeControlsProps, {}> {

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -33,7 +33,6 @@ interface MyTfEditorProps {
   volumeData: Uint8Array;
   channelData: Channel;
   controlPoints: ControlPoint[];
-  updateChannelTransferFunction: (index: number, lut: Uint8Array) => void;
   updateChannelLutControlPoints: (controlPoints: ControlPoint[]) => void;
   updateColorizeMode: (colorizeEnabled: boolean) => void;
   updateColorizeAlpha: (colorizeAlpha: number) => void;
@@ -489,14 +488,6 @@ export default class MyTfEditor extends React.Component<MyTfEditorProps, MyTfEdi
 
     // Draw gradient in canvas and update image
     this.drawCanvas();
-    this.updateImage();
-  }
-
-  private updateImage(): void {
-    const { controlPoints, index } = this.props;
-    const opacityGradient = controlPointsToLut(controlPoints);
-    // send update to image rendering
-    this.props.updateChannelTransferFunction(index, opacityGradient);
   }
 
   /**

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -28,7 +28,6 @@ type Pair = [number, number];
 interface MyTfEditorProps {
   id: string;
   index: number;
-  imageName: string | undefined;
   width: number;
   height: number;
   volumeData: Uint8Array;

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -10,7 +10,6 @@ import "./styles.css";
 import { Button, Checkbox } from "antd";
 
 import { LUT_MIN_PERCENTILE, LUT_MAX_PERCENTILE } from "../../shared/constants";
-import { controlPointsToLut } from "../../shared/utils/controlPointsToLut";
 import {
   ColorArray,
   colorArrayToObject,

--- a/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
+++ b/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
@@ -1,6 +1,9 @@
 import colorString from "color-string";
-import { ControlPoint } from "@aics/volume-viewer";
+import { ControlPoint, Volume } from "@aics/volume-viewer";
 import { ColorArray } from "./colorRepresentations";
+import { findFirstChannelMatch, ViewerChannelSettings } from "./viewerChannelSettings";
+import { LUT_MAX_PERCENTILE, LUT_MIN_PERCENTILE } from "../constants";
+import { TFEDITOR_DEFAULT_COLOR } from "../../components/TfEditor";
 
 const canv = document.createElement("canvas");
 canv.width = 256;
@@ -49,4 +52,57 @@ export function controlPointsToLut(controlPoints: ControlPoint[]): Uint8Array {
   ctx.fillRect(0, 0, 256, 1);
   const imgData = ctx.getImageData(0, 0, 256, 1);
   return new Uint8Array(imgData.data.buffer);
+}
+
+export function initializeLut(
+  aimg: Volume,
+  channelIndex: number,
+  channelSettings?: ViewerChannelSettings
+): ControlPoint[] {
+  const histogram = aimg.getHistogram(channelIndex);
+
+  // find channelIndex among viewerChannelSettings.
+  const name = aimg.channel_names[channelIndex];
+  // default to percentiles
+  let lutObject = histogram.lutGenerator_percentiles(LUT_MIN_PERCENTILE, LUT_MAX_PERCENTILE);
+  // and if init settings dictate, recompute it:
+  if (channelSettings) {
+    const initSettings = findFirstChannelMatch(name, channelIndex, channelSettings);
+    if (initSettings) {
+      if (initSettings.lut !== undefined && initSettings.lut.length === 2) {
+        let lutmod = "";
+        let lvalue = 0;
+        let lutvalues = [0, 0];
+        for (let i = 0; i < 2; ++i) {
+          const lstr = initSettings.lut[i];
+          // look at first char of string.
+          let firstchar = lstr.charAt(0);
+          if (firstchar === "m" || firstchar === "p") {
+            lutmod = firstchar;
+            lvalue = parseFloat(lstr.substring(1)) / 100.0;
+          } else {
+            lutmod = "";
+            lvalue = parseFloat(lstr);
+          }
+          if (lutmod === "m") {
+            lutvalues[i] = histogram.maxBin * lvalue;
+          } else if (lutmod === "p") {
+            lutvalues[i] = histogram.findBinOfPercentile(lvalue);
+          }
+        }
+
+        lutObject = histogram.lutGenerator_minMax(
+          Math.min(lutvalues[0], lutvalues[1]),
+          Math.max(lutvalues[0], lutvalues[1])
+        );
+      }
+    }
+  }
+
+  const newControlPoints = lutObject.controlPoints.map((controlPoint) => ({
+    ...controlPoint,
+    color: TFEDITOR_DEFAULT_COLOR,
+  }));
+  aimg.setLut(channelIndex, lutObject.lut);
+  return newControlPoints;
 }

--- a/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
+++ b/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
@@ -88,6 +88,8 @@ export function initializeLut(
             lutvalues[i] = histogram.maxBin * lvalue;
           } else if (lutmod === "p") {
             lutvalues[i] = histogram.findBinOfPercentile(lvalue);
+          } else {
+            lutvalues[i] = lvalue;
           }
         }
 

--- a/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
+++ b/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
@@ -135,7 +135,15 @@ export function getDisplayName(name: string, index: number, settings?: ViewerCha
   return name;
 }
 
-export function makeChannelIndexGrouping(channels: string[], settings: ViewerChannelSettings): ChannelGrouping {
+export function makeChannelIndexGrouping(channels: string[], settings?: ViewerChannelSettings): ChannelGrouping {
+  if (!channels) {
+    return {};
+  }
+  if (!settings) {
+    // return all channels
+    return { [SINGLE_GROUP_CHANNEL_KEY]: channels.map((_val, index) => index) };
+  }
+
   const groups = settings.groups;
   const grouping: ChannelGrouping = {};
   const channelsMatched: number[] = [];

--- a/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
+++ b/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
@@ -1,4 +1,4 @@
-import { ControlPoint, View3d, Volume } from "@aics/volume-viewer";
+import { ControlPoint } from "@aics/volume-viewer";
 import { OTHER_CHANNEL_KEY, SINGLE_GROUP_CHANNEL_KEY } from "../constants";
 import { ColorArray } from "./colorRepresentations";
 
@@ -16,13 +16,10 @@ export interface ChannelState {
 }
 
 export type ChannelStateKey = keyof ChannelState;
-export type ChannelStateChangeHandlers = {
-  [K in ChannelStateKey]?: (value: ChannelState[K], index: number, view3d: View3d, image: Volume) => void;
-};
-export type ChannelSettingUpdater = <K extends ChannelStateKey>(index: number, type: K, value: ChannelState[K]) => void;
+export type ChannelSettingUpdater = <K extends ChannelStateKey>(index: number, key: K, value: ChannelState[K]) => void;
 export type MultipleChannelSettingsUpdater = <K extends ChannelStateKey>(
   indices: number[],
-  type: K,
+  key: K,
   value: ChannelState[K]
 ) => void;
 

--- a/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
+++ b/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
@@ -12,7 +12,6 @@ export interface ChannelState {
   colorizeAlpha: number;
   opacity: number;
   color: ColorArray;
-  dataReady: boolean;
   controlPoints: ControlPoint[];
 }
 
@@ -20,6 +19,12 @@ export type ChannelStateKey = keyof ChannelState;
 export type ChannelStateChangeHandlers = {
   [K in ChannelStateKey]?: (value: ChannelState[K], index: number, view3d: View3d, image: Volume) => void;
 };
+export type ChannelSettingUpdater = <K extends ChannelStateKey>(index: number, type: K, value: ChannelState[K]) => void;
+export type MultipleChannelSettingsUpdater = <K extends ChannelStateKey>(
+  indices: number[],
+  type: K,
+  value: ChannelState[K]
+) => void;
 
 /** Settings for a single channel, as passed in via props by App users */
 export interface ViewerChannelSetting {
@@ -130,10 +135,7 @@ export function getDisplayName(name: string, index: number, settings?: ViewerCha
   return name;
 }
 
-export function makeChannelIndexGrouping(
-  channels: string[],
-  settings: ViewerChannelSettings
-): ChannelGrouping {
+export function makeChannelIndexGrouping(channels: string[], settings: ViewerChannelSettings): ChannelGrouping {
   const groups = settings.groups;
   const grouping: ChannelGrouping = {};
   const channelsMatched: number[] = [];


### PR DESCRIPTION
In order to properly set or change the state of the app, two things need to happen: UI state values need to be changed using React's API, and viewer state needs to be changed using volume-viewer's API. Since these procedures are currently relatively decoupled, every pathway to changing app state (including interacting with UI; changing props; or loading a new image, which may require settings to be re-propagated to volume-viewer) must individually consider which volume-viewer methods to call to effect the change they need to make. This can be tough to read and reason about, creates duplicated code, and may lead to unpredictable interactions between multiple updates. Since Milestone 3 (#113) stands to add a new state-changing pathway (#107), now is a reasonable time to consider alternate approaches.

Modern React, based on function components with hooks, encourages imperative updates that always occur in response to props or state updates to be made within the [`useEffect`](https://react.dev/reference/react/useEffect) hook. This hook accepts a callback and an array of dependent values, and re-runs the callback whenever one or more of those values changes between renders. In effect, this allows imperative updates to "react" to props/state changes the same way UI updates do. Using this pattern frees different state-changing mechanisms from having to worry about which volume-viewer methods to call, and makes the addition of new state-changing mechanisms easier and cleaner.

This PR rewrites (or attempts to rewrite) `App` as a function component which calls volume-viewer methods within `useEffect`.