### PR TITLE
fix zarr loading from CFE

### DIFF
--- a/public/index.tsx
+++ b/public/index.tsx
@@ -137,11 +137,9 @@ if (params) {
   }
   if (params.url) {
     // ZARR:
-    // ?url=zarrstore&image=imagename
-    // ?url=zarrstore will default to image "0"
-    // zarrstore must end with .zarr
-    // put the store url in baseUrl,
-    // and the image name in cellPath
+    // ?url=baseurl/zarr.zarr&image=subpath
+    // ?url=baseurl&image=imagename.zarr (no subpath)
+    // everything except for baseurl will be the cellPath
     // Time 0 will be loaded.
     // TODO specify Pyramid level
 
@@ -157,27 +155,25 @@ if (params) {
     // any split between baseUrl + cellPath is ok
     // as long as (baseUrl+cellPath) ends with .json
 
-    // it is understood that if nextImgPath and/or prevImgPath
-    // are provided, they must be relative to baseUrl in addition to cellPath.
-    // same deal for fovPath
+    // it is understood that if fovPath is provided, 
+    // it must be relative to baseUrl in addition to cellPath.
 
     let decodedurl = decodeURI(params.url);
     let decodedimage = "";
     if (params.image) {
       decodedimage = decodeURIComponent(params.image);
-    } else {
-      // image not specified
-      if (decodedurl.endsWith(".zarr")) {
-        decodedimage = "";
-      } else {
-        if (decodedurl.endsWith("/")) {
-          decodedurl = decodedurl.slice(0, -1);
-        }
-        const spliturl = decodedurl.split("/");
-        decodedimage = spliturl[spliturl.length - 1];
-        decodedurl = decodedurl.slice(0, -decodedimage.length);
-      }
+    } 
+
+    // get the last thing in the url
+    if (decodedurl.endsWith("/")) {
+      decodedurl = decodedurl.slice(0, -1);
     }
+    const spliturl = decodedurl.split("/");
+    const lastpart = spliturl[spliturl.length - 1];
+    const baseUrl = decodedurl.slice(0, -lastpart.length);
+    // any difference for zarr or tiff or json?
+    decodedurl = baseUrl;
+    decodedimage = lastpart+"/"+decodedimage;
 
     args.cellid = 1;
     args.baseurl = decodedurl;

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -452,7 +452,8 @@ const App: React.FC<AppProps> = (props) => {
 
     // If this is the same image at a different time, keep luts. If same image at same time, don't bother reloading.
     const currentLoadSpec = image?.loadSpec;
-    const samePath = path === currentLoadSpec?.subpath;
+    const samePath = fullUrl === currentLoadSpec?.url;
+    // future TODO: check for whether multiresolution level (subpath) would be different too.
     if (samePath && viewerSettings.time === currentLoadSpec?.time) {
       return;
     }

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -462,7 +462,7 @@ const App: React.FC<AppProps> = (props) => {
 
     const loadSpec = new LoadSpec();
     loadSpec.url = fullUrl;
-    loadSpec.subpath = path;
+    loadSpec.subpath = "";
     loadSpec.time = viewerSettings.time;
 
     // if this does NOT end with tif or json,


### PR DESCRIPTION
Most CFE datasets use a `baseUrl` and then combine it with a `cellPath` which is the individual image name. 
The use of `subpath` was doubling up the filename and causing bad urls when fetching zarr data.  `subpath` is really supposed to be used for multiresolution level and not much else. (A future change will have to address this naming)

This changeset just stops putting any information in subpath, and adjusts the standalone app inputs accordingly.  

This should fully enable CFE datasets to support zarr as the file format for 3d viewer!