### PR TITLE
Allow multiple data sources for zarr volumes

### DIFF
--- a/public/firebase/index.ts
+++ b/public/firebase/index.ts
@@ -2,7 +2,7 @@ import { DocumentReference, QuerySnapshot, DocumentData } from "@firebase/firest
 
 import { firestore } from "./configure-firebase";
 
-interface DatasetMetaData {
+export interface DatasetMetaData {
   name: string;
   version: string;
   datasets?: { [key: string]: DatasetMetaData };

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -83,8 +83,8 @@ const args = {
   cellid: 2025,
   imageUrl: (BASE_URL + "AICS-22/AICS-22_8319_2025_atlas.json") as string | string[],
   parentImageUrl: BASE_URL + "AICS-22/AICS-22_8319_atlas.json",
-  fovDownloadHref: "https://files.allencell.org/api/2.0/file/download?collection=cellviewer-1-4/?id=F8319",
-  cellDownloadHref: "https://files.allencell.org/api/2.0/file/download?collection=cellviewer-1-4/?id=C2025",
+  parentImageDownloadHref: "https://files.allencell.org/api/2.0/file/download?collection=cellviewer-1-4/?id=F8319",
+  imageDownloadHref: "https://files.allencell.org/api/2.0/file/download?collection=cellviewer-1-4/?id=C2025",
   initialChannelSettings: VIEWER_3D_SETTINGS,
 };
 const viewerSettings: Partial<GlobalViewerSettings> = {
@@ -123,7 +123,7 @@ async function loadDataset(dataset: string, id: string) {
 
   const datasetData = await db.selectDataset(datasetMeta.manifest!);
   const baseUrl = datasetData.volumeViewerDataRoot + "/";
-  args.cellDownloadHref = datasetData.downloadRoot + "/" + id;
+  args.imageDownloadHref = datasetData.downloadRoot + "/" + id;
   // args.fovDownloadHref = datasetData.downloadRoot + "/" + id;
 
   const fileInfo = await db.getFileInfoByCellId(id);
@@ -193,9 +193,9 @@ if (params) {
     args.cellid = 1;
     args.imageUrl = imageUrl;
     // this is invalid for zarr?
-    args.cellDownloadHref = decodedUrl;
+    args.imageDownloadHref = decodedUrl;
     args.parentImageUrl = "";
-    args.fovDownloadHref = "";
+    args.parentImageDownloadHref = "";
     // if json, then use the CFE settings for now.
     // (See VIEWER_3D_SETTINGS)
     // otherwise turn the first 3 channels on and group them
@@ -222,8 +222,8 @@ if (params) {
     const baseUrl = "http://dev-aics-dtp-001.corp.alleninstitute.org/dan-data/";
     args.imageUrl = baseUrl + params.file;
     args.parentImageUrl = baseUrl + params.file;
-    args.fovDownloadHref = "";
-    args.cellDownloadHref = "";
+    args.parentImageDownloadHref = "";
+    args.imageDownloadHref = "";
     runApp();
   } else if (params.dataset && params.id) {
     // ?dataset=aics_hipsc_v2020.1&id=232265
@@ -243,8 +243,8 @@ function runApp() {
       parentImageUrl={args.parentImageUrl}
       appHeight="100vh"
       canvasMargin="0 0 0 0"
-      parentImageDownloadHref={args.fovDownloadHref}
-      imageDownloadHref={args.cellDownloadHref}
+      parentImageDownloadHref={args.parentImageDownloadHref}
+      imageDownloadHref={args.imageDownloadHref}
       viewerSettings={viewerSettings}
       viewerChannelSettings={args.initialChannelSettings}
     />,

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -237,17 +237,7 @@ if (params) {
 
 function runApp() {
   ReactDOM.render(
-    <ImageViewerApp
-      cellId={args.cellId}
-      imageUrl={args.imageUrl}
-      parentImageUrl={args.parentImageUrl}
-      appHeight="100vh"
-      canvasMargin="0 0 0 0"
-      parentImageDownloadHref={args.parentImageDownloadHref}
-      imageDownloadHref={args.imageDownloadHref}
-      viewerSettings={viewerSettings}
-      viewerChannelSettings={args.viewerChannelSettings}
-    />,
+    <ImageViewerApp {...args} appHeight="100vh" canvasMargin="0 0 0 0" viewerSettings={viewerSettings} />,
     document.getElementById("cell-viewer")
   );
 }

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -9,7 +9,7 @@ import "./App.css";
 
 import { ImageViewerApp, RenderMode, ViewerChannelSettings, ViewMode } from "../src";
 import FirebaseRequest, { DatasetMetaData } from "./firebase";
-import { GlobalViewerSettings } from "../src/aics-image-viewer/components/App/types";
+import { AppProps, GlobalViewerSettings } from "../src/aics-image-viewer/components/App/types";
 
 // vars filled at build time using webpack DefinePlugin
 console.log(`website-3d-cell-viewer ${WEBSITE3DCELLVIEWER_BUILD_ENVIRONMENT} build`);
@@ -79,13 +79,13 @@ const decodeUrl = (url: string) => {
 };
 
 const BASE_URL = "https://s3-us-west-2.amazonaws.com/bisque.allencell.org/v1.4.0/Cell-Viewer_Thumbnails/";
-const args = {
-  cellid: 2025,
-  imageUrl: (BASE_URL + "AICS-22/AICS-22_8319_2025_atlas.json") as string | string[],
+const args: Omit<AppProps, "appHeight" | "canvasMargin"> = {
+  cellId: "2025",
+  imageUrl: BASE_URL + "AICS-22/AICS-22_8319_2025_atlas.json",
   parentImageUrl: BASE_URL + "AICS-22/AICS-22_8319_atlas.json",
   parentImageDownloadHref: "https://files.allencell.org/api/2.0/file/download?collection=cellviewer-1-4/?id=F8319",
   imageDownloadHref: "https://files.allencell.org/api/2.0/file/download?collection=cellviewer-1-4/?id=C2025",
-  initialChannelSettings: VIEWER_3D_SETTINGS,
+  viewerChannelSettings: VIEWER_3D_SETTINGS,
 };
 const viewerSettings: Partial<GlobalViewerSettings> = {
   showAxes: false,
@@ -183,14 +183,14 @@ if (params) {
         ch[i]["color"] = colors[i];
       }
     }
-    args.initialChannelSettings = initialChannelSettings;
+    args.viewerChannelSettings = initialChannelSettings;
   }
   if (params.url) {
     const decodedUrl = decodeUrl(params.url);
     const decodedUrl2 = params.url2 && decodeUrl(params.url2);
     const imageUrl = decodedUrl2 ? [decodedUrl, decodedUrl2] : decodedUrl;
 
-    args.cellid = 1;
+    args.cellId = "1";
     args.imageUrl = imageUrl;
     // this is invalid for zarr?
     args.imageDownloadHref = decodedUrl;
@@ -200,7 +200,7 @@ if (params) {
     // (See VIEWER_3D_SETTINGS)
     // otherwise turn the first 3 channels on and group them
     if (!decodedUrl.endsWith("json") && !params.ch) {
-      args.initialChannelSettings = {
+      args.viewerChannelSettings = {
         groups: [
           // first 3 channels on by default!
           {
@@ -218,7 +218,7 @@ if (params) {
     // quick way to load a atlas.json from a special directory.
     //
     // ?file=relative-path-to-atlas-on-isilon
-    args.cellid = 1;
+    args.cellId = "1";
     const baseUrl = "http://dev-aics-dtp-001.corp.alleninstitute.org/dan-data/";
     args.imageUrl = baseUrl + params.file;
     args.parentImageUrl = baseUrl + params.file;
@@ -238,7 +238,7 @@ if (params) {
 function runApp() {
   ReactDOM.render(
     <ImageViewerApp
-      cellId={args.cellid.toString()}
+      cellId={args.cellId}
       imageUrl={args.imageUrl}
       parentImageUrl={args.parentImageUrl}
       appHeight="100vh"
@@ -246,7 +246,7 @@ function runApp() {
       parentImageDownloadHref={args.parentImageDownloadHref}
       imageDownloadHref={args.imageDownloadHref}
       viewerSettings={viewerSettings}
-      viewerChannelSettings={args.initialChannelSettings}
+      viewerChannelSettings={args.viewerChannelSettings}
     />,
     document.getElementById("cell-viewer")
   );

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -81,7 +81,7 @@ const decodeUrl = (url: string) => {
 const BASE_URL = "https://s3-us-west-2.amazonaws.com/bisque.allencell.org/v1.4.0/Cell-Viewer_Thumbnails/";
 const args = {
   cellid: 2025,
-  imageUrl: BASE_URL + "AICS-22/AICS-22_8319_2025_atlas.json",
+  imageUrl: (BASE_URL + "AICS-22/AICS-22_8319_2025_atlas.json") as string | string[],
   parentImageUrl: BASE_URL + "AICS-22/AICS-22_8319_atlas.json",
   fovDownloadHref: "https://files.allencell.org/api/2.0/file/download?collection=cellviewer-1-4/?id=F8319",
   cellDownloadHref: "https://files.allencell.org/api/2.0/file/download?collection=cellviewer-1-4/?id=C2025",
@@ -187,9 +187,11 @@ if (params) {
   }
   if (params.url) {
     const decodedUrl = decodeUrl(params.url);
+    const decodedUrl2 = params.url2 && decodeUrl(params.url2);
+    const imageUrl = decodedUrl2 ? [decodedUrl, decodedUrl2] : decodedUrl;
 
     args.cellid = 1;
-    args.imageUrl = decodedUrl;
+    args.imageUrl = imageUrl;
     // this is invalid for zarr?
     args.cellDownloadHref = decodedUrl;
     args.parentImageUrl = "";

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -63,8 +63,8 @@ type ParamKeys = "mask" | "ch" | "luts" | "colors" | "url" | "url2" | "file" | "
 type Params = { [_ in ParamKeys]?: string };
 
 function parseQueryString(): Params {
-  var pairs = location.search.slice(1).split("&");
-  var result = {};
+  const pairs = location.search.slice(1).split("&");
+  const result = {};
   pairs.forEach((pairString) => {
     const pair = pairString.split("=");
     result[pair[0]] = decodeURIComponent(pair[1] || "");
@@ -186,7 +186,7 @@ if (params) {
     args.initialChannelSettings = initialChannelSettings;
   }
   if (params.url) {
-    let decodedUrl = decodeUrl(params.url);
+    const decodedUrl = decodeUrl(params.url);
 
     args.cellid = 1;
     args.imageUrl = decodedUrl;

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -78,7 +78,7 @@ const decodeUrl = (url: string): string => {
   return decodedUrl.endsWith("/") ? decodedUrl.slice(0, -1) : decodedUrl;
 };
 
-/** Tries to parse a string as a list of URLs */
+/** Try to parse a `string` as a list of 2 or more URLs. Returns `undefined` if the string is not a valid URL list. */
 const tryDecodeURLList = (url: string, delim = ","): string[] | undefined => {
   if (!url.includes(delim)) {
     return undefined;

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -243,8 +243,8 @@ function runApp() {
       parentImageUrl={args.parentImageUrl}
       appHeight="100vh"
       canvasMargin="0 0 0 0"
-      fovDownloadHref={args.fovDownloadHref}
-      cellDownloadHref={args.cellDownloadHref}
+      parentImageDownloadHref={args.fovDownloadHref}
+      imageDownloadHref={args.cellDownloadHref}
       viewerSettings={viewerSettings}
       viewerChannelSettings={args.initialChannelSettings}
     />,

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -73,7 +73,7 @@ function parseQueryString(): Params {
 }
 const params = parseQueryString();
 
-const decodeUrl = (url: string): string => {
+const decodeURL = (url: string): string => {
   const decodedUrl = decodeURIComponent(url);
   return decodedUrl.endsWith("/") ? decodedUrl.slice(0, -1) : decodedUrl;
 };
@@ -84,7 +84,7 @@ const tryDecodeURLList = (url: string, delim = ","): string[] | undefined => {
     return undefined;
   }
 
-  const urls = url.split(delim).map((u) => decodeUrl(u));
+  const urls = url.split(delim).map((u) => decodeURL(u));
 
   // Verify that all urls are valid
   for (const u of urls) {
@@ -206,7 +206,7 @@ if (params) {
     args.viewerChannelSettings = initialChannelSettings;
   }
   if (params.url) {
-    const imageUrls = tryDecodeURLList(params.url) ?? decodeUrl(params.url);
+    const imageUrls = tryDecodeURLList(params.url) ?? decodeURL(params.url);
     const firstUrl = Array.isArray(imageUrls) ? imageUrls[0] : imageUrls;
 
     args.cellId = "1";

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -126,12 +126,12 @@ const defaultProps: AppProps = {
   // rawDims is the volume dims that normally come from a json file
   rawDims: undefined,
 
+  imageUrl: "",
+  parentImageUrl: "",
+
   appHeight: "100vh",
-  cellPath: "",
-  fovPath: "",
   showControls: defaultShownControls,
   viewerSettings: defaultViewerSettings,
-  baseUrl: "",
   cellId: "",
   cellDownloadHref: "",
   fovDownloadHref: "",

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -133,8 +133,8 @@ const defaultProps: AppProps = {
   showControls: defaultShownControls,
   viewerSettings: defaultViewerSettings,
   cellId: "",
-  cellDownloadHref: "",
-  fovDownloadHref: "",
+  imageDownloadHref: "",
+  parentImageDownloadHref: "",
   pixelSize: undefined,
   canvasMargin: "0 0 0 0",
 };
@@ -815,8 +815,8 @@ const App: React.FC<AppProps> = (props) => {
         <Content>
           <Toolbar
             viewMode={viewerSettings.viewMode}
-            fovDownloadHref={props.fovDownloadHref}
-            cellDownloadHref={props.cellDownloadHref}
+            fovDownloadHref={props.parentImageDownloadHref}
+            cellDownloadHref={props.imageDownloadHref}
             autorotate={viewerSettings.autorotate}
             imageType={viewerSettings.imageType}
             hasParentImage={!!props.parentImageUrl}

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -819,7 +819,7 @@ const App: React.FC<AppProps> = (props) => {
             cellDownloadHref={props.cellDownloadHref}
             autorotate={viewerSettings.autorotate}
             imageType={viewerSettings.imageType}
-            hasParentImage={!!props.fovPath}
+            hasParentImage={!!props.parentImageUrl}
             hasCellId={!!props.cellId}
             canPathTrace={view3d ? view3d.hasWebGL2() : false}
             showAxes={viewerSettings.showAxes}

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -584,7 +584,7 @@ const App: React.FC<AppProps> = (props) => {
     view3d.setCameraMode(viewerSettings.viewMode);
   }, []);
 
-  // Hook to trigger image load: on mount, when image source props/state change (`cellId`, `imageType`, data)
+  // Hook to trigger image load: on mount, when image source props/state change (`cellId`, `imageType`, `rawData`, etc)
   useEffect(() => {
     if (props.rawDims && props.rawData) {
       loadFromRaw();

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -446,8 +446,8 @@ const App: React.FC<AppProps> = (props) => {
 
   const openImage = async (): Promise<void> => {
     const { imageUrl, parentImageUrl } = props;
-    const path =
-      viewerSettings.imageType === ImageType.fullField && parentImageUrl !== undefined ? parentImageUrl : imageUrl;
+    const showParentImage = viewerSettings.imageType === ImageType.fullField && parentImageUrl !== undefined;
+    const path = showParentImage ? parentImageUrl : imageUrl;
     // Don't reload if we're already looking at this image
     if (path === imageUrlRef.current) {
       return;

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -54,21 +54,23 @@ export interface GlobalViewerSettings {
 }
 
 export interface AppProps {
+  // FIRST WAY TO GET DATA INTO THE VIEWER: pass in volume data directly
   // rawData has a "dtype" which is expected to be "uint8", a "shape":[c,z,y,x] and a "buffer" which is a DataView
   rawData?: { dtype: "uint8"; shape: [number, number, number, number]; buffer: DataView };
   // rawDims is the volume dims that normally come from a json file
   rawDims?: ImageInfo;
+
+  // SECOND WAY TO GET DATA INTO THE VIEWER: (if `rawData`/`rawDims` isn't present) pass in URL(s) to fetch volume data
+  imageUrl: string | string[];
+  parentImageUrl?: string | string[];
 
   // replaces / obviates groupToChannelNameMap, channelNameClean, channelNameMapping, filterFunc, initialChannelSettings, defaultSurfacesOn and defaultVolumesOn
   viewerChannelSettings?: ViewerChannelSettings;
 
   appHeight: string;
   cellId: string;
-  cellPath: string;
-  fovPath: string;
   showControls?: Partial<ShowControls>;
   viewerSettings?: Partial<GlobalViewerSettings>;
-  baseUrl: string;
   cellDownloadHref: string;
   fovDownloadHref: string;
   pixelSize?: [number, number, number];

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -71,8 +71,8 @@ export interface AppProps {
   cellId: string;
   showControls?: Partial<ShowControls>;
   viewerSettings?: Partial<GlobalViewerSettings>;
-  cellDownloadHref: string;
-  fovDownloadHref: string;
+  imageDownloadHref: string;
+  parentImageDownloadHref: string;
   pixelSize?: [number, number, number];
   canvasMargin: string;
   transform?: {


### PR DESCRIPTION
Review time: pretty quick (~20min)

Closes allen-cell-animated/volume-viewer#78: allow users to take advantage of volume-viewer's new ability to load zarrs from multiple data sources.

## This PR makes the following breaking changes to the viewer API:

### Viewer component: replace the `cellPath`, `fovPath`, and `baseUrl` props with `imageUrl` and `parentImageUrl`.

Like the props they replace, `imageUrl` and `parentImageUrl` specify the paths from which to load image data. They correspond to the old `cellPath` and `fovPath` props, respectively, in that they specify what CFE calls "single cell" and "full field" images. However, they are different from the old set of data-loading props in the following ways:

- With `baseUrl` gone, **both URLs must be fully qualified**. No more automatically picking two files out of a single parent directory.
- **Both props may be `string[]`.** When passed down to volume-viewer to get a loader, a `string[]` will create a (zarr) loader which loads channels from multiple volumes. (NOTE: JSON loaders may also accept arrays of URLs, but will interpret each image as a different time point, not an additional source of channel data.)
- **`parentImageUrl` may be `undefined`.**

CFE will have to be updated to use these new props.

### Public app: remove `image` url parameter and add `url2`.

`image`, when present, behaved like the `cellPath` to `url`'s `baseUrl`. This was basically never used, since it was just as easy to specify the full url in `url`. So now it's gone.

In its place is `url2`, which adds a second zarr source (or JSON time step, I guess) to the loaded image. After some discussion about how we might support arbitrarily many source urls, we decided that just two sources would be good enough to support 95% of realistic use cases for this feature. (If anyone has any bright ideas about how to safely delimit a list of arbitrary URLs within another URL, let me know.)

## To test:

- `npm start`
- Open http://localhost:9020/?url=https://animatedcell-test-data.s3.us-west-2.amazonaws.com/variance/1.zarr/&url2=https://animatedcell-test-data.s3.us-west-2.amazonaws.com/variance/10.zarr/.
- You should now be able to mix and match channels from both zarr volumes.