### PR TITLE
Feature/slider spinboxes

### DIFF
--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -12,7 +12,7 @@ import { AxisName, PerAxis, activeAxisMap } from "../../shared/types";
 const AXES: AxisName[] = ["x", "y", "z"];
 const PLAY_RATE_MS_PER_STEP = 125;
 
-interface LabeledSliderProps {
+interface SliderRowProps {
   label: string;
   vals: number[];
   valsReadout?: number[];
@@ -21,14 +21,7 @@ interface LabeledSliderProps {
   onSet?: (values: number[]) => void;
 }
 
-const LabeledSlider: React.FC<LabeledSliderProps> = ({
-  label,
-  vals,
-  valsReadout = vals,
-  max,
-  onSlide,
-  onSet = onSlide,
-}) => {
+const SliderRow: React.FC<SliderRowProps> = ({ label, vals, valsReadout = vals, max, onSlide, onSet = onSlide }) => {
   const isRange = vals.length > 1;
 
   return (
@@ -48,18 +41,18 @@ const LabeledSlider: React.FC<LabeledSliderProps> = ({
           onSet={onSet}
         />
       </span>
-      <span className="slider-slices">
+      <span className="slider-values">
         <InputNumber
-          size="small"
+          className="slider-number-input"
           step={1}
           value={valsReadout[0]}
           onChange={(value?: number) => value !== undefined && onSet?.(isRange ? [value, vals[1]] : [value])}
         />
         {isRange && (
           <>
-            {", "}
+            {" , "}
             <InputNumber
-              size="small"
+              className="slider-number-input"
               step={1}
               value={valsReadout[1]}
               onChange={(value?: number) => value !== undefined && onSet?.([vals[0], value])}
@@ -184,7 +177,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
 
     return (
       <div key={axis + numSlices} className={`slider-row slider-${axis}`}>
-        <LabeledSlider
+        <SliderRow
           // prevents slider from potentially not updating number of handles
           key={`${twoD}`}
           label={axis.toUpperCase()}
@@ -215,7 +208,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
 
     return (
       <div className="slider-row">
-        <LabeledSlider
+        <SliderRow
           label={""}
           vals={[time]}
           valsReadout={[timeReadout]}

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -129,11 +129,6 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     this.updateClipping(activeAxis, leftValue, leftValue + 1);
   }
 
-  step(backward: boolean): void {
-    this.pause();
-    this.moveSlice(backward);
-  }
-
   play(): void {
     if (this.getActiveAxis() && !this.state.playing) {
       const intervalId = window.setInterval(this.moveSlice, PLAY_RATE_MS_PER_STEP);

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { Button, InputNumber, Tooltip } from "antd";
+import { Button, Tooltip } from "antd";
 
+import NumericInput from "../shared/NumericInput";
 import SmarterSlider from "../shared/SmarterSlider";
 
 import "./styles.css";
@@ -42,21 +43,15 @@ const SliderRow: React.FC<SliderRowProps> = ({ label, vals, valsReadout = vals, 
         />
       </span>
       <span className="slider-values">
-        <InputNumber
-          className="slider-number-input"
-          step={1}
+        <NumericInput
+          max={max}
           value={valsReadout[0]}
-          onChange={(value?: number) => value !== undefined && onSet?.(isRange ? [value, vals[1]] : [value])}
+          onChange={(value) => onSet?.(isRange ? [value, vals[1]] : [value])}
         />
         {isRange && (
           <>
             {" , "}
-            <InputNumber
-              className="slider-number-input"
-              step={1}
-              value={valsReadout[1]}
-              onChange={(value?: number) => value !== undefined && onSet?.([vals[0], value])}
-            />
+            <NumericInput max={max} value={valsReadout[1]} onChange={(value) => onSet?.([vals[0], value])} />
           </>
         )}
         {" / "}

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -181,17 +181,13 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
           onSlide={this.makeSliderCallback(axis)}
         />
         {twoD && (
-          <Button.Group className="slider-play-buttons">
-            <Tooltip placement="top" title="Step back">
-              <Button icon="step-backward" onClick={() => this.step(true)} />
-            </Tooltip>
-            <Tooltip placement="top" title="Play through sequence">
-              <Button onClick={playing ? this.pause : this.play} icon={playing ? "pause" : "caret-right"} />
-            </Tooltip>
-            <Tooltip placement="top" title="Step forward">
-              <Button icon="step-forward" onClick={() => this.step(false)} />
-            </Tooltip>
-          </Button.Group>
+          <Tooltip placement="top" title="Play through sequence">
+            <Button
+              className="slider-play-button"
+              onClick={playing ? this.pause : this.play}
+              icon={playing ? "pause" : "caret-right"}
+            />
+          </Tooltip>
         )}
       </div>
     );

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, Tooltip } from "antd";
+import { Button, InputNumber, Tooltip } from "antd";
 import { Callback } from "nouislider-react";
 
 import SmarterSlider from "../shared/SmarterSlider";
@@ -19,10 +19,10 @@ interface LabeledSliderProps {
   valsReadout?: number[];
   max: number;
   onSlide?: Callback;
-  onEnd?: Callback;
+  onSet?: Callback;
 }
 
-const LabeledSlider: React.FC<LabeledSliderProps> = ({ label, vals, valsReadout = vals, max, onSlide, onEnd }) => (
+const LabeledSlider: React.FC<LabeledSliderProps> = ({ label, vals, valsReadout = vals, max, onSlide, onSet }) => (
   <span className="axis-slider-container">
     <span className="slider-name">{label}</span>
     <span className="axis-slider">
@@ -36,7 +36,7 @@ const LabeledSlider: React.FC<LabeledSliderProps> = ({ label, vals, valsReadout 
         // round slider output to nearest slice; assume any string inputs represent ints
         format={{ to: Math.round, from: parseInt }}
         onSlide={onSlide}
-        onEnd={onEnd}
+        onSet={onSet}
       />
     </span>
     <span className="slider-slices">
@@ -165,7 +165,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
           vals={twoD ? [sliderVals[0]] : sliderVals}
           max={numSlices - (twoD ? 1 : 0)}
           onSlide={onChange}
-          onEnd={onChange}
+          onSet={onChange}
         />
         {twoD && (
           <Button.Group className="slider-play-buttons">
@@ -196,7 +196,7 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
           valsReadout={[timeReadout]}
           max={numTimesteps}
           onSlide={([time]) => this.setState({ timeReadout: time })}
-          onEnd={([time]) => changeViewerSetting("time", time)}
+          onSet={([time]) => changeViewerSetting("time", time)}
         />
       </div>
     );

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -90,7 +90,7 @@
     font-weight: bold;
   }
 
-  /* TODO this will need to be expanded (in 2d too!) */
+  /* TODO this will need to be expanded (here and in 2d!) */
   .slider-values {
     flex: 0 0 105px;
     margin-left: 18px;
@@ -117,12 +117,28 @@
     }
 
     .ant-input-number-handler-wrap {
-      width: 11px;
+      width: 12px;
       opacity: 1;
-    }
+      border-radius: 0;
 
-    .ant-input-number-handler-down-inner {
-      font-size: 6px;
+      /* nest deeply to gain enough specificity to override ant's styles */
+      .ant-input-number-handler {
+        box-sizing: content-box;
+        border-radius: 0;
+
+        .ant-input-number-handler-up-inner,
+        .ant-input-number-handler-down-inner {
+          box-sizing: content-box;
+          font-size: 9px;
+          transform: none;
+          width: 10px;
+          height: 10px;
+          vertical-align: middle;
+          left: 0;
+          line-height: normal;
+          color: #bfbfbf;
+        }
+      }
     }
   }
 

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -102,46 +102,6 @@
     margin-top: 2px;
   }
 
-  .slider-number-input {
-    height: 21px;
-    width: 50px;
-    font-size: 12px;
-    background-color: #222222;
-    border: 1px solid #4b4b4b;
-    border-radius: 0;
-
-    input {
-      height: 21px;
-      padding: 0 6px;
-      text-align: right;
-    }
-
-    .ant-input-number-handler-wrap {
-      width: 12px;
-      opacity: 1;
-      border-radius: 0;
-
-      /* nest deeply to gain enough specificity to override ant's styles */
-      .ant-input-number-handler {
-        box-sizing: content-box;
-        border-radius: 0;
-
-        .ant-input-number-handler-up-inner,
-        .ant-input-number-handler-down-inner {
-          box-sizing: content-box;
-          font-size: 9px;
-          transform: none;
-          width: 10px;
-          height: 10px;
-          vertical-align: middle;
-          left: 0;
-          line-height: normal;
-          color: #bfbfbf;
-        }
-      }
-    }
-  }
-
   &.clip-sliders-2d {
     /* Make room for play buttons */
     /* .slider-group-title (50) + .axis-slider (480) + .slider-name (10) + .slider-values (70) + .slider-play-buttons (95) + margins & padding (100) */

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -8,7 +8,7 @@
 
   @extend %axis-override;
   /* .slider-group-title (50) + .axis-slider (480) + .slider-name (10) + .slider-values (160) + margins & padding (80) */
-  max-width: 770px;
+  max-width: 780px;
   position: absolute;
   margin: 0 auto;
   left: 0;
@@ -94,7 +94,7 @@
     flex: 0 0 160px;
     margin-left: 18px;
     white-space: nowrap;
-    max-width: 105px;
+    max-width: 160px;
   }
 
   .slider-play-buttons {
@@ -102,9 +102,9 @@
   }
 
   &.clip-sliders-2d {
-    /* Make room for play buttons */
-    /* .slider-group-title (50) + .axis-slider (480) + .slider-name (10) + .slider-values (100) + .slider-play-buttons (95) + margins & padding (100) */
-    max-width: 835px;
+    /* Make room for play button */
+    /* .slider-group-title (50) + .axis-slider (480) + .slider-name (10) + .slider-values (100) + .slider-play-button (28) + margins & padding (82) */
+    max-width: 750px;
 
     /* Slider slice display contains 2 numbers in 2d mode, not 3 - shrink accordingly */
     .slider-values {

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -2,13 +2,19 @@
 @import "../../assets/styles/variables";
 
 .clip-sliders {
+  --w-group-title: 50px;
+  --w-axis-slider: 480px;
+  --w-name: 10px;
+  --w-values-3d: 160px;
+  --w-values-2d: 100px;
+  --w-play-button: 28px;
+
   --color-x: #ff4d4d;
   --color-y: #61d900;
   --color-z: #0099ff;
 
   @extend %axis-override;
-  /* .slider-group-title (50) + .axis-slider (480) + .slider-name (10) + .slider-values (160) + margins & padding (80) */
-  max-width: 780px;
+  max-width: calc(var(--w-group-title) + var(--w-axis-slider) + var(--w-name) + var(--w-values-3d) + 80px);
   position: absolute;
   margin: 0 auto;
   left: 0;
@@ -24,7 +30,7 @@
     }
 
     .slider-group-title {
-      flex: 0 0 50px;
+      flex: 0 0 var(--w-group-title);
     }
 
     .slider-group-rows {
@@ -74,8 +80,8 @@
   }
 
   .axis-slider {
-    flex: 1 1 480px;
-    max-width: 480px;
+    flex: 1 1 var(--w-axis-slider);
+    max-width: var(--w-axis-slider);
     margin-top: 0.5em;
   }
 
@@ -86,15 +92,15 @@
   }
 
   .slider-name {
-    flex: 0 0 10px;
+    flex: 0 0 var(--w-name);
     font-weight: bold;
   }
 
   .slider-values {
-    flex: 0 0 160px;
+    flex: 0 0 var(--w-values-3d);
+    max-width: var(--w-values-3d);
     margin-left: 18px;
     white-space: nowrap;
-    max-width: 160px;
   }
 
   .slider-play-buttons {
@@ -103,17 +109,17 @@
 
   &.clip-sliders-2d {
     /* Make room for play button */
-    /* .slider-group-title (50) + .axis-slider (480) + .slider-name (10) + .slider-values (100) + .slider-play-button (28) + margins & padding (82) */
-    max-width: 750px;
+    max-width: calc(
+      var(--w-group-title) + var(--w-axis-slider) + var(--w-name) + var(--w-values-2d) + var(--w-play-button) + 80px
+    );
 
     /* Slider slice display contains 2 numbers in 2d mode, not 3 - shrink accordingly */
     .slider-values {
-      flex: 0 0 100px;
+      flex: 0 0 var(--w-values-2d);
     }
 
     .axis-slider-container {
-      /* .axis-slider (480) + .slider-name (10) + .slider-values (100) + margins (30) */
-      flex: 0 1 620px;
+      flex: 0 1 calc(var(--w-axis-slider) + var(--w-name) + var(--w-values-2d) + 30px);
     }
   }
 
@@ -137,7 +143,7 @@
   .ant-btn.slider-play-button {
     line-height: 1;
     height: 23px;
-    width: 28px;
+    width: var(--w-play-button);
     color: #bfbfbf;
     border-color: #4b4b4b !important;
     background-color: transparent;

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -7,7 +7,7 @@
   --color-z: #0099ff;
 
   @extend %axis-override;
-  /* .slider-group-title (50) + .axis-slider (480) + .slider-name (10) + .slider-slices (105) + margins & padding (80) */
+  /* .slider-group-title (50) + .axis-slider (480) + .slider-name (10) + .slider-values (105) + margins & padding (80) */
   max-width: 725px;
   position: absolute;
   margin: 0 auto;
@@ -90,7 +90,8 @@
     font-weight: bold;
   }
 
-  .slider-slices {
+  /* TODO this will need to be expanded (in 2d too!) */
+  .slider-values {
     flex: 0 0 105px;
     margin-left: 18px;
     white-space: nowrap;
@@ -101,18 +102,42 @@
     margin-top: 2px;
   }
 
+  .slider-number-input {
+    height: 21px;
+    width: 50px;
+    font-size: 12px;
+    background-color: #222222;
+    border: 1px solid #4b4b4b;
+    border-radius: 0;
+
+    input {
+      height: 21px;
+      padding: 0 6px;
+      text-align: right;
+    }
+
+    .ant-input-number-handler-wrap {
+      width: 11px;
+      opacity: 1;
+    }
+
+    .ant-input-number-handler-down-inner {
+      font-size: 6px;
+    }
+  }
+
   &.clip-sliders-2d {
     /* Make room for play buttons */
-    /* .slider-group-title (50) + .axis-slider (480) + .slider-name (10) + .slider-slices (70) + .slider-play-buttons (95) + margins & padding (100) */
+    /* .slider-group-title (50) + .axis-slider (480) + .slider-name (10) + .slider-values (70) + .slider-play-buttons (95) + margins & padding (100) */
     max-width: 805px;
 
     /* Slider slice display contains 2 numbers in 2d mode, not 3 - shrink accordingly */
-    .slider-slices {
+    .slider-values {
       flex: 0 0 70px;
     }
 
     .axis-slider-container {
-      /* .axis-slider (480) + .slider-name (10) + .slider-slices (70) + margins (30) */
+      /* .axis-slider (480) + .slider-name (10) + .slider-values (70) + margins (30) */
       flex: 0 1 590px;
     }
   }

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -7,8 +7,8 @@
   --color-z: #0099ff;
 
   @extend %axis-override;
-  /* .slider-group-title (50) + .axis-slider (480) + .slider-name (10) + .slider-values (105) + margins & padding (80) */
-  max-width: 725px;
+  /* .slider-group-title (50) + .axis-slider (480) + .slider-name (10) + .slider-values (160) + margins & padding (80) */
+  max-width: 770px;
   position: absolute;
   margin: 0 auto;
   left: 0;
@@ -90,9 +90,8 @@
     font-weight: bold;
   }
 
-  /* TODO this will need to be expanded (here and in 2d!) */
   .slider-values {
-    flex: 0 0 105px;
+    flex: 0 0 160px;
     margin-left: 18px;
     white-space: nowrap;
     max-width: 105px;
@@ -104,17 +103,17 @@
 
   &.clip-sliders-2d {
     /* Make room for play buttons */
-    /* .slider-group-title (50) + .axis-slider (480) + .slider-name (10) + .slider-values (70) + .slider-play-buttons (95) + margins & padding (100) */
-    max-width: 805px;
+    /* .slider-group-title (50) + .axis-slider (480) + .slider-name (10) + .slider-values (100) + .slider-play-buttons (95) + margins & padding (100) */
+    max-width: 835px;
 
     /* Slider slice display contains 2 numbers in 2d mode, not 3 - shrink accordingly */
     .slider-values {
-      flex: 0 0 70px;
+      flex: 0 0 100px;
     }
 
     .axis-slider-container {
-      /* .axis-slider (480) + .slider-name (10) + .slider-values (70) + margins (30) */
-      flex: 0 1 590px;
+      /* .axis-slider (480) + .slider-name (10) + .slider-values (100) + margins (30) */
+      flex: 0 1 620px;
     }
   }
 
@@ -135,11 +134,12 @@
     transform: matrix(0.5, 0.6, -0.5, 0.6, 0, 5);
   }
 
-  .slider-play-buttons .ant-btn {
-    line-height: 1.2;
-    height: 21px;
-    color: $light-gray;
-    border-color: $light-gray !important;
+  .ant-btn.slider-play-button {
+    line-height: 1;
+    height: 23px;
+    width: 28px;
+    color: #bfbfbf;
+    border-color: #4b4b4b !important;
     background-color: transparent;
 
     &:hover {

--- a/src/aics-image-viewer/components/shared/NumericInput/index.tsx
+++ b/src/aics-image-viewer/components/shared/NumericInput/index.tsx
@@ -16,7 +16,8 @@ interface NumericInputProps {
 
 /**
  * Fully-controlled numeric input (value must be supplied from state in parent).
- * Changeable with arrow keys, typing, or clickable arrows.
+ * Changeable with arrow keys, typing values, or clickable arrows. Inspired by
+ * ant's `InputNumber`, but conforms to our style and behavior expectations.
  */
 const NumericInput: React.FC<NumericInputProps> = ({
   value,

--- a/src/aics-image-viewer/components/shared/NumericInput/index.tsx
+++ b/src/aics-image-viewer/components/shared/NumericInput/index.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { Icon } from "antd";
+
+import "./styles.css";
+
+interface NumericInputProps {
+  value: number;
+  step?: number;
+  min?: number;
+  max?: number;
+  disabled?: boolean;
+  className?: string;
+  onChange: (value: number) => void;
+}
+
+/**
+ * Fully-controlled numeric input (value must be supplied from state in parent).
+ * Changeable with arrow keys, typing, or clickable arrows.
+ */
+const NumericInput: React.FC<NumericInputProps> = ({
+  value,
+  step = 1,
+  min = 0,
+  max = Number.MAX_SAFE_INTEGER,
+  disabled = false,
+  className = "",
+  onChange,
+}) => {
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const fullClassName = "numinput" + (disabled ? " numinput-disabled" : "") + (className && ` ${className}`);
+
+  const clamp = (newValue: number): number => Math.min(Math.max(newValue, min), max);
+  const roundToStep = (newValue: number): number => clamp(Math.round(newValue * step) / step);
+
+  const onChangeChecked = (newValue: number): void => {
+    if (newValue !== value && !disabled) {
+      onChange(newValue);
+    }
+  };
+
+  const changeByStep = (up: boolean): void => {
+    const delta = up ? step : -step;
+    onChangeChecked(clamp(value + delta));
+    inputRef.current?.focus();
+  };
+
+  const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (event) => {
+    if (["Up", "ArrowUp", "Down", "ArrowDown"].includes(event.key)) {
+      changeByStep(event.key === "Up" || event.key === "ArrowUp");
+      event.preventDefault();
+    }
+  };
+
+  return (
+    <div className={fullClassName} onKeyDown={onKeyDown}>
+      <input
+        value={value}
+        step={step}
+        min={min}
+        max={max}
+        disabled={disabled}
+        className="numinput-input"
+        autoComplete="off"
+        role="spinbutton"
+        aria-valuenow={value}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        ref={inputRef}
+        onChange={({ target }) => onChangeChecked(roundToStep(parseFloat(target.value)))}
+      />
+      <div className="numinput-controls">
+        <div
+          className="numinput-controls-button numinput-controls-button-up"
+          unselectable="on"
+          role="button"
+          aria-label="Increase Value"
+          aria-disabled={disabled}
+          onClick={() => changeByStep(true)}
+        >
+          <Icon className="numinput-controls-button-icon" type="up" />
+        </div>
+        <div
+          className="numinput-controls-button numinput-controls-button-down"
+          unselectable="on"
+          role="button"
+          aria-label="Decrease Value"
+          aria-disabled={disabled}
+          onClick={() => changeByStep(false)}
+        >
+          <Icon className="numinput-controls-button-icon" type="down" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NumericInput;

--- a/src/aics-image-viewer/components/shared/NumericInput/index.tsx
+++ b/src/aics-image-viewer/components/shared/NumericInput/index.tsx
@@ -30,7 +30,14 @@ const NumericInput: React.FC<NumericInputProps> = ({
   onChange,
 }) => {
   // While the input has focus, allow invalid input, just don't call `onChange` with it
-  const [hasFocus, setHasFocus] = React.useState(false);
+  const [hasFocus, _setHasFocus] = React.useState(false);
+  // State doesn't update before focus handler runs - keep a ref following focus state
+  const hasFocusRef = React.useRef(false);
+  const setHasFocus = (focus: boolean): void => {
+    _setHasFocus(focus);
+    hasFocusRef.current = focus;
+  };
+
   // Hold the potentially invalid contents of the focused input here
   const [textContent, setTextContent] = React.useState("");
 
@@ -41,7 +48,7 @@ const NumericInput: React.FC<NumericInputProps> = ({
   const shouldChange = (newValue: number): boolean => !(isNaN(newValue) || newValue === value || disabled);
 
   const onFocus = (): void => {
-    if (!hasFocus) {
+    if (!hasFocusRef.current) {
       // propagate current value to `textContent` on focus
       setTextContent(value.toString());
       setHasFocus(true);
@@ -55,7 +62,7 @@ const NumericInput: React.FC<NumericInputProps> = ({
     if (shouldChange(newValue)) {
       onChange(newValue);
       setTextContent(newValue.toString());
-      // ensure the previous value won't be restored on focus
+      // let the focus handler know we've taken care of things, so it won't restore the previous value
       setHasFocus(true);
     }
 
@@ -74,6 +81,7 @@ const NumericInput: React.FC<NumericInputProps> = ({
   };
 
   const handleTyping = (inputStr: string): void => {
+    console.log("handletyping");
     setTextContent(inputStr);
 
     // if the user clears all text, assume they mean 0 (or the extremum closest to it)

--- a/src/aics-image-viewer/components/shared/NumericInput/index.tsx
+++ b/src/aics-image-viewer/components/shared/NumericInput/index.tsx
@@ -6,6 +6,7 @@ import "./styles.css";
 interface NumericInputProps {
   value: number;
   step?: number;
+  precision?: number;
   min?: number;
   max?: number;
   disabled?: boolean;
@@ -20,6 +21,7 @@ interface NumericInputProps {
 const NumericInput: React.FC<NumericInputProps> = ({
   value,
   step = 1,
+  precision = step,
   min = 0,
   max = Number.MAX_SAFE_INTEGER,
   disabled = false,
@@ -30,10 +32,10 @@ const NumericInput: React.FC<NumericInputProps> = ({
   const fullClassName = "numinput" + (disabled ? " numinput-disabled" : "") + (className && ` ${className}`);
 
   const clamp = (newValue: number): number => Math.min(Math.max(newValue, min), max);
-  const roundToStep = (newValue: number): number => clamp(Math.round(newValue * step) / step);
+  const roundToPrecision = (newValue: number): number => clamp(Math.round(newValue * precision) / precision);
 
   const onChangeChecked = (newValue: number): void => {
-    if (newValue !== value && !disabled) {
+    if (newValue !== value && !disabled && !isNaN(newValue)) {
       onChange(newValue);
     }
   };
@@ -66,7 +68,7 @@ const NumericInput: React.FC<NumericInputProps> = ({
         aria-valuemin={min}
         aria-valuemax={max}
         ref={inputRef}
-        onChange={({ target }) => onChangeChecked(roundToStep(parseFloat(target.value)))}
+        onChange={({ target }) => onChangeChecked(roundToPrecision(parseFloat(target.value)))}
       />
       <div className="numinput-controls">
         <div

--- a/src/aics-image-viewer/components/shared/NumericInput/index.tsx
+++ b/src/aics-image-viewer/components/shared/NumericInput/index.tsx
@@ -74,7 +74,6 @@ const NumericInput: React.FC<NumericInputProps> = ({
       <div className="numinput-controls">
         <div
           className="numinput-controls-button numinput-controls-button-up"
-          unselectable="on"
           role="button"
           aria-label="Increase Value"
           aria-disabled={disabled}
@@ -84,7 +83,6 @@ const NumericInput: React.FC<NumericInputProps> = ({
         </div>
         <div
           className="numinput-controls-button numinput-controls-button-down"
-          unselectable="on"
           role="button"
           aria-label="Decrease Value"
           aria-disabled={disabled}

--- a/src/aics-image-viewer/components/shared/NumericInput/styles.css
+++ b/src/aics-image-viewer/components/shared/NumericInput/styles.css
@@ -1,0 +1,60 @@
+.numinput {
+  height: 23px;
+  width: 52px;
+  position: relative;
+  display: inline-block;
+  box-sizing: border-box;
+
+  &.numinput-disabled {
+    opacity: 0.5;
+  }
+
+  .numinput-input {
+    width: 40px;
+    height: 100%;
+    font-size: 12px;
+    background-color: #222222;
+    text-align: right;
+    border: 1px solid #4b4b4b;
+    padding-right: 6px;
+
+    &:focus {
+      outline: none;
+    }
+  }
+
+  .numinput-controls {
+    width: 12px;
+    height: 100%;
+    position: absolute;
+    display: inline-block;
+    border: 1px solid #4b4b4b;
+    border-left-width: 0;
+  }
+
+  .numinput-controls-button {
+    width: 100%;
+    height: 50%;
+    line-height: 0;
+    transition: all 0.3s linear;
+
+    &.numinput-controls-button-up {
+      border-bottom: 1px solid #4b4b4b;
+    }
+
+    .numinput-controls-button-icon {
+      font-size: 9px;
+      margin: 1px;
+    }
+  }
+
+  &:not(.numinput-disabled) .numinput-controls-button {
+    cursor: pointer;
+
+    &:hover,
+    &:focus {
+      background-color: #9e6aff;
+      color: white;
+    }
+  }
+}

--- a/src/aics-image-viewer/components/shared/NumericInput/styles.css
+++ b/src/aics-image-viewer/components/shared/NumericInput/styles.css
@@ -13,10 +13,10 @@
     width: 40px;
     height: 100%;
     font-size: 12px;
-    background-color: #222222;
     text-align: right;
-    border: 1px solid #4b4b4b;
     padding-right: 6px;
+    background-color: #222222;
+    border: 1px solid #4b4b4b;
 
     &:focus {
       outline: none;


### PR DESCRIPTION
Resolve #134: add spinboxes to allow manual entry of values in ROI/Time sliders. Remove now-redundant step buttons next to the play button in 2d mode.

I initially tried to add ant's [`InputNumber`](https://ant.design/components/input-number) component (as mentioned in the issue) and override its styles until it matched specification. But I eventually decided that this would likely take me as long as writing a new component, which would produce a cleaner and more legible result anyways. So, by observing `InputNumber` in the inspector and referencing a bit of its source (relevant file [here](https://github.com/react-component/input-number/blob/master/src/InputNumber.tsx)), I added the `NumericInput` shared component. `NumericInput` supports a reasonable subset of the original component's props, should be equivalently accessible, and behaves as specified by default without requiring a tangled mess of contradictory CSS.

### Screenshots

![image](https://github.com/allen-cell-animated/website-3d-cell-viewer/assets/53030214/89625c6a-671f-4a79-b131-4a53eded62b5)
![image](https://github.com/allen-cell-animated/website-3d-cell-viewer/assets/53030214/e3ee4a6c-05de-4f79-9053-43053bf9a2ee)
