### PR TITLE
Show timestep indicator on start

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -152,6 +152,8 @@ const setIndicatorPositions = (view3d: View3d, panelOpen: boolean, hasTime: bool
   if (hasTime) {
     // Move scale bar left out of the way of timestep indicator
     scaleBarX += SCALE_BAR_TIME_SERIES_OFFSET;
+    // Make sure the timestep indicator is showing
+    view3d.setShowTimestepIndicator(true);
   }
 
   view3d.setAxisPosition(AXIS_MARGIN_DEFAULT[0], axisY);


### PR DESCRIPTION
Because we never explicitly enabled the timestep indicator on startup for volumes with a time dimension, it would not show up until the user triggered an event which changed its enabled/disabled state. This one-line fix makes sure it's enabled to begin with.