### PR TITLE
Feature/viewer 3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@aics/volume-viewer": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.1.1.tgz",
-      "integrity": "sha512-LFIbO5RkBpOkZMAj44BU0hHI9/quybiei51HN+Q8txOxISIthyyMXdx9b7VEA1GL3aqnQ4l/Pr/j9eeBaveQjg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.2.0.tgz",
+      "integrity": "sha512-4h72U+MJO5zdqlxtdfq69cCs+3BQyv1SPx0cLk/Tt1SHihPCBQ/hGjkABIcWSOG/RbZC0Mx4SoGfn6KiJt8Zpg==",
       "requires": {
         "geotiff": "^2.0.5",
         "three": "^0.144.0",
@@ -3102,9 +3102,9 @@
       }
     },
     "@petamoriken/float16": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.7.1.tgz",
-      "integrity": "sha512-oXZOc+aePd0FnhTWk15pyqK+Do87n0TyLV1nxdEougE95X/WXWDqmQobfhgnSY7QsWn5euZUWuDVeTQvoQ5VNw=="
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.1.tgz",
+      "integrity": "sha512-oj3dU9kuMy8AqrreIboVh3KCJGSQO5T+dJ8JQFl369961jTWvPLP1GIlLy0FVoWehXLoI9BXygu/yzuNiIHBlg=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -16637,9 +16637,9 @@
       "dev": true
     },
     "xml-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.3.0.tgz",
-      "integrity": "sha512-i4PIrX33Wd66dvwo4syicwlwmnr6wuvvn4f2ku9hA67C2Uk62Xubczuhct+Evnd12/DV71qKNeDdJwES8HX1RA=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.7.0.tgz",
+      "integrity": "sha512-bWB489+RQQclC7A9OW8e5BzbT8Tu//jtAOvkYwewFr+Q9T9KDGvfzC1lp0pYPEQPEoPQLDkmxkepSC/2gIAZGw=="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/volume-viewer": "^3.1.1",
+    "@aics/volume-viewer": "^3.2.0",
     "color-string": "^1.5.3",
     "d3": "^4.11.0",
     "lodash": "^4.17.20",

--- a/src/aics-image-viewer/components/App/ChannelUpdater.tsx
+++ b/src/aics-image-viewer/components/App/ChannelUpdater.tsx
@@ -11,24 +11,24 @@ interface ChannelUpdaterProps {
   channelState: ChannelState;
   view3d: View3d;
   image: Volume | null;
-  channelLoaded: boolean;
+  version: number;
 }
 
 /**
  * A component that doesn't render anything, but reacts to the provided `ChannelState`
  * and keeps it in sync with the viewer.
  */
