### PR TITLE
Allow unloaded channels to be enabled

### DIFF
--- a/src/aics-image-viewer/components/App/ChannelUpdater.tsx
+++ b/src/aics-image-viewer/components/App/ChannelUpdater.tsx
@@ -31,18 +31,19 @@ const ChannelUpdater: React.FC<ChannelUpdaterProps> = ({ index, channelState, vi
     }, [...deps, image, version]);
   };
 
-  useImageEffect(
-    (currentImage) => {
-      view3d.setVolumeChannelEnabled(currentImage, index, volumeEnabled);
-      view3d.updateLuts(currentImage);
-    },
-    [volumeEnabled]
-  );
+  // enable/disable channel can't be dependent on channel load state because it may trigger the channel to load
+  useEffect(() => {
+    if (image) {
+      view3d.setVolumeChannelEnabled(image, index, volumeEnabled);
+      view3d.updateLuts(image);
+    }
+  }, [image, volumeEnabled]);
 
-  useImageEffect(
-    (currentImage) => view3d.setVolumeChannelOptions(currentImage, index, { isosurfaceEnabled }),
-    [isosurfaceEnabled]
-  );
+  useEffect(() => {
+    if (image) {
+      view3d.setVolumeChannelOptions(image, index, { isosurfaceEnabled });
+    }
+  }, [image, isosurfaceEnabled]);
 
   useImageEffect((currentImage) => view3d.setVolumeChannelOptions(currentImage, index, { isovalue }), [isovalue]);
 


### PR DESCRIPTION
Quick fix: currently, channel settings are not updated on channels that are never loaded. When allen-cell-animated/volume-viewer#173 is published, disabled channels may never be loaded when the user moves to a new time point. Currently, this would cause these channels to be stuck in the disabled state. This change allows the enabled/disabled setting to be changed on unloaded channels.