### PR TITLE
Feature/time series props

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -138,8 +138,7 @@ const defaultProps: AppProps = {
 /** A `useState` that also creates a getter function for breaking through closures */
 function useStateWithGetter<T>(initialState: T | (() => T)): [T, (value: T) => void, () => T] {
   const [state, setState] = useState(initialState);
-  const isSetterFunction = (val: T | (() => T)): val is () => T => typeof val === "function";
-  const stateRef = useRef(isSetterFunction(initialState) ? initialState() : initialState);
+  const stateRef = useRef(state);
   const wrappedSetState = useCallback((value: T) => {
     stateRef.current = value;
     setState(value);

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -430,7 +430,6 @@ const App: React.FC<AppProps> = (props) => {
     imageLoadHandlers.current.forEach((effect) => effect(aimg));
 
     if (doResetMaskAlpha) {
-      console.log("reset mask alpha");
       const initialAlpha = getInitialAlphaLevel();
       changeViewerSetting("maskAlpha", initialAlpha);
       view3d.updateMaskAlpha(aimg, alphaSliderToImageValue(initialAlpha));

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -46,6 +46,7 @@ export interface GlobalViewerSettings {
   // `region` values are in the range [0, 1]. We derive from this the format that the sliders expect
   // (integers between 0 and num_slices - 1) and the format that view3d expects (in [-0.5, 0.5])
   region: PerAxis<[number, number]>;
+  time: number;
 }
 
 export interface AppProps {


### PR DESCRIPTION
Adds a field for time series step to props and state: `GlobalViewerSettings.time`. No UI controls this bit of state yet, but changing its value triggers the appropriate image to be loaded. Image loads triggered by only a time point change do not trigger a reset to 3D mode or recalculated transfer functions and mask alpha, as a completely new image would.

This addresses allen-cell-animated/volume-viewer#93, and may be enough to close it.