### PR TITLE
Don't update transfer function on reloads

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -429,11 +429,8 @@ const App: React.FC<AppProps> = (props) => {
     const { fovPath, cellPath, baseUrl } = props;
     const path = viewerSettings.imageType === ImageType.fullField ? fovPath : cellPath;
     const fullUrl = `${baseUrl}${path}`;
-
-    // If this is the same image at a different time, keep luts. If same image at same time, don't bother reloading.
-    const samePath = fullUrl === imageUrlRef.current;
-    // future TODO: check for whether multiresolution level (subpath) would be different too.
-    if (samePath && viewerSettings.time === image?.loadSpec.time) {
+    // Don't reload if we're already looking at this image
+    if (fullUrl === imageUrlRef.current) {
       return;
     }
 

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -426,11 +426,10 @@ const App: React.FC<AppProps> = (props) => {
   };
 
   const openImage = async (): Promise<void> => {
+    // Don't reload if we're already looking at this image
     const { fovPath, cellPath, baseUrl } = props;
     const path = viewerSettings.imageType === ImageType.fullField ? fovPath : cellPath;
-    const fullUrl = `${baseUrl}${path}`;
-    // Don't reload if we're already looking at this image
-    if (fullUrl === imageUrlRef.current) {
+    if (baseUrl + path === imageUrlRef.current) {
       return;
     }
 

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -426,10 +426,11 @@ const App: React.FC<AppProps> = (props) => {
   };
 
   const openImage = async (): Promise<void> => {
-    // Don't reload if we're already looking at this image
     const { fovPath, cellPath, baseUrl } = props;
     const path = viewerSettings.imageType === ImageType.fullField ? fovPath : cellPath;
-    if (baseUrl + path === imageUrlRef.current) {
+    const fullUrl = `${baseUrl}${path}`;
+    // Don't reload if we're already looking at this image
+    if (fullUrl === imageUrlRef.current) {
       return;
     }
 


### PR DESCRIPTION
### Problem

Currently, the transfer function is automatically updated every time new data is loaded into the volume. Scientists would prefer if it remained constant between time steps and z slices.

### Solution

Track when data is being loaded into the `Volume` for the first time, and only regenerate the transfer function on that load.