### PR TITLE
fix bug with trailing slash when url points to complete file (tiff)

### DIFF
--- a/public/index.tsx
+++ b/public/index.tsx
@@ -173,7 +173,12 @@ if (params) {
     const baseUrl = decodedurl.slice(0, -lastpart.length);
     // any difference for zarr or tiff or json?
     decodedurl = baseUrl;
-    decodedimage = lastpart+"/"+decodedimage;
+    if (decodedimage !== "") {
+      decodedimage = lastpart+"/"+decodedimage;
+    }
+    else {
+      decodedimage = lastpart;
+    }
 
     args.cellid = 1;
     args.baseurl = decodedurl;


### PR DESCRIPTION
Trying to load a tiff url from AWS was failing due to a trailing slash added to the file path.  This fixes it.  The slash will only be added if it is needed to separate `url` and `image`.  If `image` is not provided, then `url` will be assumed to be the whole path.

This change is only for the standalone static web app and does not change the React component.

Repro:
https://allen-cell-animated.github.io/website-3d-cell-viewer/?url=https://animatedcell-test-data.s3.us-west-2.amazonaws.com/HAMILTONIAN_TERM_FOV_VSAHJUP_0000_000192.ome.tif