### PR TITLE
Feature/time slider

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -821,6 +821,7 @@ const App: React.FC<AppProps> = (props) => {
             numSlices={getNumberOfSlices()}
             numTimesteps={image?.imageInfo.times || 1}
             region={viewerSettings.region}
+            time={viewerSettings.time}
             appHeight={props.appHeight}
             showControls={showControls}
             changeViewerSetting={changeViewerSetting}

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -585,9 +585,6 @@ const App: React.FC<AppProps> = (props) => {
 
   // On mount
   useEffect(() => {
-    view3d.setAxisPosition(...AXIS_MARGIN_DEFAULT);
-    view3d.setScaleBarPosition(...SCALE_BAR_MARGIN_DEFAULT);
-
     const onResize = (): void => {
       if (window.innerWidth < CONTROL_PANEL_CLOSE_WIDTH) {
         setControlPanelClosed(true);

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -814,11 +814,12 @@ const App: React.FC<AppProps> = (props) => {
           />
           <CellViewerCanvasWrapper
             view3d={view3d}
-            image={image}
+            hasImage={!!image}
             viewMode={viewerSettings.viewMode}
             autorotate={viewerSettings.autorotate}
             loadingImage={sendingQueryRequest}
             numSlices={getNumberOfSlices()}
+            numTimesteps={image?.imageInfo.times || 1}
             region={viewerSettings.region}
             appHeight={props.appHeight}
             showControls={showControls}

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -78,8 +78,13 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     this.createAxisSlider = this.createAxisSlider.bind(this);
   }
 
-  // Pause if mode or fov has changed
   componentDidUpdate(prevProps: AxisClipSlidersProps): void {
+    // Make extra sure the number next to the time slider is accurate
+    if (prevProps.time !== this.props.time) {
+      this.setState({ timeReadout: this.props.time });
+    }
+
+    // Pause if mode or fov has changed
     const numSlicesChanged = AXES.reduce(
       (hasChanged, axis) => hasChanged || prevProps.numSlices[axis] !== this.props.numSlices[axis],
       false

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -37,8 +37,8 @@ const LabeledSlider: React.FC<LabeledSliderProps> = ({ label, vals, max, onChang
       />
     </span>
     <span className="slider-slices">
-      {/* {twoD ? `${sliderVals[0]} / ${numSlices}` : `${sliderVals[0]}, ${sliderVals[1]} / ${numSlices}`} */}
-      {vals.reduce((acc, cur) => (acc ? `${acc}, ${cur}` : `${cur}`), "")} / {max}
+      {vals[0]}
+      {vals.length > 1 && `, ${vals[1]}`} / {max}
     </span>
   </span>
 );

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -111,7 +111,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     const max = this.props.numSlices[activeAxis];
     const currentLeftSliderValue = Math.round(this.props.region[activeAxis][0] * max);
     const leftValue = (currentLeftSliderValue + delta + max) % max;
-    this.updateClipping(activeAxis, leftValue, leftValue);
+    this.updateClipping(activeAxis, leftValue, leftValue + 1);
   }
 
   step(backward: boolean): void {

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -16,12 +16,13 @@ const PLAY_RATE_MS_PER_STEP = 125;
 interface LabeledSliderProps {
   label: string;
   vals: number[];
+  valsReadout?: number[];
   max: number;
   onSlide?: Callback;
   onEnd?: Callback;
 }
 
-const LabeledSlider: React.FC<LabeledSliderProps> = ({ label, vals, max, onSlide, onEnd }) => (
+const LabeledSlider: React.FC<LabeledSliderProps> = ({ label, vals, valsReadout = vals, max, onSlide, onEnd }) => (
   <span className="axis-slider-container">
     <span className="slider-name">{label}</span>
     <span className="axis-slider">
@@ -39,8 +40,8 @@ const LabeledSlider: React.FC<LabeledSliderProps> = ({ label, vals, max, onSlide
       />
     </span>
     <span className="slider-slices">
-      {vals[0]}
-      {vals.length > 1 && `, ${vals[1]}`} / {max}
+      {valsReadout[0]}
+      {valsReadout.length > 1 && `, ${valsReadout[1]}`} / {max}
     </span>
   </span>
 );
@@ -57,6 +58,8 @@ interface AxisClipSlidersProps {
 interface AxisClipSlidersState {
   playing: boolean;
   intervalId: number;
+  // shadows `time` prop, but updates while time slider is moving (`time` does not to avoid reloads)
+  timeReadout: number;
 }
 
 export default class AxisClipSliders extends React.Component<AxisClipSlidersProps, AxisClipSlidersState> {
@@ -66,6 +69,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     this.state = {
       playing: false,
       intervalId: 0,
+      timeReadout: props.time,
     };
 
     this.play = this.play.bind(this);
@@ -177,13 +181,16 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
 
   createTimeSlider(): React.ReactNode {
     const { time, numTimesteps, changeViewerSetting } = this.props;
+    const { timeReadout } = this.state;
 
     return (
       <div className="slider-row">
         <LabeledSlider
           label={"t="}
           vals={[time]}
+          valsReadout={[timeReadout]}
           max={numTimesteps}
+          onSlide={([time]) => this.setState({ timeReadout: time })}
           onEnd={([time]) => changeViewerSetting("time", time)}
         />
       </div>

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -191,7 +191,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     return (
       <div className="slider-row">
         <LabeledSlider
-          label={"t="}
+          label={""}
           vals={[time]}
           valsReadout={[timeReadout]}
           max={numTimesteps}

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -1,7 +1,8 @@
-import { Button, Tooltip } from "antd";
-import SmarterSlider from "../shared/SmarterSlider";
-
 import React from "react";
+import { Button, Tooltip } from "antd";
+import { Callback } from "nouislider-react";
+
+import SmarterSlider from "../shared/SmarterSlider";
 
 import "./styles.css";
 
@@ -16,10 +17,11 @@ interface LabeledSliderProps {
   label: string;
   vals: number[];
   max: number;
-  onChange: (values: number[]) => void;
+  onSlide?: Callback;
+  onEnd?: Callback;
 }
 
-const LabeledSlider: React.FC<LabeledSliderProps> = ({ label, vals, max, onChange }) => (
+const LabeledSlider: React.FC<LabeledSliderProps> = ({ label, vals, max, onSlide, onEnd }) => (
   <span className="axis-slider-container">
     <span className="slider-name">{label}</span>
     <span className="axis-slider">
@@ -32,8 +34,8 @@ const LabeledSlider: React.FC<LabeledSliderProps> = ({ label, vals, max, onChang
         behaviour="drag"
         // round slider output to nearest slice; assume any string inputs represent ints
         format={{ to: Math.round, from: parseInt }}
-        onSlide={onChange}
-        onEnd={onChange}
+        onSlide={onSlide}
+        onEnd={onEnd}
       />
     </span>
     <span className="slider-slices">
@@ -143,7 +145,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     const numSlices = this.props.numSlices[axis];
     const clipVals = this.props.region[axis];
     const sliderVals = [Math.round(clipVals[0] * numSlices), Math.round(clipVals[1] * numSlices)];
-    const callback = this.makeSliderCallback(axis);
+    const onChange = this.makeSliderCallback(axis);
 
     return (
       <div key={axis + numSlices} className={`slider-row slider-${axis}`}>
@@ -153,7 +155,8 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
           label={axis.toUpperCase()}
           vals={twoD ? [sliderVals[0]] : sliderVals}
           max={numSlices - (twoD ? 1 : 0)}
-          onChange={callback}
+          onSlide={onChange}
+          onEnd={onChange}
         />
         {twoD && (
           <Button.Group className="slider-play-buttons">
@@ -181,7 +184,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
           label={"t="}
           vals={[time]}
           max={numTimesteps}
-          onChange={([time]) => changeViewerSetting("time", time)}
+          onEnd={([time]) => changeViewerSetting("time", time)}
         />
       </div>
     );

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -7,7 +7,7 @@
   --color-z: #0099ff;
 
   @extend %axis-override;
-  /* .slider-group-title (50) + .axis-slider (480) + .slider-name (20) + .slider-slices (105) + margins & padding (70) */
+  /* .slider-group-title (50) + .axis-slider (480) + .slider-name (10) + .slider-slices (105) + margins & padding (80) */
   max-width: 725px;
   position: absolute;
   margin: 0 auto;
@@ -81,11 +81,15 @@
     margin-top: 0.5em;
   }
 
-  .slider-name {
-    flex: 0 0 20px;
-    font-weight: bold;
-    margin-right: 4px;
+  .slider-name,
+  .slider-play-buttons {
+    margin-right: 14px;
     white-space: nowrap;
+  }
+
+  .slider-name {
+    flex: 0 0 10px;
+    font-weight: bold;
   }
 
   .slider-slices {
@@ -97,13 +101,11 @@
 
   .slider-play-buttons {
     margin-top: 2px;
-    margin-right: 14px;
-    white-space: nowrap;
   }
 
   &.clip-sliders-2d {
     /* Make room for play buttons */
-    /* .axis-slider (480) + .slider-name (20) + .slider-slices (70) + .slider-play-buttons (95) + margins & padding (90) */
+    /* .axis-slider (480) + .slider-name (10) + .slider-slices (70) + .slider-play-buttons (95) + margins & padding (100) */
     max-width: 805px;
 
     /* Slider slice display contains 2 numbers in 2d mode, not 3 - shrink accordingly */
@@ -112,7 +114,7 @@
     }
 
     .axis-slider-container {
-      /* .axis-slider (480) + .slider-name (20) + .slider-slices (70) + margins (20) */
+      /* .axis-slider (480) + .slider-name (10) + .slider-slices (70) + margins (30) */
       flex: 0 1 590px;
     }
   }

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -34,8 +34,6 @@
 
   .slider-row {
     display: flex;
-    justify-content: flex-end;
-    align-items: flex-start;
     flex-wrap: wrap;
     color: #bfbfbf;
     margin-bottom: 6px;

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -7,7 +7,7 @@
   --color-z: #0099ff;
 
   @extend %axis-override;
-  /* .slider-group-title (50) + .axis-slider (480) + .slider-name (10) + .slider-slices (105) + margins & padding (80) */
+  /* .slider-group-title (50) + .axis-slider (480) + .slider-name (20) + .slider-slices (105) + margins & padding (70) */
   max-width: 725px;
   position: absolute;
   margin: 0 auto;
@@ -81,15 +81,11 @@
     margin-top: 0.5em;
   }
 
-  .slider-name,
-  .slider-play-buttons {
-    margin-right: 14px;
-    white-space: nowrap;
-  }
-
   .slider-name {
-    flex: 0 0 10px;
+    flex: 0 0 20px;
     font-weight: bold;
+    margin-right: 4px;
+    white-space: nowrap;
   }
 
   .slider-slices {
@@ -101,11 +97,13 @@
 
   .slider-play-buttons {
     margin-top: 2px;
+    margin-right: 14px;
+    white-space: nowrap;
   }
 
   &.clip-sliders-2d {
     /* Make room for play buttons */
-    /* .axis-slider (480) + .slider-name (10) + .slider-slices (70) + .slider-play-buttons (95) + margins & padding (100) */
+    /* .axis-slider (480) + .slider-name (20) + .slider-slices (70) + .slider-play-buttons (95) + margins & padding (90) */
     max-width: 805px;
 
     /* Slider slice display contains 2 numbers in 2d mode, not 3 - shrink accordingly */
@@ -114,7 +112,7 @@
     }
 
     .axis-slider-container {
-      /* .axis-slider (480) + .slider-name (10) + .slider-slices (70) + margins (30) */
+      /* .axis-slider (480) + .slider-name (20) + .slider-slices (70) + margins (20) */
       flex: 0 1 590px;
     }
   }

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -19,6 +19,10 @@
     display: flex;
     flex-wrap: nowrap;
 
+    &:not(:last-child) {
+      margin-bottom: 8px;
+    }
+
     .slider-group-title {
       flex: 0 0 50px;
     }

--- a/src/aics-image-viewer/components/BottomPanel/index.tsx
+++ b/src/aics-image-viewer/components/BottomPanel/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Drawer, Button } from "antd";
 
 import ViewerIcon from "../shared/ViewerIcon";
@@ -12,6 +12,15 @@ type BottomPanelProps = {
 
 const BottomPanel: React.FC<BottomPanelProps> = ({ children, title, onVisibleChange, onVisibleChangeEnd }) => {
   const [isVisible, setIsVisible] = useState(true);
+
+  // Call `onVisibleChange` on mount
+  useEffect(() => {
+    onVisibleChange?.(isVisible);
+    if (!isVisible) {
+      onVisibleChangeEnd?.(isVisible);
+    }
+  }, []);
+
   const toggleDrawer = (): void => {
     setIsVisible(!isVisible);
     if (onVisibleChange) {

--- a/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
+++ b/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
@@ -18,9 +18,10 @@ interface ViewerWrapperProps {
   viewMode: ViewMode;
   appHeight: string;
   hasImage: boolean;
-  numTimesteps: number;
   numSlices: PerAxis<number>;
   region: PerAxis<[number, number]>;
+  numTimesteps: number;
+  time: number;
   showControls: {
     axisClipSliders: boolean;
   };
@@ -64,7 +65,8 @@ export default class ViewerWrapper extends React.Component<ViewerWrapperProps, V
   }
 
   render(): React.ReactNode {
-    const { appHeight, changeViewerSetting, showControls, numSlices, numTimesteps, viewMode, region } = this.props;
+    const { appHeight, changeViewerSetting, showControls, numSlices, numTimesteps, viewMode, region, time } =
+      this.props;
 
     return (
       <div className="cell-canvas" style={{ ...STYLES.viewer, height: appHeight }}>
@@ -78,9 +80,10 @@ export default class ViewerWrapper extends React.Component<ViewerWrapperProps, V
             <AxisClipSliders
               mode={viewMode}
               changeViewerSetting={changeViewerSetting}
-              numTimesteps={numTimesteps}
               numSlices={numSlices}
               region={region}
+              numTimesteps={numTimesteps}
+              time={time}
             />
           )}
         </BottomPanel>

--- a/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
+++ b/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { View3d, Volume } from "@aics/volume-viewer";
+import { View3d } from "@aics/volume-viewer";
 
 import { Icon } from "antd";
 
@@ -17,7 +17,8 @@ interface ViewerWrapperProps {
   loadingImage: boolean;
   viewMode: ViewMode;
   appHeight: string;
-  image: Volume | null;
+  hasImage: boolean;
+  numTimesteps: number;
   numSlices: PerAxis<number>;
   region: PerAxis<[number, number]>;
   showControls: {
@@ -55,7 +56,7 @@ export default class ViewerWrapper extends React.Component<ViewerWrapperProps, V
     ) : null;
 
     const noImageText =
-      !this.props.loadingImage && !this.props.image ? <div style={STYLES.noImage}>No image selected</div> : null;
+      !this.props.loadingImage && !this.props.hasImage ? <div style={STYLES.noImage}>No image selected</div> : null;
     if (!!noImageText && this.props.view3d) {
       this.props.view3d.removeAllVolumes();
     }
@@ -63,7 +64,8 @@ export default class ViewerWrapper extends React.Component<ViewerWrapperProps, V
   }
 
   render(): React.ReactNode {
-    const { appHeight, changeViewerSetting, showControls, image, numSlices, viewMode, region } = this.props;
+    const { appHeight, changeViewerSetting, showControls, numSlices, numTimesteps, viewMode, region } = this.props;
+
     return (
       <div className="cell-canvas" style={{ ...STYLES.viewer, height: appHeight }}>
         <div ref={this.view3dviewerRef} style={STYLES.view3d}></div>
@@ -72,10 +74,11 @@ export default class ViewerWrapper extends React.Component<ViewerWrapperProps, V
           onVisibleChange={this.props.onClippingPanelVisibleChange}
           onVisibleChangeEnd={this.props.onClippingPanelVisibleChangeEnd}
         >
-          {showControls.axisClipSliders && !!image && (
+          {showControls.axisClipSliders && this.props.hasImage && (
             <AxisClipSliders
               mode={viewMode}
               changeViewerSetting={changeViewerSetting}
+              numTimesteps={numTimesteps}
               numSlices={numSlices}
               region={region}
             />


### PR DESCRIPTION
Adds a time slider (which doesn't have an associated issue?)

- The slider only appears for volumes with multiple time points
- Apart from spinboxes and extra styling (to come later), the slider appears as specified in #127
- While the slider is being dragged, the numeric readout updates but the new time point is not loaded
- When the slider handle is released, the new time point is loaded

### Screenshot:
![image](https://github.com/allen-cell-animated/website-3d-cell-viewer/assets/53030214/cf4c0127-27cf-4c8b-be24-8e6191440d3e)
