### PR TITLE
Camera mode in url params

### DIFF
--- a/public/index.tsx
+++ b/public/index.tsx
@@ -59,7 +59,7 @@ export const VIEWER_3D_SETTINGS: ViewerChannelSettings = {
   maskChannelName: "SEG_Memb",
 };
 
-type ParamKeys = "mask" | "ch" | "luts" | "colors" | "image" | "url" | "file" | "dataset" | "id";
+type ParamKeys = "mask" | "ch" | "luts" | "colors" | "image" | "url" | "file" | "dataset" | "id" | "view";
 type Params = { [_ in ParamKeys]?: string };
 
 function parseQueryString(): Params {
@@ -100,6 +100,19 @@ const viewerSettings: Partial<GlobalViewerSettings> = {
 if (params) {
   if (params.mask) {
     viewerSettings.maskAlpha = parseInt(params.mask, 10);
+  }
+  if (params.view) {
+    const mapping = {
+      "3D": ViewMode.threeD,
+      Z: ViewMode.xy,
+      Y: ViewMode.xz,
+      X: ViewMode.yz,
+    }
+    const allowedViews = Object.keys(mapping);
+    if (!allowedViews.includes(params.view)) {
+      params.view = "3D";
+    }
+    viewerSettings.viewMode = mapping[params.view];
   }
   if (params.ch) {
     // ?ch=1,2

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -699,24 +699,25 @@ const App: React.FC<AppProps> = (props) => {
   const usePerAxisClippingUpdater = (axis: AxisName, [minval, maxval]: [number, number], slice: number): void => {
     useImageEffect(
       (currentImage) => {
-        // if (viewerSettings.viewMode === ViewMode.threeD) {
-        //   view3d.setAxisClip(currentImage, axis, -0.5, 0.5, false);
-        // } else {
-        //   const isOrthoAxis = activeAxisMap[viewerSettings.viewMode] === axis;
-        //   view3d.setAxisClip(currentImage, axis, minval - 0.5, maxval - 0.5, isOrthoAxis);
-        // }
-        //view3d.setCameraMode(viewerSettings.viewMode);
+        let isOrthoAxis = false;
+        let axismin = 0.0;
+        let axismax = 1.0;
         if (viewerSettings.viewMode === ViewMode.threeD) {
-          view3d.setAxisClip(currentImage, axis, minval - 0.5, maxval - 0.5, false);
+          axismin = minval;
+          axismax = maxval;
+          isOrthoAxis = false;
         } else {
-          const isOrthoAxis = activeAxisMap[viewerSettings.viewMode] === axis && axis !== "z";
-          const normSlice = slice - 0.5;
+          isOrthoAxis = activeAxisMap[viewerSettings.viewMode] === axis;
           const oneSlice = 1 / currentImage.imageInfo.volumeSize[axis];
+          axismin = isOrthoAxis ? slice : 0.0;
+          axismax = isOrthoAxis ? slice + oneSlice : 1.0;
           if (axis === "z" && viewerSettings.viewMode === ViewMode.xy) {
             view3d.setZSlice(currentImage, Math.floor(slice * currentImage.imageInfo.volumeSize.z));
           }
-          view3d.setAxisClip(currentImage, axis, isOrthoAxis ? normSlice : -0.5, isOrthoAxis ? normSlice + oneSlice : 0.5, isOrthoAxis);
         }
+        // view3d wants the coordinates in the -0.5 to 0.5 range
+        view3d.setAxisClip(currentImage, axis, axismin - 0.5, axismax - 0.5, isOrthoAxis);
+        view3d.setCameraMode(viewerSettings.viewMode);
       },
       [minval, maxval, slice, viewerSettings.viewMode]
     );

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -544,6 +544,11 @@ const App: React.FC<AppProps> = (props) => {
     return () => window.removeEventListener("resize", onResizeDebounced);
   }, []);
 
+  // one-time init after view3d exists and before we start loading images
+  useEffect(() => {
+    view3d.setCameraMode(viewerSettings.viewMode);
+  });
+
   // Hook to trigger image load: on mount, when image source props/state change (`cellId`, `imageType`, `time`)
   useEffect(() => {
     if (props.rawDims && props.rawData) {

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -689,6 +689,10 @@ const App: React.FC<AppProps> = (props) => {
 
   const usePerAxisClippingUpdater = (axis: AxisName, [minval, maxval]: [number, number], slice: number): void => {
     useImageEffect(
+      // Logic to determine axis clipping range, for each of x,y,z,3d slider:
+      // if slider was same as active axis view mode:  [viewerSettings.slice[axis], viewerSettings.slice[axis] + 1.0/volumeSize[axis]]
+      // if in 3d mode: viewerSettings.region[axis]
+      // else: [0,1]
       (currentImage) => {
         let isOrthoAxis = false;
         let axismin = 0.0;
@@ -717,19 +721,6 @@ const App: React.FC<AppProps> = (props) => {
   usePerAxisClippingUpdater("x", viewerSettings.region.x, viewerSettings.slice.x);
   usePerAxisClippingUpdater("y", viewerSettings.region.y, viewerSettings.slice.y);
   usePerAxisClippingUpdater("z", viewerSettings.region.z, viewerSettings.slice.z);
-
-  // if in X mode:  [viewerSettings.slice.x, viewerSettings.slice.x + 1.0/image!.imageInfo.volumeSize.x]
-  // if in 3d mode: viewerSettings.region.x
-  // else: [0,1]
-
-  // Z slice is a separate property that also must be updated
-  // useImageEffect(
-  //   (currentImage) => {
-  //     const slice = Math.floor(viewerSettings.slice.z * currentImage.imageInfo.volumeSize.z);
-  //     view3d.setZSlice(currentImage, slice);
-  //   },
-  //   [viewerSettings.slice.z]
-  // );
 
   // Rendering ////////////////////////////////////////////////////////////////
 

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -452,11 +452,6 @@ const App: React.FC<AppProps> = (props) => {
 
     setAllChannelsUnloaded(channelNames.length);
 
-    // if this image is completely unrelated to the previous image, switch view mode
-    // if (!switchingFov && !samePath) {
-    //   changeViewerSetting("viewMode", ViewMode.threeD);
-    // }
-
     imageUrlRef.current = fullUrl;
     placeImageInViewer(aimg, newChannelSettings);
   };

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -204,30 +204,22 @@ const App: React.FC<AppProps> = (props) => {
   // Some viewer settings require custom change behaviors to change related settings simultaneously or guard against
   // entering an illegal state (e.g. autorotate must not be on in pathtrace mode). Those behaviors are defined here.
   const viewerSettingsChangeHandlers: ViewerSettingChangeHandlers = {
+    // View mode: if we're switching to 2d, switch to volumetric rendering
     viewMode: (prevSettings, viewMode) => {
-      if (viewMode === prevSettings.viewMode) {
-        return prevSettings;
-      }
-      const newSettings: GlobalViewerSettings = { ...prevSettings, viewMode };
-
-      if (activeAxisMap[viewMode]) {
-        // switching to 2d
-        if (prevSettings.viewMode === ViewMode.threeD && newSettings.renderMode === RenderMode.pathTrace) {
-          // Switching from 3D to 2D
-          // if path trace was enabled in 3D turn it off when switching to 2D.
-          newSettings.renderMode = RenderMode.volumetric;
-        }
-      }
-      return newSettings;
+      const switchToVolumetric = viewMode !== ViewMode.threeD && prevSettings.renderMode === RenderMode.pathTrace;
+      return {
+        ...prevSettings,
+        viewMode,
+        renderMode: switchToVolumetric ? RenderMode.volumetric : prevSettings.renderMode,
+      };
     },
-    imageType: (prevSettings, imageType) => {
-      return { ...prevSettings, imageType };
-    },
+    // Render mode: if we're switching to pathtrace, turn off autorotate
     renderMode: (prevSettings, renderMode) => ({
       ...prevSettings,
       renderMode,
       autorotate: renderMode === RenderMode.pathTrace ? false : prevSettings.autorotate,
     }),
+    // Autorotate: do not enable autorotate while in pathtrace mode
     autorotate: (prevSettings, autorotate) => ({
       ...prevSettings,
       // The button should theoretically be unclickable while in pathtrace mode, but this provides extra security

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -182,8 +182,6 @@ const App: React.FC<AppProps> = (props) => {
   const [sendingQueryRequest, setSendingQueryRequest] = useState(false);
   // `true` when all channels of the current image are loaded
   const [imageLoaded, setImageLoaded] = useState(false);
-  // `true` when the image being loaded is related to the previous one, so some settings should be preserved
-  const [switchingFov, setSwitchingFov] = useState(false);
   // tracks which channels have been loaded
   const [channelVersions, setChannelVersions, getChannelVersions] = useStateWithGetter<number[]>([]);
 
@@ -223,7 +221,6 @@ const App: React.FC<AppProps> = (props) => {
       return newSettings;
     },
     imageType: (prevSettings, imageType) => {
-      setSwitchingFov(true);
       return { ...prevSettings, imageType };
     },
     renderMode: (prevSettings, renderMode) => ({
@@ -326,7 +323,6 @@ const App: React.FC<AppProps> = (props) => {
     if (aimg.isLoaded()) {
       view3d.updateActiveChannels(aimg);
       setImageLoaded(true);
-      setSwitchingFov(false);
     }
   };
 

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -547,7 +547,7 @@ const App: React.FC<AppProps> = (props) => {
   // one-time init after view3d exists and before we start loading images
   useEffect(() => {
     view3d.setCameraMode(viewerSettings.viewMode);
-  });
+  }, []);
 
   // Hook to trigger image load: on mount, when image source props/state change (`cellId`, `imageType`, `time`)
   useEffect(() => {

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -111,7 +111,7 @@ const defaultViewerSettings: GlobalViewerSettings = {
   levels: LEVELS_SLIDER_DEFAULT,
   interpolationEnabled: INTERPOLATION_ENABLED_DEFAULT,
   region: { x: [0, 1], y: [0, 1], z: [0, 1] },
-  slice: {x:0.5, y:0.5, z:0.5},
+  slice: { x: 0.5, y: 0.5, z: 0.5 },
   time: 0,
 };
 
@@ -726,7 +726,7 @@ const App: React.FC<AppProps> = (props) => {
   usePerAxisClippingUpdater("x", viewerSettings.region.x, viewerSettings.slice.x);
   usePerAxisClippingUpdater("y", viewerSettings.region.y, viewerSettings.slice.y);
   usePerAxisClippingUpdater("z", viewerSettings.region.z, viewerSettings.slice.z);
-  
+
   // if in X mode:  [viewerSettings.slice.x, viewerSettings.slice.x + 1.0/image!.imageInfo.volumeSize.x]
   // if in 3d mode: viewerSettings.region.x
   // else: [0,1]

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -44,9 +44,11 @@ export interface GlobalViewerSettings {
   levels: [number, number, number];
   interpolationEnabled: boolean;
   // `region` values are in the range [0, 1]. We derive from this the format that the sliders expect
-  // (integers between 0 and num_slices - 1) and the format that view3d expects (in [-0.5, 0.5])
+  // (integers between 0 and num_slices - 1) and the format that view3d expects (in [-0.5, 0.5]).
+  // This state is only active in 3d mode.
   region: PerAxis<[number, number]>;
-  // store the relative position of the slice in the range [0, 1] for each of 3 axes
+  // Store the relative position of the slice in the range [0, 1] for each of 3 axes.
+  // This state is active in x,y,z single slice modes.
   slice: PerAxis<number>;
   time: number;
 }

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -46,6 +46,8 @@ export interface GlobalViewerSettings {
   // `region` values are in the range [0, 1]. We derive from this the format that the sliders expect
   // (integers between 0 and num_slices - 1) and the format that view3d expects (in [-0.5, 0.5])
   region: PerAxis<[number, number]>;
+  // store the relative position of the slice in the range [0, 1] for each of 3 axes
+  slice: PerAxis<number>;
   time: number;
 }
 

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -160,10 +160,9 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     const max = numSlices[axis];
     const start = minval / max;
     const end = maxval / max;
-    if (twoD){
+    if (twoD) {
       changeViewerSetting("slice", { ...slices, [axis]: start });
-    }
-    else {
+    } else {
       changeViewerSetting("region", { ...region, [axis]: [start, end] });
     }
   }
@@ -180,7 +179,9 @@ export default class AxisClipSliders extends React.Component<AxisClipSlidersProp
     const numSlices = this.props.numSlices[axis];
     const clipVals = this.props.region[axis];
     const slice = this.props.slices[axis];
-    const sliderVals = twoD ? [Math.round(slice*numSlices)] : [Math.round(clipVals[0] * numSlices), Math.round(clipVals[1] * numSlices)];
+    const sliderVals = twoD
+      ? [Math.round(slice * numSlices)]
+      : [Math.round(clipVals[0] * numSlices), Math.round(clipVals[1] * numSlices)];
 
     return (
       <div key={axis + numSlices} className={`slider-row slider-${axis}`}>

--- a/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
+++ b/src/aics-image-viewer/components/CellViewerCanvasWrapper/index.tsx
@@ -20,6 +20,7 @@ interface ViewerWrapperProps {
   hasImage: boolean;
   numSlices: PerAxis<number>;
   region: PerAxis<[number, number]>;
+  slices: PerAxis<number>;
   numTimesteps: number;
   time: number;
   showControls: {
@@ -65,7 +66,7 @@ export default class ViewerWrapper extends React.Component<ViewerWrapperProps, V
   }
 
   render(): React.ReactNode {
-    const { appHeight, changeViewerSetting, showControls, numSlices, numTimesteps, viewMode, region, time } =
+    const { appHeight, changeViewerSetting, showControls, numSlices, numTimesteps, viewMode, region, slices, time } =
       this.props;
 
     return (
@@ -82,6 +83,7 @@ export default class ViewerWrapper extends React.Component<ViewerWrapperProps, V
               changeViewerSetting={changeViewerSetting}
               numSlices={numSlices}
               region={region}
+              slices={slices}
               numTimesteps={numTimesteps}
               time={time}
             />


### PR DESCRIPTION
Added a url parameter to set camera mode at initialization of the standalone viewer. 

In doing so, there is one behavior change: camera views will now remember their clipping slider settings, even when loading new images.

We also discovered something out of sync between the axis clipping sliders and the initial view state, so we changed the way the slider state is held by the app.  

Pair programmed with @frasercl 