### PR TITLE
Fix control point remapping

### DIFF
--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -718,6 +718,7 @@ export default class MyTfEditor extends React.Component<MyTfEditorProps, MyTfEdi
     this.last_color = colorObjectToArray(color.rgb);
     if (this.selected) {
       this.selected.color = this.last_color;
+      this.props.updateChannelLutControlPoints([...this.props.controlPoints]);
       this.redraw();
     }
   }

--- a/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
+++ b/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
@@ -1,63 +1,12 @@
-import colorString from "color-string";
 import { ControlPoint, Lut, Volume } from "@aics/volume-viewer";
-import { ColorArray } from "./colorRepresentations";
 import { findFirstChannelMatch, ViewerChannelSettings } from "./viewerChannelSettings";
 import { LUT_MAX_PERCENTILE, LUT_MIN_PERCENTILE } from "../constants";
 import { TFEDITOR_DEFAULT_COLOR } from "../../components/TfEditor";
 
-const canv = document.createElement("canvas");
-canv.width = 256;
-canv.height = 1;
-canv.style.width = "256px";
-canv.style.height = "1px";
-const ctx = canv.getContext("2d")!;
-
-// @param {string} css_str - string representing a color that is css canvas context2d compatible
-// @param {number} opacity_override - number representing an opacity value from 0 to 1
-// @return {string} the new rgba color with the opacity applied to its alpha value as a css color string
-function cssColorWithOpacity(css_str: ColorArray | string, opacity_override: number): string {
-  if (Array.isArray(css_str)) {
-    return colorString.to.rgb([css_str[0], css_str[1], css_str[2], opacity_override]);
-  }
-  const arr = colorString.get(css_str)!.value;
-  arr[3] = opacity_override;
-  return colorString.to.rgb(arr);
-}
-
-// clamp x to the range [0,1]
-function clamp(x: number): number {
-  return Math.min(1.0, Math.max(0.0, x));
-}
-
 // @param {Object[]} controlPoints - array of {x:number, opacity:number, color:string}
 // @return {Uint8Array} array of length 256*4 representing the rgba values of the gradient
 export function controlPointsToLut(controlPoints: ControlPoint[]): Lut {
-  const grd = ctx.createLinearGradient(0, 0, 255, 0);
-  if (!controlPoints.length || controlPoints.length < 1) {
-    console.log("warning: bad control points submitted to makeColorGradient; reverting to linear greyscale gradient");
-    grd.addColorStop(0, "black");
-    grd.addColorStop(1, "white");
-  } else {
-    // TODO: what if none at 0 and none at 1?
-    for (let i = 0; i < controlPoints.length; ++i) {
-      // multiply in controlPoints[i].opacity somehow at this time?
-      const colorStop = cssColorWithOpacity(controlPoints[i].color, controlPoints[i].opacity);
-      //console.log(controlPoints[i].x / 255.0, colorStop);
-      grd.addColorStop(clamp((controlPoints[i].x + 0.5) / 255.0), colorStop);
-    }
-  }
-
-  ctx.clearRect(0, 0, 256, 1);
-  ctx.fillStyle = grd;
-  ctx.fillRect(0, 0, 256, 1);
-  const imgData = ctx.getImageData(0, 0, 256, 1);
-
-  const lut = new Lut();
-  lut.lut = new Uint8Array(imgData.data.buffer);
-  lut.controlPoints = controlPoints;
-
-  // TODO Replace this whole function with new Lut().createFromControlPoints(controlPoints) ?
-
+  const lut = new Lut().createFromControlPoints(controlPoints);
   return lut;
 }
 


### PR DESCRIPTION
This change picks up a change from volume-viewer to let control points be out of range, so they are remembered when they have to be remapped multiple consecutive times.  We adopt volume-viewer's method for rebuilding the lookup table array from the control points. 

Bonus bug fix: control points receiving a color change but no position change, were not actually updating colors in the view.  Added an update call to make sure it happens.

(volume viewer PR linked below)