### PR TITLE
Feature/ROI slider layout

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -536,7 +536,7 @@ const App: React.FC<AppProps> = (props) => {
 
   const onClippingPanelVisibleChange = useCallback(
     (open: boolean): void => {
-      const CLIPPING_PANEL_HEIGHT = 130;
+      const CLIPPING_PANEL_HEIGHT = 150;
 
       let axisY = AXIS_MARGIN_DEFAULT[1];
       let scaleBarY = SCALE_BAR_MARGIN_DEFAULT[1];

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -100,6 +100,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     return (
       <div key={axis + numSlices} className={`slider-row slider-${axis}`}>
         <span className="axis-slider-container">
+          <span className="slider-name">{axis.toUpperCase()}</span>
           <span className="axis-slider">
             <SmarterSlider
               connect={true}
@@ -114,7 +115,6 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
               onEnd={callback}
             />
           </span>
-          <span className="slider-name">{axis.toUpperCase()}</span>
           <span className="slider-slices">
             {twoD
               ? `${sliderVals[0]} (${numSlices})`

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -156,8 +156,12 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     const activeAxis = this.getActiveAxis();
     return (
       <div className={activeAxis ? "clip-sliders clip-sliders-2d" : "clip-sliders"}>
-        <h4>Region of interest</h4>
-        {activeAxis ? this.createSlider(activeAxis, true) : AXES.map((axis) => this.createSlider(axis, false))}
+        <span className="slider-group">
+          <h4 className="slider-group-title">ROI</h4>
+          <span className="slider-group-rows">
+            {activeAxis ? this.createSlider(activeAxis, true) : AXES.map((axis) => this.createSlider(axis, false))}
+          </span>
+        </span>
       </div>
     );
   }

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -103,7 +103,8 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
           <span className="slider-name">{axis.toUpperCase()}</span>
           <span className="axis-slider">
             <SmarterSlider
-              key={`${twoD}`} // prevents slider from potentially not updating number of handles
+              // prevents slider from potentially not updating number of handles
+              key={`${twoD}`}
               connect={true}
               range={range}
               start={twoD ? [sliderVals[0]] : sliderVals}

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -116,9 +116,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
             />
           </span>
           <span className="slider-slices">
-            {twoD
-              ? `${sliderVals[0]} (${numSlices})`
-              : `${sliderVals[0]}, ${sliderVals[1]} (${sliderVals[1] - sliderVals[0]})`}
+            {twoD ? `${sliderVals[0]} / ${numSlices}` : `${sliderVals[0]}, ${sliderVals[1]} / ${numSlices}`}
           </span>
         </span>
         {twoD && (

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -103,6 +103,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
           <span className="slider-name">{axis.toUpperCase()}</span>
           <span className="axis-slider">
             <SmarterSlider
+              key={`${twoD}`} // prevents slider from potentially not updating number of handles
               connect={true}
               range={range}
               start={twoD ? [sliderVals[0]] : sliderVals}

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -34,6 +34,7 @@
     align-items: flex-start;
     flex-wrap: wrap;
     color: #bfbfbf;
+    margin-bottom: 6px;
 
     &.slider-x {
       .slider-name {

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -122,7 +122,7 @@
 
   .noUi-handle {
     width: 8px;
-    height: 9px;
+    height: 8px;
     transform: translate(-50%, calc(-100% - 4px));
   }
 

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -65,7 +65,7 @@
 
   .slider-name,
   .slider-play-buttons {
-    margin-left: 20px;
+    margin-right: 14px;
     white-space: nowrap;
   }
 

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -116,8 +116,20 @@
   }
 
   .noUi-target {
-    height: 4px;
+    height: 3px;
     background-color: rgba(160, 160, 160, 0.4) !important;
+  }
+
+  .noUi-handle {
+    width: 8px;
+    height: 9px;
+    transform: translate(-50%, calc(-100% - 4px));
+  }
+
+  .noUi-handle::after {
+    width: 8px;
+    height: 8px;
+    transform: matrix(0.5, 0.6, -0.5, 0.6, 0, 5);
   }
 
   .slider-play-buttons .ant-btn {

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -7,13 +7,26 @@
   --color-z: #0099ff;
 
   @extend %axis-override;
-  /* .axis-slider (480) + .slider-name (10) + .slider-slices (105) + margins & padding (80) */
-  max-width: 675px;
+  /* .slider-group-title (50) + .axis-slider (480) + .slider-name (10) + .slider-slices (105) + margins & padding (80) */
+  max-width: 725px;
   position: absolute;
   margin: 0 auto;
   left: 0;
   right: 0;
   padding: 0 25px;
+
+  .slider-group {
+    display: flex;
+    flex-wrap: nowrap;
+
+    .slider-group-title {
+      flex: 0 0 50px;
+    }
+
+    .slider-group-rows {
+      flex: 1 1 auto;
+    }
+  }
 
   .slider-row {
     display: flex;
@@ -88,7 +101,7 @@
   &.clip-sliders-2d {
     /* Make room for play buttons */
     /* .axis-slider (480) + .slider-name (10) + .slider-slices (70) + .slider-play-buttons (95) + margins & padding (100) */
-    max-width: 755px;
+    max-width: 805px;
 
     /* Slider slice display contains 2 numbers in 2d mode, not 3 - shrink accordingly */
     .slider-slices {
@@ -130,11 +143,12 @@
 }
 
 @media only screen and (max-width: 500px) {
-  .clip-sliders .slider-row {
+  .clip-sliders .slider-group {
     display: none;
   }
 
   .clip-sliders::after {
+    /* TODO this message should be updated to be more general once time slider is added */
     content: "ROI clipping is not available at this size. Please try again with a larger viewport.";
     font-style: italic;
   }

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -76,9 +76,8 @@
 
   .slider-slices {
     flex: 0 0 105px;
-    margin-left: 10px;
+    margin-left: 18px;
     white-space: nowrap;
-    text-align: right;
     max-width: 105px;
   }
 

--- a/src/aics-image-viewer/components/BottomPanel/index.tsx
+++ b/src/aics-image-viewer/components/BottomPanel/index.tsx
@@ -11,7 +11,7 @@ type BottomPanelProps = {
 };
 
 const BottomPanel: React.FC<BottomPanelProps> = ({ children, title, onVisibleChange, onVisibleChangeEnd }) => {
-  const [isVisible, setIsVisible] = useState(false);
+  const [isVisible, setIsVisible] = useState(true);
   const toggleDrawer = (): void => {
     setIsVisible(!isVisible);
     if (onVisibleChange) {

--- a/src/aics-image-viewer/components/BottomPanel/styles.css
+++ b/src/aics-image-viewer/components/BottomPanel/styles.css
@@ -34,7 +34,7 @@
   }
 
   .ant-drawer-body {
-    height: 130px;
+    height: 150px;
   }
 
   .ant-drawer-title .ant-btn {

--- a/src/aics-image-viewer/components/BottomPanel/styles.css
+++ b/src/aics-image-viewer/components/BottomPanel/styles.css
@@ -34,6 +34,7 @@
   }
 
   .ant-drawer-body {
+    padding: 16px 24px;
     height: 150px;
   }
 


### PR DESCRIPTION
#### Resolve #136: modify layout of clipping sliders
- Move axis labels (and future time label) to the left of sliders
- Turn the "Region of interest" title above sliders to "ROI" to the left of sliders (with a class that can be reused for the time slider)
- Left-align and reformat slice readouts, in preparation for spinboxes here
- Adjust vertical spacing

#### Resolve #133: the app starts with the clipping panel open by default

#### Partially address #137: restyle clipping sliders
- The slider "track" is thinner, the handles are wider
- TODO: more complex appearance and behavior changes (ghost handles on hover, tickmarks, etc.)

### Screenshot
![image](https://github.com/allen-cell-animated/website-3d-cell-viewer/assets/53030214/f9c46856-bf53-43a1-ae9b-309cf57090e2)
