### PR TITLE
Use workerized loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "@aics/volume-viewer": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.5.3.tgz",
-      "integrity": "sha512-MmYW34eRZN9OHTSEWlNRBE1XZB5ddtEc1ueJEStaKPASJ8DO4O3bicsCLMIZeC5M0BxleK+pINzZfjgRuePKXQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.6.1.tgz",
+      "integrity": "sha512-HRUagzCXnWsBXCtBAQY+Pya7lgg/HIwgTEQKSCxAA3CmImrTBIlfQyRxBPH/pIRORfjqKr0VlxYluUhiM0JtpQ==",
       "requires": {
         "geotiff": "^2.0.5",
         "three": "^0.144.0",
@@ -8339,9 +8339,9 @@
       "dev": true
     },
     "geotiff": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.0.tgz",
-      "integrity": "sha512-B/iFJuFfRpmPHXf8aIRPRgUWwfaNb6dlsynkM8SWeHAPu7CpyvfqEa43KlBt7xxq5OTVysQacFHxhCn3SZhRKQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.2.tgz",
+      "integrity": "sha512-xw7Cd6HXukUdfFSe5QCSjdhebTCGkk87x7fKURqQPFKT+TijCCwKvoksL7T3+B6mJWZSB7muTJlwVIQsLtbkMA==",
       "requires": {
         "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
@@ -17001,9 +17001,9 @@
       }
     },
     "web-worker": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
-      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.3.0.tgz",
+      "integrity": "sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA=="
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/volume-viewer": "^3.5.3",
+    "@aics/volume-viewer": "^3.6.1",
     "color-string": "^1.5.3",
     "d3": "^4.11.0",
     "lodash": "^4.17.20",

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -2,7 +2,14 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Layout } from "antd";
 import { debounce } from "lodash";
-import { LoadSpec, LoadWorker, RENDERMODE_PATHTRACE, RENDERMODE_RAYMARCH, View3d, Volume } from "@aics/volume-viewer";
+import {
+  LoadSpec,
+  VolumeLoaderContext,
+  RENDERMODE_PATHTRACE,
+  RENDERMODE_RAYMARCH,
+  View3d,
+  Volume,
+} from "@aics/volume-viewer";
 
 import {
   AppProps,
@@ -154,7 +161,7 @@ const App: React.FC<AppProps> = (props) => {
   // State management /////////////////////////////////////////////////////////
 
   const view3d = useConstructor(() => new View3d());
-  const loadWorker = useConstructor(() => new LoadWorker(250_000_000 * 4, 8, 3));
+  const loadContext = useConstructor(() => new VolumeLoaderContext(250_000_000 * 4, 8, 3));
   const [image, setImage] = useState<Volume | null>(null);
   const imageUrlRef = useRef<string>("");
 
@@ -420,8 +427,8 @@ const App: React.FC<AppProps> = (props) => {
 
     // if this does NOT end with tif or json,
     // then we assume it's zarr.
-    await loadWorker.onOpen();
-    const loader = await loadWorker.createLoader(fullUrl);
+    await loadContext.onOpen();
+    const loader = await loadContext.createLoader(fullUrl);
 
     const aimg = await loader.createVolume(loadSpec, (v, channelIndex) => {
       // NOTE: this callback runs *after* `onNewVolumeCreated` below, for every loaded channel

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -43,6 +43,9 @@ import {
   INTERPOLATION_ENABLED_DEFAULT,
   AXIS_MARGIN_DEFAULT,
   SCALE_BAR_MARGIN_DEFAULT,
+  CACHE_MAX_SIZE,
+  QUEUE_MAX_SIZE,
+  QUEUE_MAX_LOW_PRIORITY_SIZE,
 } from "../../shared/constants";
 
 import ChannelUpdater from "./ChannelUpdater";
@@ -161,7 +164,9 @@ const App: React.FC<AppProps> = (props) => {
   // State management /////////////////////////////////////////////////////////
 
   const view3d = useConstructor(() => new View3d());
-  const loadContext = useConstructor(() => new VolumeLoaderContext(250_000_000 * 4, 8, 3));
+  const loadContext = useConstructor(
+    () => new VolumeLoaderContext(CACHE_MAX_SIZE, QUEUE_MAX_SIZE, QUEUE_MAX_LOW_PRIORITY_SIZE)
+  );
   const [image, setImage] = useState<Volume | null>(null);
   const imageUrlRef = useRef<string>("");
 

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -21,6 +21,10 @@ export const // Control panel will automatically close if viewport is less than 
   OTHER_CHANNEL_KEY = "Other",
   SINGLE_GROUP_CHANNEL_KEY = "Channels";
 
+export const CACHE_MAX_SIZE = 1_000_000_000;
+export const QUEUE_MAX_SIZE = 10;
+export const QUEUE_MAX_LOW_PRIORITY_SIZE = 4;
+
 export const PRESET_COLORS_1: ColorArray[] = [
   [190, 68, 171],
   [189, 211, 75],


### PR DESCRIPTION
The latest version of volume-viewer introduces the `VolumeLoaderContext`, which can offload volume loaders to a WebWorker where they won't block rendering and updates. This PR updates volume-viewer and replaces the current single-threaded loader creation with creation mediated by `VolumeLoaderContext`.