### PR TITLE
Fix/metadata viewer tweaks

### DIFF
--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -5,11 +5,6 @@ import "./styles.css";
 
 interface MetadataTableProps {
   metadata: MetadataRecord;
-  // Track whether a category title will abut another category title below when in the collapsed state.
-  // If so, this category title should not render a bottom border when collapsed, otherwise the border will double
-  // up with the top border of the lower category and create the appearance of a single thick, uneven border.
-  // (there is not a way to prevent this with pure CSS to my knowledge)
-  categoryFollows: boolean;
   topLevel?: boolean;
 }
 
@@ -38,16 +33,13 @@ const sortCategoriesFirst = (entry: MetadataEntry): MetadataEntry => {
 };
 
 /** Component to hold collapse state */
-const MetadataCategory: React.FC<CollapsibleCategoryProps> = ({ metadata, title, categoryFollows }) => {
+const MetadataCategory: React.FC<CollapsibleCategoryProps> = ({ metadata, title }) => {
   const [collapsed, setCollapsed] = React.useState(true);
-  const toggleCollapsed = (): void => setCollapsed(!collapsed);
-
-  const rowClass =
-    (collapsed ? " metadata-collapse-collapsed" : "") + (!categoryFollows ? " metadata-collapse-bottom-border" : "");
+  const collapsedClass = collapsed ? " metadata-collapse-collapsed" : "";
 
   return (
     <>
-      <tr className={"metadata-collapse-title" + rowClass} onClick={toggleCollapsed}>
+      <tr className={"metadata-row-collapse-title" + collapsedClass} onClick={() => setCollapsed(!collapsed)}>
         <td colSpan={2}>
           <span className="metadata-collapse-caret">
             <Icon type="right" style={{ transform: `rotate(${collapsed ? 0 : 90}deg)` }} />
@@ -55,16 +47,16 @@ const MetadataCategory: React.FC<CollapsibleCategoryProps> = ({ metadata, title,
           {title}
         </td>
       </tr>
-      <tr className={"metadata-collapse-content-row" + rowClass}>
+      <tr className={"metadata-row-collapse-content" + collapsedClass}>
         <td className="metadata-collapse-content" colSpan={2}>
-          <MetadataTable metadata={metadata} categoryFollows={categoryFollows} />
+          <MetadataTable metadata={metadata} />
         </td>
       </tr>
     </>
   );
 };
 
-const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows, topLevel }) => {
+const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, topLevel }) => {
   const metadataKeys = Object.keys(metadata);
   const metadataIsArray = Array.isArray(metadata);
 
@@ -75,13 +67,7 @@ const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows
           const metadataValue = sortCategoriesFirst(metadataIsArray ? metadata[idx] : metadata[key]);
 
           if (isCategory(metadataValue)) {
-            // Determine whether this category is followed by another category, ignoring data hierarchy:
-            // - If this is the last element in the table, this category has another category below if the table does.
-            // - Otherwise, just check if the next element in this table is a category.
-            const nextItem = metadataIsArray ? metadata[idx + 1] : metadata[metadataKeys[idx + 1]];
-            const categoryBelow = idx + 1 >= metadataKeys.length ? isCategory(nextItem) : categoryFollows;
-
-            return <MetadataCategory key={key} metadata={metadataValue} title={key} categoryFollows={categoryBelow} />;
+            return <MetadataCategory key={key} metadata={metadataValue} title={key} />;
           } else {
             return (
               <tr key={key}>
@@ -97,7 +83,7 @@ const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows
 };
 
 const MetadataViewer: React.FC<{ metadata: MetadataRecord }> = ({ metadata }) => (
-  <MetadataTable metadata={metadata} categoryFollows={false} topLevel={true} />
+  <MetadataTable metadata={metadata} topLevel={true} />
 );
 
 export default MetadataViewer;

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -19,7 +19,7 @@ interface CollapsibleCategoryProps extends MetadataTableProps {
 const isCategory = (val: MetadataEntry): val is MetadataRecord => typeof val === "object" && val !== null;
 
 /** Component to hold collapse state */
-const MetadataCollapsibleCategory: React.FC<CollapsibleCategoryProps> = ({ metadata, title, categoryFollows }) => {
+const MetadataCategory: React.FC<CollapsibleCategoryProps> = ({ metadata, title, categoryFollows }) => {
   const [collapsed, setCollapsed] = React.useState(true);
   const toggleCollapsed = (): void => setCollapsed(!collapsed);
 
@@ -64,14 +64,7 @@ const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows
             const nextItem = metadataIsArray ? metadata[idx + 1] : metadata[metadataKeys[idx + 1]];
             const categoryBelow = idx + 1 >= metadataKeys.length ? isCategory(nextItem) : categoryFollows;
 
-            return (
-              <MetadataCollapsibleCategory
-                key={key}
-                metadata={metadataValue}
-                title={key}
-                categoryFollows={categoryBelow}
-              />
-            );
+            return <MetadataCategory key={key} metadata={metadataValue} title={key} categoryFollows={categoryBelow} />;
           } else {
             return (
               <tr key={key}>

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -10,6 +10,7 @@ interface MetadataTableProps {
   // up with the top border of the lower category and create the appearance of a single thick, uneven border.
   // (there is not a way to prevent this with pure CSS to my knowledge)
   categoryFollows: boolean;
+  topLevel?: boolean;
 }
 
 interface CollapsibleCategoryProps extends MetadataTableProps {
@@ -23,14 +24,12 @@ const MetadataCategory: React.FC<CollapsibleCategoryProps> = ({ metadata, title,
   const [collapsed, setCollapsed] = React.useState(true);
   const toggleCollapsed = (): void => setCollapsed(!collapsed);
 
+  const rowClass =
+    (collapsed ? " metadata-collapse-collapsed" : "") + (!categoryFollows ? " metadata-collapse-bottom-border" : "");
+
   return (
     <>
-      <tr
-        className={
-          "metadata-collapse-title" + (categoryFollows && collapsed ? " metadata-collapse-no-bottom-border" : "")
-        }
-        onClick={toggleCollapsed}
-      >
+      <tr className={"metadata-collapse-title" + rowClass} onClick={toggleCollapsed}>
         <td colSpan={2}>
           <span className="metadata-collapse-caret">
             <Icon type="right" style={{ transform: `rotate(${collapsed ? 0 : 90}deg)` }} />
@@ -38,7 +37,7 @@ const MetadataCategory: React.FC<CollapsibleCategoryProps> = ({ metadata, title,
           {title}
         </td>
       </tr>
-      <tr className={"metadata-collapse-content-row" + (collapsed ? " metadata-collapse-collapsed" : "")}>
+      <tr className={"metadata-collapse-content-row" + rowClass}>
         <td className="metadata-collapse-content" colSpan={2}>
           <MetadataTable metadata={metadata} categoryFollows={categoryFollows} />
         </td>
@@ -47,12 +46,12 @@ const MetadataCategory: React.FC<CollapsibleCategoryProps> = ({ metadata, title,
   );
 };
 
-const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows }) => {
+const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows, topLevel }) => {
   const metadataKeys = Object.keys(metadata);
   const metadataIsArray = Array.isArray(metadata);
 
   return (
-    <table className="viewer-metadata-table">
+    <table className={"viewer-metadata-table" + (topLevel ? " metadata-top-level" : "")}>
       <tbody>
         {metadataKeys.map((key, idx) => {
           const metadataValue = metadataIsArray ? metadata[idx] : metadata[key];
@@ -80,7 +79,7 @@ const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows
 };
 
 const MetadataViewer: React.FC<{ metadata: MetadataRecord }> = ({ metadata }) => (
-  <MetadataTable metadata={metadata} categoryFollows={false} />
+  <MetadataTable metadata={metadata} categoryFollows={false} topLevel={true} />
 );
 
 export default MetadataViewer;

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -3,14 +3,15 @@ import React from "react";
 import { MetadataEntry, MetadataRecord } from "../../shared/types";
 import "./styles.css";
 
-interface MetadataTableProps {
+type MetadataTableProps = {
   metadata: MetadataRecord;
   topLevel?: boolean;
-}
+};
 
-interface CollapsibleCategoryProps extends MetadataTableProps {
+type CollapsibleCategoryProps = {
+  metadata: MetadataRecord;
   title: string;
-}
+};
 
 const isCategory = (entry: MetadataEntry): entry is MetadataRecord => typeof entry === "object" && entry !== null;
 

--- a/src/aics-image-viewer/components/MetadataViewer/index.tsx
+++ b/src/aics-image-viewer/components/MetadataViewer/index.tsx
@@ -17,7 +17,25 @@ interface CollapsibleCategoryProps extends MetadataTableProps {
   title: string;
 }
 
-const isCategory = (val: MetadataEntry): val is MetadataRecord => typeof val === "object" && val !== null;
+const isCategory = (entry: MetadataEntry): entry is MetadataRecord => typeof entry === "object" && entry !== null;
+
+const sortCategoriesFirst = (entry: MetadataEntry): MetadataEntry => {
+  if (!isCategory(entry) || Array.isArray(entry)) {
+    return entry;
+  }
+
+  const cats: MetadataRecord = {};
+  const vals: MetadataRecord = {};
+  for (const key in entry) {
+    if (isCategory(entry[key])) {
+      cats[key] = entry[key];
+    } else {
+      vals[key] = entry[key];
+    }
+  }
+
+  return { ...cats, ...vals };
+};
 
 /** Component to hold collapse state */
 const MetadataCategory: React.FC<CollapsibleCategoryProps> = ({ metadata, title, categoryFollows }) => {
@@ -54,7 +72,7 @@ const MetadataTable: React.FC<MetadataTableProps> = ({ metadata, categoryFollows
     <table className={"viewer-metadata-table" + (topLevel ? " metadata-top-level" : "")}>
       <tbody>
         {metadataKeys.map((key, idx) => {
-          const metadataValue = metadataIsArray ? metadata[idx] : metadata[key];
+          const metadataValue = sortCategoriesFirst(metadataIsArray ? metadata[idx] : metadata[key]);
 
           if (isCategory(metadataValue)) {
             // Determine whether this category is followed by another category, ignoring data hierarchy:

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -49,7 +49,7 @@
     }
 
     &.metadata-key {
-      padding-left: 24px;
+      padding-left: 16px;
     }
 
     &.metadata-value {
@@ -59,12 +59,12 @@
     }
 
     &:last-child {
-      padding-right: 16px;
+      padding-right: 8px;
     }
 
     &.metadata-collapse-content {
       padding: 0;
-      padding-left: 16px;
+      padding-left: 24px;
       border-bottom: none;
     }
 

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -2,65 +2,47 @@
   width: 100%;
   table-layout: fixed;
 
-  /* On the top nest level, the top border is given by the panel header, and the bottom by the containing table */
-  &.metadata-top-level {
-    border-bottom: 1px solid #6e6e6e;
-
-    > tbody > tr.metadata-collapse-title {
-      &:first-child {
-        border-top: none;
-      }
-
-      &:nth-last-child(2).metadata-collapse-collapsed > td {
-        padding-bottom: 6px;
-      }
-    }
-  }
-
   tbody {
     padding: 10px;
   }
 
+  /* On the top nest level, the top border is given by the panel header, and the bottom by the containing table */
+  &.metadata-top-level {
+    border-bottom: 1px solid #6e6e6e;
+
+    > tbody > tr.metadata-row-collapse-title:first-child {
+      border-top: none;
+    }
+  }
+
   /* ----- TABLE ROWS ----- */
   tr {
-    &:nth-child(odd) {
+    &:nth-child(odd):not(.metadata-row-collapse-content) {
       background-color: #3a3a3a;
     }
 
-    &.metadata-collapse-title {
+    /* CATEGORY TITLE */
+    &.metadata-row-collapse-title {
       color: white;
-      background-color: #4b4b4b;
-      border-top: 1px solid #6e6e6e;
-      > td {
-        padding-bottom: 5px;
-      }
+      background-color: #4b4b4b !important;
 
-      /* This complex rule decides if the title should have its own bottom border, or if a line is already drawn below:
-      - If the category is not collapsed, the bottom border is the responsibility of the content row
-      - If the next sibling is a category (React determines this), they are separated by the sibling's top border
-      - If this is the last entry in its category, the parent category's longer bottom border is below
-      */
-      &.metadata-collapse-collapsed.metadata-collapse-bottom-border:not(:nth-last-child(2)) {
-        border-bottom: 1px solid #6e6e6e;
-        > td {
-          padding-bottom: 6px;
-        }
+      /* Keeps borders aligned when this category opens and closes */
+      &:not(.metadata-collapse-collapsed) > td {
+        padding-bottom: 5px;
       }
     }
 
-    &.metadata-collapse-content-row {
-      background-color: #313131;
+    /* CATEGORY CONTENT */
+    &.metadata-row-collapse-content.metadata-collapse-collapsed {
+      visibility: collapse;
+      height: 0px;
+      display: none;
+    }
 
-      &.metadata-collapse-collapsed {
-        visibility: collapse;
-        height: 0px;
-        display: none;
-      }
-
-      /* Same as above, but the content takes the bottom border when this category is NOT collapsed. */
-      &:not(.metadata-collapse-collapsed).metadata-collapse-bottom-border:not(:last-child) {
-        border-bottom: 1px solid #6e6e6e;
-      }
+    /* ROW BORDERS: all categories have top borders; any row which follows a category provides its bottom border */
+    tr.metadata-row-collapse-title,
+    &.metadata-row-collapse-content + tr {
+      border-top: 1px solid #6e6e6e;
     }
   }
 
@@ -92,7 +74,6 @@
     &.metadata-collapse-content {
       padding: 0;
       padding-left: 24px;
-      border-bottom: none;
     }
 
     i {

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -2,6 +2,14 @@
   width: 100%;
   table-layout: fixed;
 
+  &.metadata-top-level {
+    border-bottom: 1px solid #6e6e6e;
+
+    > tbody > tr.metadata-collapse-title:first-child {
+      border-top: none;
+    }
+  }
+
   tbody {
     padding: 10px;
   }
@@ -12,28 +20,28 @@
       background-color: #3a3a3a;
     }
 
-    &.metadata-collapse-collapsed {
-      visibility: collapse;
-      height: 0px;
-      display: none;
-    }
-
     &.metadata-collapse-title {
       color: white;
       background-color: #4b4b4b;
-      &:not(.metadata-collapse-no-bottom-border) {
+      border-top: 1px solid #6e6e6e;
+
+      &.metadata-collapse-collapsed.metadata-collapse-bottom-border:not(:nth-last-child(2)) {
         border-bottom: 1px solid #6e6e6e;
-      }
-      &.metadata-collapse-no-bottom-border > td {
-        padding-bottom: 5px;
-      }
-      &:not(:first-child) {
-        border-top: 1px solid #6e6e6e;
       }
     }
 
     &.metadata-collapse-content-row {
       background-color: #313131;
+
+      &.metadata-collapse-collapsed {
+        visibility: collapse;
+        height: 0px;
+        display: none;
+      }
+
+      &:not(.metadata-collapse-collapsed).metadata-collapse-bottom-border:not(:last-child) {
+        border-bottom: 1px solid #6e6e6e;
+      }
     }
   }
 

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -2,6 +2,7 @@
   width: 100%;
   table-layout: fixed;
 
+  /* On the top nest level, the top border is given by the panel header, and the bottom by the containing table */
   &.metadata-top-level {
     border-bottom: 1px solid #6e6e6e;
 
@@ -20,7 +21,7 @@
     padding: 10px;
   }
 
-  /* Table rows */
+  /* ----- TABLE ROWS ----- */
   tr {
     &:nth-child(odd) {
       background-color: #3a3a3a;
@@ -34,6 +35,11 @@
         padding-bottom: 5px;
       }
 
+      /* This complex rule decides if the title should have its own bottom border, or if a line is already drawn below:
+      - If the category is not collapsed, the bottom border is the responsibility of the content row
+      - If the next sibling is a category (React determines this), they are separated by the sibling's top border
+      - If this is the last entry in its category, the parent category's longer bottom border is below
+      */
       &.metadata-collapse-collapsed.metadata-collapse-bottom-border:not(:nth-last-child(2)) {
         border-bottom: 1px solid #6e6e6e;
         > td {
@@ -51,13 +57,14 @@
         display: none;
       }
 
+      /* Same as above, but the content takes the bottom border when this category is NOT collapsed. */
       &:not(.metadata-collapse-collapsed).metadata-collapse-bottom-border:not(:last-child) {
         border-bottom: 1px solid #6e6e6e;
       }
     }
   }
 
-  /* Table cells */
+  /* ----- TABLE CELLS ----- */
   td {
     padding: 6px 0;
     overflow-wrap: break-word;

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -5,9 +5,13 @@
   &.metadata-top-level {
     border-bottom: 1px solid #6e6e6e;
 
-    > tbody {
-      > tr.metadata-collapse-title:first-child {
+    > tbody > tr.metadata-collapse-title {
+      &:first-child {
         border-top: none;
+      }
+
+      &:nth-last-child(2).metadata-collapse-collapsed > td {
+        padding-bottom: 6px;
       }
     }
   }

--- a/src/aics-image-viewer/components/MetadataViewer/styles.css
+++ b/src/aics-image-viewer/components/MetadataViewer/styles.css
@@ -5,8 +5,10 @@
   &.metadata-top-level {
     border-bottom: 1px solid #6e6e6e;
 
-    > tbody > tr.metadata-collapse-title:first-child {
-      border-top: none;
+    > tbody {
+      > tr.metadata-collapse-title:first-child {
+        border-top: none;
+      }
     }
   }
 
@@ -24,9 +26,15 @@
       color: white;
       background-color: #4b4b4b;
       border-top: 1px solid #6e6e6e;
+      > td {
+        padding-bottom: 5px;
+      }
 
       &.metadata-collapse-collapsed.metadata-collapse-bottom-border:not(:nth-last-child(2)) {
         border-bottom: 1px solid #6e6e6e;
+        > td {
+          padding-bottom: 6px;
+        }
       }
     }
 


### PR DESCRIPTION
Incorporates visual tweaks to the metadata viewer designed by @lynwilhelm:
- Collapsible category borders now appear above the title and below the content (rather than above and below the title)
- Better horizontal alignment of category content to match titles
- Categories are sorted out and always appear above data

The first of those was surprisingly challenging and accounts for most of the code changes in this PR, but I think I ultimately got things much cleaner than they were before.

### Before:
![image](https://github.com/allen-cell-animated/website-3d-cell-viewer/assets/53030214/c3112602-3a6e-4aa7-a50c-d915633824fd)
### After:
![image](https://github.com/allen-cell-animated/website-3d-cell-viewer/assets/53030214/aa5ca01f-b5ea-45a9-aca7-db3504804f37)