-const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, channelState, view3d, image, channelLoaded }) => {
+const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, channelState, view3d, image, version }) => {
   const { volumeEnabled, isosurfaceEnabled, isovalue, colorizeEnabled, colorizeAlpha, opacity, color, controlPoints } =
     channelState;
 
   // Effects to update channel settings should check if image is present and channel is loaded first
   const useImageEffect: UseImageEffectType = (effect, deps) => {
     useEffect(() => {
-      if (image && channelLoaded) {
+      if (image && version > 0) {
         return effect(image);
       }
-    }, [...deps, image, channelLoaded]);
+    }, [...deps, image, version]);
   };
 
   useImageEffect(

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -175,9 +175,6 @@ const App: React.FC<AppProps> = (props) => {
   const [switchingFov, setSwitchingFov] = useState(false);
   // tracks which channels have been loaded
   const [loadedChannels, setLoadedChannels, getLoadedChannels] = useStateWithGetter<boolean[]>([]);
-  // TODO use `loadSpec` held by `Volume` instead
-  // tracks the source of the current image, to keep us from reloading an image that is already open
-  const [currentImageLoadSpec, setCurrentImageLoadSpec] = useState<LoadSpec | undefined>(undefined);
 
   const [channelGroupedByType, setChannelGroupedByType] = useState<ChannelGrouping>({});
   const [controlPanelClosed, setControlPanelClosed] = useState(() => window.innerWidth < CONTROL_PANEL_CLOSE_WIDTH);
@@ -448,8 +445,9 @@ const App: React.FC<AppProps> = (props) => {
     const fullUrl = `${baseUrl}${path}`;
 
     // If this is the same image at a different time, keep luts. If same image at same time, don't bother reloading.
-    const samePath = path === currentImageLoadSpec?.subpath;
-    if (samePath && viewerSettings.time === currentImageLoadSpec?.time) {
+    const currentLoadSpec = image?.loadSpec;
+    const samePath = path === currentLoadSpec?.subpath;
+    if (samePath && viewerSettings.time === currentLoadSpec?.time) {
       return;
     }
 
@@ -479,8 +477,6 @@ const App: React.FC<AppProps> = (props) => {
       const thisChannelSettings = getOneChannelSetting(v.imageInfo.channel_names[channelIndex]);
       onChannelDataLoaded(v, thisChannelSettings!, channelIndex, samePath);
     });
-
-    setCurrentImageLoadSpec(loadSpec);
 
     const channelNames = aimg.imageInfo.channel_names;
     const newChannelSettings = setChannelStateForNewImage(channelNames);

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -135,6 +135,28 @@ const defaultProps: AppProps = {
   canvasMargin: "0 0 0 0",
 };
 
+const setIndicatorPositions = (view3d: View3d, panelOpen: boolean, hasTime: boolean): void => {
+  const CLIPPING_PANEL_HEIGHT = 150;
+  // Move scale bars this far to the left when showing time series, to make room for timestep indicator
+  const SCALE_BAR_TIME_SERIES_OFFSET = 120;
+
+  let axisY = AXIS_MARGIN_DEFAULT[1];
+  let [scaleBarX, scaleBarY] = SCALE_BAR_MARGIN_DEFAULT;
+  if (panelOpen) {
+    // Move indicators up out of the way of the clipping panel
+    axisY += CLIPPING_PANEL_HEIGHT;
+    scaleBarY += CLIPPING_PANEL_HEIGHT;
+  }
+  if (hasTime) {
+    // Move scale bar left out of the way of timestep indicator
+    scaleBarX += SCALE_BAR_TIME_SERIES_OFFSET;
+  }
+
+  view3d.setAxisPosition(AXIS_MARGIN_DEFAULT[0], axisY);
+  view3d.setTimestepIndicatorPosition(SCALE_BAR_MARGIN_DEFAULT[0], scaleBarY);
+  view3d.setScaleBarPosition(scaleBarX, scaleBarY);
+};
+
 /** A `useState` that also creates a getter function for breaking through closures */
 function useStateWithGetter<T>(initialState: T | (() => T)): [T, (value: T) => void, () => T] {
   const [state, setState] = useState(initialState);
@@ -432,7 +454,7 @@ const App: React.FC<AppProps> = (props) => {
       }),
     });
 
-    setIndicatorPositions(clippingPanelOpenRef.current, aimg.imageInfo.times > 1);
+    setIndicatorPositions(view3d, clippingPanelOpenRef.current, aimg.imageInfo.times > 1);
     imageLoadHandlers.current.forEach((effect) => effect(aimg));
 
     if (doResetMaskAlpha) {
@@ -540,32 +562,10 @@ const App: React.FC<AppProps> = (props) => {
 
   const resetCamera = useCallback((): void => view3d.resetCamera(), []);
 
-  const setIndicatorPositions = (panelOpen: boolean, hasTime: boolean): void => {
-    const CLIPPING_PANEL_HEIGHT = 150;
-    // Move scale bars this far to the left when showing time series, to make room for timestep indicator
-    const SCALE_BAR_TIME_SERIES_OFFSET = 120;
-
-    let axisY = AXIS_MARGIN_DEFAULT[1];
-    let [scaleBarX, scaleBarY] = SCALE_BAR_MARGIN_DEFAULT;
-    if (panelOpen) {
-      // Move indicators up out of the way of the clipping panel
-      axisY += CLIPPING_PANEL_HEIGHT;
-      scaleBarY += CLIPPING_PANEL_HEIGHT;
-    }
-    if (hasTime) {
-      // Move scale bar left out of the way of timestep indicator
-      scaleBarX += SCALE_BAR_TIME_SERIES_OFFSET;
-    }
-
-    view3d.setAxisPosition(AXIS_MARGIN_DEFAULT[0], axisY);
-    view3d.setTimestepIndicatorPosition(SCALE_BAR_MARGIN_DEFAULT[0], scaleBarY);
-    view3d.setScaleBarPosition(scaleBarX, scaleBarY);
-  };
-
   const onClippingPanelVisibleChange = useCallback(
     (panelOpen: boolean, hasTime: boolean): void => {
       clippingPanelOpenRef.current = panelOpen;
-      setIndicatorPositions(panelOpen, hasTime);
+      setIndicatorPositions(view3d, panelOpen, hasTime);
 
       // Hide indicators while clipping panel is in motion - otherwise they pop to the right place prematurely
       view3d.setShowScaleBar(false);

--- a/src/aics-image-viewer/components/AxisClipSliders/styles.css
+++ b/src/aics-image-viewer/components/AxisClipSliders/styles.css
@@ -16,13 +16,21 @@
   @extend %axis-override;
   max-width: calc(var(--w-group-title) + var(--w-axis-slider) + var(--w-name) + var(--w-values-3d) + 80px);
   position: absolute;
-  margin: 0 auto;
+  margin: auto;
+  top: calc(50% + 21px);
+  transform: translateY(-50%);
   left: 0;
   right: 0;
   padding: 0 25px;
+  /* padding: 42px 25px 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap; */
 
   .slider-group {
     display: flex;
+    flex: 1 0 auto;
     flex-wrap: nowrap;
 
     &:not(:last-child) {

--- a/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
+++ b/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
@@ -26,8 +26,8 @@ interface ViewerWrapperProps {
     axisClipSliders: boolean;
   };
   changeViewerSetting: ViewerSettingUpdater;
-  onClippingPanelVisibleChange?: (open: boolean) => void;
-  onClippingPanelVisibleChangeEnd?: (open: boolean) => void;
+  onClippingPanelVisibleChange?: (panelOpen: boolean, hasTime: boolean) => void;
+  onClippingPanelVisibleChangeEnd?: (panelOpen: boolean) => void;
 }
 
 interface ViewerWrapperState {}
@@ -73,7 +73,7 @@ export default class ViewerWrapper extends React.Component<ViewerWrapperProps, V
         <div ref={this.view3dviewerRef} style={STYLES.view3d}></div>
         <BottomPanel
           title="Clipping"
-          onVisibleChange={this.props.onClippingPanelVisibleChange}
+          onVisibleChange={(visible) => this.props.onClippingPanelVisibleChange?.(visible, numTimesteps > 1)}
           onVisibleChangeEnd={this.props.onClippingPanelVisibleChangeEnd}
         >
           {showControls.axisClipSliders && this.props.hasImage && (

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -7,8 +7,6 @@ export const // Control panel will automatically close if viewport is less than 
   BOUNDING_BOX_COLOR_DEFAULT: ColorArray = [255, 255, 255],
   AXIS_MARGIN_DEFAULT: [number, number] = [16, 16],
   SCALE_BAR_MARGIN_DEFAULT: [number, number] = [120, 12],
-  // Move scale bars this far to the left when showing time series, to make room for timestep indicator
-  SCALE_BAR_TIME_SERIES_OFFSET = 120,
   // These settings were chosen to work well with most AICS microscopy pipeline images.
   // These numbers mean: remap the bottom LUT_MIN_PERCENTILE fraction of pixels to zero intensity,
   // and linearly increase intensity up to the LUT_MAX_PERCENTILE fraction of pixels.

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -7,6 +7,8 @@ export const // Control panel will automatically close if viewport is less than 
   BOUNDING_BOX_COLOR_DEFAULT: ColorArray = [255, 255, 255],
   AXIS_MARGIN_DEFAULT: [number, number] = [16, 16],
   SCALE_BAR_MARGIN_DEFAULT: [number, number] = [120, 12],
+  // Move scale bars this far to the left when showing time series, to make room for timestep indicator
+  SCALE_BAR_TIME_SERIES_OFFSET = 120,
   // These settings were chosen to work well with most AICS microscopy pipeline images.
   // These numbers mean: remap the bottom LUT_MIN_PERCENTILE fraction of pixels to zero intensity,
   // and linearly increase intensity up to the LUT_MAX_PERCENTILE fraction of pixels.


### PR DESCRIPTION
Update volume-viewer to 3.2.0 and use its new APIs and features.

Since the last version, the API for volume loaders has changed, `View3d` gained a method for changing time in a time series, and a new time step indicator has been added.

#### Changes
- Update image loading to use the new `IVolumeLoader` API; stores created loaders in a ref for use when loading time series images
- Use the new `setTime` method to move through time (using the stored loader) without creating a new `Volume`
- Use the new time step indicator; add logic to move scale bars out of its way when present
- Remove the current image's `LoadSpec` as an element of state, since `Volume` objects now store their own `LoadSpec`s
- Vertically centers the clipping sliders (unrelated to the update, but it was a bit of the design I missed)
- Fix a bug where, if multiple loads of the same image were processing at the same time, only the first load to complete would trigger a channel update and subsequent ones would leave channels in a state that didn't match settings. This state was technically possible to create previously by switching from "Single cell" to "Full field" and back very fast, but became a clear problem when it became possible to quickly scrub through time. I fixed this by replacing the boolean `channelLoaded` prop on `ChannelUpdater` with a `version` number which increments on channel load, so that many concurrent loads can all create a new value for this prop when they arrive.

### Screenshot
![image](https://github.com/allen-cell-animated/website-3d-cell-viewer/assets/53030214/ad383c5e-e756-40a3-ac7b-d29b29980c43)
