### PR TITLE
synchronize channel loading during playback only

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -220,6 +220,7 @@ const App: React.FC<AppProps> = (props) => {
   const [playingAxis, setPlayingAxis] = useState<AxisName | "t" | null>(null);
   playControls.onPlayingAxisChanged = (axis) => {
     loader.current?.setPrefetchPriority(axis ? [axisToLoaderPriority[axis]] : []);
+    loader.current?.syncMultichannelLoading(axis ? true : false);
     setPlayingAxis(axis);
   };
 


### PR DESCRIPTION
Depends on api changes from https://github.com/allen-cell-animated/volume-viewer/pull/185
This calls a function to tell the volume loader to wait for all channels to arrive before updating the displayed volume, only during playback modes.  Fixes #190 after both pull requests go through.

After the dependent PR is approved, there will be a volume-viewer version bump added to this PR.   That will fix the CI breakage.

Estimated time to review: ~5 minutes