### PR TITLE
Feature/slider styling

### DIFF
--- a/src/aics-image-viewer/assets/styles/noui-slider-override.css
+++ b/src/aics-image-viewer/assets/styles/noui-slider-override.css
@@ -10,11 +10,11 @@
     top: 0px;
     left: 100%;
     z-index: 1;
-    width: 6px;
+    width: 8px;
     height: 8px;
     border: none;
     border-radius: 0;
-    transform: translate(-50%, calc(-100% - 5px));
+    transform: translate(-50%, calc(-100% - 4px));
   }
 
   .noUi-handle::before {
@@ -25,13 +25,19 @@
   /* Slider handle arrow */
   .noUi-handle::after {
     background-color: inherit;
-    width: 6px;
-    height: 6px;
+    width: 8px;
+    height: 8px;
     top: 0;
     left: 0;
-    /* rotate 45deg, skew vertically, translate down */
-    transform: matrix(0.5, 1, -0.5, 1, 0, 5);
+    /* rotate 45deg, translate down */
+    transform: matrix(0.5, 0.5, -0.5, 0.5, 0, 4);
     content: "";
+  }
+
+  .noUi-touch-area {
+    padding: 8px;
+    margin-top: -4px;
+    margin-left: -4px;
   }
 
   .noUi-connect {

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -30,6 +30,7 @@ const SliderRow: React.FC<SliderRowProps> = ({ label, vals, valsReadout = vals, 
       <span className="slider-name">{label}</span>
       <span className="axis-slider">
         <SmarterSlider
+          className={isRange ? "" : "slider-single-handle"}
           connect={true}
           range={{ min: 0, max }}
           start={vals}

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -36,6 +36,15 @@ const SliderRow: React.FC<SliderRowProps> = ({ label, vals, valsReadout = vals, 
           step={1}
           margin={1}
           behaviour="drag"
+          pips={{
+            mode: "positions",
+            values: [25, 50, 75],
+            density: 25,
+            format: {
+              // remove labels from pips
+              to: () => "",
+            },
+          }}
           // round slider output to nearest slice; assume any string inputs represent ints
           format={{ to: Math.round, from: parseInt }}
           onSlide={onSlide}

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -132,6 +132,7 @@
     transform: translate(-50%, calc(-100% - 4px));
   }
 
+  /* Dot on the slider track for single-handle sliders */
   .slider-single-handle .noUi-handle::before {
     content: "";
     display: block;

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -72,7 +72,7 @@
     }
   }
 
-  /* container to keep slider and labels on one line while play buttons wrap */
+  /* container to keep slider and labels on one line while play button wraps */
   .axis-slider-container {
     display: flex;
     flex: 1 1 auto;
@@ -129,21 +129,22 @@
   }
 
   .noUi-handle {
-    width: 8px;
-    height: 8px;
-    transform: translate(-50%, calc(-100% - 3px));
+    transform: translate(-50%, calc(-100% - 4px));
   }
 
-  .noUi-touch-area {
-    padding: 8px;
-    margin-top: -4px;
-    margin-left: -4px;
+  .slider-single-handle .noUi-handle::before {
+    content: "";
+    display: block;
+    height: 4px;
+    width: 4px;
+    left: 2px;
+    top: 11px;
+    border-radius: 50%;
+    background-color: $slider-color;
   }
 
   .noUi-handle::after {
-    width: 8px;
-    height: 8px;
-    transform: matrix(0.5, 0.5, -0.5, 0.5, 0, 4);
+    box-shadow: 3px 3px 3px -2px black;
   }
 
   .noUi-pips {

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -131,13 +131,29 @@
   .noUi-handle {
     width: 8px;
     height: 8px;
-    transform: translate(-50%, calc(-100% - 4px));
+    transform: translate(-50%, calc(-100% - 3px));
   }
 
   .noUi-handle::after {
     width: 8px;
     height: 8px;
-    transform: matrix(0.5, 0.6, -0.5, 0.6, 0, 5);
+    transform: matrix(0.5, 0.5, -0.5, 0.5, 0, 4);
+  }
+
+  .noUi-pips {
+    padding: 0;
+    height: 0;
+    top: 2px;
+
+    .noUi-marker-normal {
+      display: none;
+    }
+
+    .noUi-marker-large {
+      background-color: #4b4b4b;
+      height: 9px;
+      bottom: -4px;
+    }
   }
 
   .ant-btn.slider-play-button {

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -144,7 +144,7 @@
   }
 
   .noUi-handle::after {
-    box-shadow: 3px 3px 3px -2px black;
+    box-shadow: 4px 4px 3px 0 rgba(0, 0, 0, 0.2);
   }
 
   .noUi-pips {

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -134,6 +134,12 @@
     transform: translate(-50%, calc(-100% - 3px));
   }
 
+  .noUi-touch-area {
+    padding: 8px;
+    margin-top: -4px;
+    margin-left: -4px;
+  }
+
   .noUi-handle::after {
     width: 8px;
     height: 8px;

--- a/src/aics-image-viewer/components/shared/NumericInput/index.tsx
+++ b/src/aics-image-viewer/components/shared/NumericInput/index.tsx
@@ -81,7 +81,6 @@ const NumericInput: React.FC<NumericInputProps> = ({
   };
 
   const handleTyping = (inputStr: string): void => {
-    console.log("handletyping");
     setTextContent(inputStr);
 
     // if the user clears all text, assume they mean 0 (or the extremum closest to it)


### PR DESCRIPTION
Resolves #137:
- Adds three evenly-spaced tick marks to sliders
- Widens slider handle, and further expands clickable area beyond visible handle (also applied to global settings sliders)
- Sliders with a single handle get a dot in the slider track
- Adds a bit of box shadow to slider handles, for added contrast against the track and dot (this appears in the design)

Remaining time slider work for #127:
- #135: Investigate ghosted handle
- Add time in proper units above clipping panel
- Potentially a bit more internals work

### Screenshot:
![image](https://github.com/allen-cell-animated/website-3d-cell-viewer/assets/53030214/5a22b161-30c2-4a23-b676-d52e36206eb0)
