### PR TITLE
fix info panel accordion collapse on Safari

### DIFF
--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -15,6 +15,7 @@
     &.metadata-collapse-collapsed {
       visibility: collapse;
       height: 0px;
+      display: none;
     }
 
     &.metadata-collapse-title {


### PR DESCRIPTION
Fixing #176 

Seems to work to just add display:none to the collapsed css.
Could use help testing/verifying on Chrome/Firefox/Safari
