### PR TITLE
Prioritize prefetching playing axis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "@aics/volume-viewer": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.6.1.tgz",
-      "integrity": "sha512-HRUagzCXnWsBXCtBAQY+Pya7lgg/HIwgTEQKSCxAA3CmImrTBIlfQyRxBPH/pIRORfjqKr0VlxYluUhiM0JtpQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.7.0.tgz",
+      "integrity": "sha512-dtavpnjJQPK9mCdiy6LrVNqMahMiZR80oruAdceT3cZ8ZwtyQfKNndz1Grv3Lj/WQMJoXSIaCr3OUBWsC+tdBw==",
       "requires": {
         "geotiff": "^2.0.5",
         "three": "^0.144.0",
@@ -8339,9 +8339,9 @@
       "dev": true
     },
     "geotiff": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.2.tgz",
-      "integrity": "sha512-xw7Cd6HXukUdfFSe5QCSjdhebTCGkk87x7fKURqQPFKT+TijCCwKvoksL7T3+B6mJWZSB7muTJlwVIQsLtbkMA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
+      "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
       "requires": {
         "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/volume-viewer": "^3.6.1",
+    "@aics/volume-viewer": "^3.7.0",
     "color-string": "^1.5.3",
     "d3": "^4.11.0",
     "lodash": "^4.17.20",

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -9,6 +9,9 @@ import {
   RENDERMODE_RAYMARCH,
   View3d,
   Volume,
+  IVolumeLoader,
+  WorkerLoader,
+  PrefetchDirection,
 } from "@aics/volume-viewer";
 
 import {
@@ -137,6 +140,13 @@ const defaultProps: AppProps = {
   canvasMargin: "0 0 0 0",
 };
 
+const axisToLoaderPriority: Record<AxisName | "t", PrefetchDirection> = {
+  t: PrefetchDirection.T_PLUS,
+  z: PrefetchDirection.Z_PLUS,
+  y: PrefetchDirection.Y_PLUS,
+  x: PrefetchDirection.X_PLUS,
+};
+
 const setIndicatorPositions = (view3d: View3d, panelOpen: boolean, hasTime: boolean): void => {
   const CLIPPING_PANEL_HEIGHT = 150;
   // Move scale bars this far to the left when showing time series, to make room for timestep indicator
@@ -168,6 +178,7 @@ const App: React.FC<AppProps> = (props) => {
   const loadContext = useConstructor(
     () => new VolumeLoaderContext(CACHE_MAX_SIZE, QUEUE_MAX_SIZE, QUEUE_MAX_LOW_PRIORITY_SIZE)
   );
+  const loader = useRef<IVolumeLoader>();
   const [image, setImage] = useState<Volume | null>(null);
   const imageUrlRef = useRef<string>("");
 
@@ -204,7 +215,10 @@ const App: React.FC<AppProps> = (props) => {
   // Playback state goes here, but the play/pause buttons that mainly control this class are down in `AxisClipSliders`
   const playControls = useConstructor(() => new PlayControls());
   const [playingAxis, setPlayingAxis] = useState<AxisName | "t" | null>(null);
-  playControls.onPlayingAxisChanged = setPlayingAxis;
+  playControls.onPlayingAxisChanged = (axis) => {
+    (loader.current as WorkerLoader)?.setPrefetchPriorityDirections?.(axis ? [axisToLoaderPriority[axis]] : []);
+    setPlayingAxis(axis);
+  };
 
   // Some viewer settings require custom change behaviors to change related settings simultaneously or guard against
   // entering an illegal state (e.g. autorotate must not be on in pathtrace mode). Those behaviors are defined here.
@@ -447,15 +461,15 @@ const App: React.FC<AppProps> = (props) => {
     // if this does NOT end with tif or json,
     // then we assume it's zarr.
     await loadContext.onOpen();
-    const loader = await loadContext.createLoader(fullUrl);
+    loader.current = await loadContext.createLoader(fullUrl);
 
-    const aimg = await loader.createVolume(loadSpec, (v, channelIndex) => {
+    const aimg = await loader.current.createVolume(loadSpec, (v, channelIndex) => {
       // NOTE: this callback runs *after* `onNewVolumeCreated` below, for every loaded channel
       // TODO is this search by name necessary or will the `channelIndex` passed to the callback always match state?
       const thisChannelSettings = getOneChannelSetting(v.imageInfo.channelNames[channelIndex]);
       onChannelDataLoaded(v, thisChannelSettings!, channelIndex, samePath);
     });
-    loader.loadVolumeData(aimg);
+    loader.current.loadVolumeData(aimg);
 
     const channelNames = aimg.imageInfo.channelNames;
     const newChannelSettings = setChannelStateForNewImage(channelNames);

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -10,7 +10,6 @@ import {
   View3d,
   Volume,
   IVolumeLoader,
-  WorkerLoader,
   PrefetchDirection,
 } from "@aics/volume-viewer";
 
@@ -216,7 +215,7 @@ const App: React.FC<AppProps> = (props) => {
   const playControls = useConstructor(() => new PlayControls());
   const [playingAxis, setPlayingAxis] = useState<AxisName | "t" | null>(null);
   playControls.onPlayingAxisChanged = (axis) => {
-    (loader.current as WorkerLoader)?.setPrefetchPriorityDirections?.(axis ? [axisToLoaderPriority[axis]] : []);
+    loader.current?.setPrefetchPriority(axis ? [axisToLoaderPriority[axis]] : []);
     setPlayingAxis(axis);
   };
 


### PR DESCRIPTION
volume-viewer added a concept of "prefetch priority" (#181) which enables forcing the zarr loader to prioritize a given axis or set of axes when prefetching. This feature was designed for playback in this viewer: when playing through time in z-slice mode, we should not be issuing prefetch requests for adjacent z slices, e.g. Update volume-viewer and connect axis playing state to prefetch priority.