### PR TITLE
Fix/slow mask alpha slider

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -1100,7 +1100,6 @@ export default class App extends React.Component<AppProps, AppState> {
             channelGroupedByType={this.state.channelGroupedByType}
             // user selections
             maxProjectOn={userSelections.maxProject}
-            pathTraceOn={userSelections.pathTrace}
             channelSettings={userSelections.channelSettings}
             showBoundingBox={userSelections.showBoundingBox}
             backgroundColor={userSelections.backgroundColor}

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -132,7 +132,6 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
                     gammaSliderLevel={props.gammaSliderLevel}
                     interpolationEnabled={props.interpolationEnabled}
                     maxProjectOn={props.maxProjectOn}
-                    pathTraceOn={props.pathTraceOn}
                     renderConfig={renderConfig}
                   />
                   <CustomizeWidget

--- a/src/aics-image-viewer/components/GlobalVolumeControls.tsx
+++ b/src/aics-image-viewer/components/GlobalVolumeControls.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Nouislider from "nouislider-react";
+import SmarterSlider from "./shared/SmarterSlider";
 import "nouislider/distribute/nouislider.css";
 
 import { Card, Collapse, Checkbox } from "antd";
@@ -38,20 +38,11 @@ export default class GlobalVolumeControls extends React.Component<GlobalVolumeCo
     super(props);
   }
 
-  shouldComponentUpdate(newProps: GlobalVolumeControlsProps): boolean {
-    const { imageName, alphaMaskSliderLevel, pathTraceOn, interpolationEnabled } = this.props;
-    const newImage = newProps.imageName !== imageName;
-    const newPathTraceValue = newProps.pathTraceOn !== pathTraceOn;
-    const newSliderValue = newProps.alphaMaskSliderLevel[0] !== alphaMaskSliderLevel[0];
-    const newInterpolationValue = newProps.interpolationEnabled !== interpolationEnabled;
-    return newImage || newSliderValue || newPathTraceValue || newInterpolationValue;
-  }
-
   createSliderRow = (label: string, start: number[], max: number, propKey: GlobalVolumeControlKey): React.ReactNode => (
     <div style={STYLES.controlRow}>
       <div style={STYLES.controlName}>{label}</div>
       <div style={STYLES.control}>
-        <Nouislider
+        <SmarterSlider
           range={{ min: 0, max }}
           start={start}
           connect={true}

--- a/src/aics-image-viewer/components/GlobalVolumeControls.tsx
+++ b/src/aics-image-viewer/components/GlobalVolumeControls.tsx
@@ -13,7 +13,6 @@ export interface GlobalVolumeControlsProps {
   imageName: string | undefined;
   pixelSize: [number, number, number];
   maxProjectOn: boolean;
-  pathTraceOn: boolean;
   renderConfig: {
     alphaMask: boolean;
     brightnessSlider: boolean;


### PR DESCRIPTION
### Problem

nouislider-react updates very very slowly on any props change by default. `GlobalVolumeControls` solved this by having a `shouldComponentUpdate`, but for some reason it was programmed to allow an update on mask alpha changes, making that slider move very slowly.

### Solution

Instead of `shouldComponentUpdate` on `GlobalVolumeControls`, replace `Nouislider` with the `SmarterSlider` component I wrote for use in `AxisClipSliders`, which implements its own `shouldComponentUpdate` to keep things moving at a reasonable pace.