### PR TITLE
feature: Landing page styling

### DIFF
--- a/public/App.css
+++ b/public/App.css
@@ -2,7 +2,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  font-family: 'Overpass'
+  font-family: "Open Sans", "Overpass", Arial, sans-serif;
 }
 
 /* Adjust container width (height needs to be changed through the appHeight prop for ImageViewerApp

--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,9 @@
             height: 100%;
         }
     </style>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet">
 
 </head>
 <body>

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -5,11 +5,14 @@ import "antd/dist/antd.less";
 
 // Components
 import "../src/aics-image-viewer/assets/styles/typography.css";
+import StyleProvider from "../src/aics-image-viewer/components/StyleProvider";
 import "./App.css";
 
 import { ImageViewerApp, RenderMode, ViewerChannelSettings, ViewMode } from "../src";
 import FirebaseRequest from "./firebase";
 import { GlobalViewerSettings } from "../src/aics-image-viewer/components/App/types";
+import LandingPage from "../src/landing-page/components/LandingPage";
+import { ViewerArgs } from "../src/landing-page/types";
 
 // vars filled at build time using webpack DefinePlugin
 console.log(`website-3d-cell-viewer ${WEBSITE3DCELLVIEWER_BUILD_ENVIRONMENT} build`);
@@ -107,7 +110,7 @@ if (params) {
       Z: ViewMode.xy,
       Y: ViewMode.xz,
       X: ViewMode.yz,
-    }
+    };
     const allowedViews = Object.keys(mapping);
     if (!allowedViews.includes(params.view)) {
       params.view = "3D";
@@ -168,14 +171,14 @@ if (params) {
     // any split between baseUrl + cellPath is ok
     // as long as (baseUrl+cellPath) ends with .json
 
-    // it is understood that if fovPath is provided, 
+    // it is understood that if fovPath is provided,
     // it must be relative to baseUrl in addition to cellPath.
 
     let decodedurl = decodeURI(params.url);
     let decodedimage = "";
     if (params.image) {
       decodedimage = decodeURIComponent(params.image);
-    } 
+    }
 
     // get the last thing in the url
     if (decodedurl.endsWith("/")) {
@@ -187,9 +190,8 @@ if (params) {
     // any difference for zarr or tiff or json?
     decodedurl = baseUrl;
     if (decodedimage !== "") {
-      decodedimage = lastpart+"/"+decodedimage;
-    }
-    else {
+      decodedimage = lastpart + "/" + decodedimage;
+    } else {
       decodedimage = lastpart;
     }
 
@@ -272,19 +274,33 @@ if (params) {
 }
 
 function runApp() {
+  const showLandingPage = true;
+
   ReactDOM.render(
-    <ImageViewerApp
-      cellId={args.cellid.toString()}
-      baseUrl={args.baseurl}
-      appHeight="100vh"
-      canvasMargin="0 0 0 0"
-      cellPath={args.cellPath}
-      fovPath={args.fovPath}
-      fovDownloadHref={args.fovDownloadHref}
-      cellDownloadHref={args.cellDownloadHref}
-      viewerSettings={viewerSettings}
-      viewerChannelSettings={args.initialChannelSettings}
-    />,
+    <>
+      {showLandingPage ? (
+        <StyleProvider>
+          <LandingPage
+            load={function (args: ViewerArgs): void {
+              throw new Error("Function not implemented.");
+            }}
+          />
+        </StyleProvider>
+      ) : (
+        <ImageViewerApp
+          cellId={args.cellid.toString()}
+          baseUrl={args.baseurl}
+          appHeight="100vh"
+          canvasMargin="0 0 0 0"
+          cellPath={args.cellPath}
+          fovPath={args.fovPath}
+          fovDownloadHref={args.fovDownloadHref}
+          cellDownloadHref={args.cellDownloadHref}
+          viewerSettings={viewerSettings}
+          viewerChannelSettings={args.initialChannelSettings}
+        />
+      )}
+    </>,
     document.getElementById("cell-viewer")
   );
 }

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -5,14 +5,11 @@ import "antd/dist/antd.less";
 
 // Components
 import "../src/aics-image-viewer/assets/styles/typography.css";
-import StyleProvider from "../src/aics-image-viewer/components/StyleProvider";
 import "./App.css";
 
 import { ImageViewerApp, RenderMode, ViewerChannelSettings, ViewMode } from "../src";
 import FirebaseRequest from "./firebase";
 import { GlobalViewerSettings } from "../src/aics-image-viewer/components/App/types";
-import LandingPage from "../src/landing-page/components/LandingPage";
-import { ViewerArgs } from "../src/landing-page/types";
 
 // vars filled at build time using webpack DefinePlugin
 console.log(`website-3d-cell-viewer ${WEBSITE3DCELLVIEWER_BUILD_ENVIRONMENT} build`);
@@ -110,7 +107,7 @@ if (params) {
       Z: ViewMode.xy,
       Y: ViewMode.xz,
       X: ViewMode.yz,
-    };
+    }
     const allowedViews = Object.keys(mapping);
     if (!allowedViews.includes(params.view)) {
       params.view = "3D";
@@ -171,14 +168,14 @@ if (params) {
     // any split between baseUrl + cellPath is ok
     // as long as (baseUrl+cellPath) ends with .json
 
-    // it is understood that if fovPath is provided,
+    // it is understood that if fovPath is provided, 
     // it must be relative to baseUrl in addition to cellPath.
 
     let decodedurl = decodeURI(params.url);
     let decodedimage = "";
     if (params.image) {
       decodedimage = decodeURIComponent(params.image);
-    }
+    } 
 
     // get the last thing in the url
     if (decodedurl.endsWith("/")) {
@@ -190,8 +187,9 @@ if (params) {
     // any difference for zarr or tiff or json?
     decodedurl = baseUrl;
     if (decodedimage !== "") {
-      decodedimage = lastpart + "/" + decodedimage;
-    } else {
+      decodedimage = lastpart+"/"+decodedimage;
+    }
+    else {
       decodedimage = lastpart;
     }
 
@@ -274,33 +272,19 @@ if (params) {
 }
 
 function runApp() {
-  const showLandingPage = true;
-
   ReactDOM.render(
-    <>
-      {showLandingPage ? (
-        <StyleProvider>
-          <LandingPage
-            load={function (args: ViewerArgs): void {
-              throw new Error("Function not implemented.");
-            }}
-          />
-        </StyleProvider>
-      ) : (
-        <ImageViewerApp
-          cellId={args.cellid.toString()}
-          baseUrl={args.baseurl}
-          appHeight="100vh"
-          canvasMargin="0 0 0 0"
-          cellPath={args.cellPath}
-          fovPath={args.fovPath}
-          fovDownloadHref={args.fovDownloadHref}
-          cellDownloadHref={args.cellDownloadHref}
-          viewerSettings={viewerSettings}
-          viewerChannelSettings={args.initialChannelSettings}
-        />
-      )}
-    </>,
+    <ImageViewerApp
+      cellId={args.cellid.toString()}
+      baseUrl={args.baseurl}
+      appHeight="100vh"
+      canvasMargin="0 0 0 0"
+      cellPath={args.cellPath}
+      fovPath={args.fovPath}
+      fovDownloadHref={args.fovDownloadHref}
+      cellDownloadHref={args.cellDownloadHref}
+      viewerSettings={viewerSettings}
+      viewerChannelSettings={args.initialChannelSettings}
+    />,
     document.getElementById("cell-viewer")
   );
 }

--- a/src/aics-image-viewer/assets/styles/globals.css
+++ b/src/aics-image-viewer/assets/styles/globals.css
@@ -1,6 +1,7 @@
 .cell-viewer-app {
   height: 100%;
 }
+/** TODO: Remove and replace with just Open Sans. */
 /* merriweather-sans-regular - latin */
 @font-face {
   font-family: "Merriweather Sans";

--- a/src/aics-image-viewer/assets/styles/typography.css
+++ b/src/aics-image-viewer/assets/styles/typography.css
@@ -1,15 +1,11 @@
 #cell-viewer {
   body {
-    font-family: "Overpass-Light";
+    font-family: "Open Sans", "Overpass-Light", Arial, sans-serif;
   }
   h1,
   h2,
   h3,
   h4 {
-    font-family: "Merriweather Sans";
-  }
-  p {
-    font-weight: 300;
-    font-size: 1rem;
+    font-family: "Open Sans", "Merriweather Sans", Arial, sans-serif;
   }
 }

--- a/src/aics-image-viewer/assets/styles/typography.css
+++ b/src/aics-image-viewer/assets/styles/typography.css
@@ -1,4 +1,6 @@
 #cell-viewer {
+  height: 100%;
+
   body {
     font-family: "Open Sans", "Overpass-Light", Arial, sans-serif;
   }

--- a/src/aics-image-viewer/assets/styles/variables.css
+++ b/src/aics-image-viewer/assets/styles/variables.css
@@ -1,3 +1,5 @@
+/* TODO: Replace all of these with CSS variables (e.g. var(--color-text-body) and remove PostCSS from the project.*/
+
 /* $app-height: 100%; */
 /* $dark-gray: #313131; */
 /* $purple: #8048f3; */

--- a/src/aics-image-viewer/assets/styles/variables.css
+++ b/src/aics-image-viewer/assets/styles/variables.css
@@ -1,14 +1,14 @@
-$app-height: 100%;
-$dark-gray: #313131;
-$purple: #8048f3;
-$highlight-purple: #8950d9;
-$light-gray: #6e6e6e;
-$bright-green: #b2d030;
-$background-gray: #fafafa;
-$header-gray: #4b4b4b;
-$background-dark-gray: #131313;
+/* $app-height: 100%; */
+/* $dark-gray: #313131; */
+/* $purple: #8048f3; */
+$highlight-purple: #9e6aff;
+/* $light-gray: #6e6e6e; (DUPLICATE) */
+/* $bright-green: #b2d030; */
+/* $background-gray: #fafafa; */
+/* $header-gray: #4b4b4b; (DUPLICATE) */
+/* $background-dark-gray: #131313; */
 $dimgray: #6e6e6e;
-$highlight-green: #b2d030;
+/* $highlight-green: #b2d030; */
 $text-gray: #a0a0a0;
 $header-gray: #4b4b4b;
 $light-gray: #aeacae;

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -1,0 +1,9 @@
+import React, { PropsWithChildren, ReactElement } from "react";
+import "./styles.css";
+
+/**
+ * Provides CSS variables and global styling for the image viewer.
+ */
+export default function StyleProvider(props: PropsWithChildren<{}>): ReactElement {
+  return <div className="aics-image-viewer-style-provider">{props.children}</div>;
+}

--- a/src/aics-image-viewer/components/StyleProvider/styles.css
+++ b/src/aics-image-viewer/components/StyleProvider/styles.css
@@ -65,8 +65,8 @@
 
     h1 {
         color: var(--color-text-header);
-        font-size: 24px;
-        font-weight: 600;
+        font-size: 28px;
+        font-weight: 400;
     }
 
     h2 {

--- a/src/aics-image-viewer/components/StyleProvider/styles.css
+++ b/src/aics-image-viewer/components/StyleProvider/styles.css
@@ -47,6 +47,9 @@
     --color-landingpage-text: var(--palette-lt-grey);
     --color-landingpage-banner-highlight-bg: #020202DB;
 
+    --color-statusflag-bg: var(--palette-very-lt-purple);
+    --color-statusflag-text: var(--palette-dark-purple);
+
     --color-layout-dividers: var(--palette-med-grey);
 
     --color-text-link: var(--palette-bright-blue);

--- a/src/aics-image-viewer/components/StyleProvider/styles.css
+++ b/src/aics-image-viewer/components/StyleProvider/styles.css
@@ -17,6 +17,7 @@
     --palette-med-purple: #9e6aff;
     /* #8950D9 is deprecated. ("medium purple") */
     --palette-dark-purple: #7e46d4;
+    --palette-very-dark-purple: #5f369f;
     --palette-very-lt-purple: #e7e4f2;
     --palette-bright-red: #ff4d4d;
     --palette-bright-green: #61d900;
@@ -52,12 +53,12 @@
     --color-landingpage-banner-highlight-bg: #020202DB;
 
     --color-statusflag-bg: var(--palette-very-lt-purple);
-    --color-statusflag-text: var(--palette-dark-purple);
+    --color-statusflag-text: var(--palette-very-dark-purple);
 
     --color-layout-dividers: var(--palette-med-grey);
 
     --color-text-link: var(--palette-bright-blue);
-    --color-text-header: var(--palette-white);
+    --color-text-header: var(--palette-lt-grey);
     --color-text-body: var(--palette-lt-grey);
     --color-text-selection-bg: var(--palette-med-purple);
     --color-text-selection-text: var(--palette-white);

--- a/src/aics-image-viewer/components/StyleProvider/styles.css
+++ b/src/aics-image-viewer/components/StyleProvider/styles.css
@@ -1,0 +1,55 @@
+.aics-image-viewer-style-provider {
+    /* Color palette. COMPONENTS USING CSS VARIABLES SHOULD **NOT** ACCESS THESE DIRECTLY. */
+    --palette-black: #000000;
+    --palette-white: #ffffff;
+    --palette-lt-grey: #bfbfbf;
+    --palette-purple-grey: #aeacae;
+    --palette-med-lt-grey-alt: #a0a0a0;
+    --palette-med-grey: #6e6e6e;
+    --palette-med-dark-grey: #4b4b4b
+    --palette-dark-grey: #313131;
+    --palette-very-dark-grey: #222222;
+    --palette-lime-green: #b2d030;
+    --palette-lt-purple: #aa88ed;
+    --palette-med-purple: #9e6aff;
+    /* #8950D9 is deprecated. ("medium purple") */
+    --palette-dark-purple: #7e46d4;
+    --palette-very-lt-purple: #e7e4f2;
+    --palette-bright-red: #ff4d4d;
+    --palette-bright-green: #61d900;
+    --palette-bright-blue: #0099ff;
+
+    /* Component and color variables.
+     * TODO: use these to control component colors.
+     */
+    --color-header-text: var(--palette-med-purple);
+    --color-header-icon: var(--palette-white);
+    --color-header-bg: var(--palette-very-dark-grey);
+    --color-header-border: var(--palette-med-grey);
+
+    --color-button-primary-bg: var(--palette-med-purple);
+    --color-button-primary-text: var(--palette-white);
+    --color-button-primary-hover-bg: var(--palette-lt-purple);
+    --color-button-primary-active-outline: var(--palette-med-purple);
+    --color-button-primary-disabled-bg: var(--palette-med-dark-grey);
+
+    --color-button-secondary-bg: transparent;
+    --color-button-secondary-text: var(--palette-med-purple);
+    --color-button-secondary-outline: var(--palette-med-purple);
+    --color-button-secondary-hover-bg: var(--palette-lt-purple);
+
+    --color-controlpanel-bg: var(--palette-dark-grey);
+    --color-controlpanel-border: var(--palette-med-grey);
+    --color-controlpanel-text: var(--palette-lt-grey);
+    --color-controlpanel-section-bg: var(--palette-med-dark-grey);
+
+    --color-landingpage-bg: var(--palette-very-dark-grey);
+    --color-landingpage-text: var(--palette-lt-grey);
+    --color-landingpage-banner-highlight-bg: #020202DB;
+
+    --color-layout-dividers: var(--palette-med-grey);
+
+    --color-text-link: var(--palette-bright-blue);
+    --color-text-header: var(--palette-white);
+    --color-text-body: var(--palette-lt-grey);
+}

--- a/src/aics-image-viewer/components/StyleProvider/styles.css
+++ b/src/aics-image-viewer/components/StyleProvider/styles.css
@@ -20,7 +20,8 @@
     --palette-bright-blue: #0099ff;
 
     /* Component and color variables.
-     * TODO: use these to control component colors.
+     * TODO: use these to control component colors instead of the currently
+     * hard-coded colors in the components.
      */
     --color-header-text: var(--palette-med-purple);
     --color-header-icon: var(--palette-white);
@@ -55,4 +56,46 @@
     --color-text-link: var(--palette-bright-blue);
     --color-text-header: var(--palette-white);
     --color-text-body: var(--palette-lt-grey);
+
+    --font-family: 'Open Sans', Arial, sans-serif;
+
+    h1, h2, h3, h4, p {
+        font-family: var(--font-family);
+    }
+
+    h1 {
+        color: var(--color-text-header);
+        font-size: 24px;
+        font-weight: 600;
+    }
+
+    h2 {
+        color: var(--color-text-header);
+        font-size: 19px;
+        font-weight: 600;
+    }
+
+    h3 {
+        font-family: var(--font-family);
+        color: var(--color-text-header);
+        font-size: 16px;
+        font-weight: 600;
+    }
+
+    p {
+        font-family: var(--font-family);
+        color: var(--color-text-body);
+        font-size: 14px;
+        font-weight: 400;
+    }
+
+    & *::selection {
+        /** 
+         * Override Ant + Less styling, since it uses a very light purple that's 
+         * impossible to read white text on.
+         * TODO: Fix this in the main app too. This currently only applies to landing page.
+         */
+        background-color: #7e46d4;
+        color: var(--palette-white);
+    }
 }

--- a/src/aics-image-viewer/components/StyleProvider/styles.css
+++ b/src/aics-image-viewer/components/StyleProvider/styles.css
@@ -56,6 +56,8 @@
     --color-text-link: var(--palette-bright-blue);
     --color-text-header: var(--palette-white);
     --color-text-body: var(--palette-lt-grey);
+    --color-text-selection-bg: var(--palette-med-purple);
+    --color-text-selection-text: var(--palette-white);
 
     --font-family: 'Open Sans', Arial, sans-serif;
 
@@ -95,7 +97,7 @@
          * impossible to read white text on.
          * TODO: Fix this in the main app too. This currently only applies to landing page.
          */
-        background-color: #7e46d4;
-        color: var(--palette-white);
+        background-color: var(--color-text-selection-bg);
+        color: var(--color-text-selection-text);
     }
 }

--- a/src/aics-image-viewer/components/StyleProvider/styles.css
+++ b/src/aics-image-viewer/components/StyleProvider/styles.css
@@ -1,4 +1,7 @@
 .aics-image-viewer-style-provider {
+    width: 100%;
+    height: 100%;
+
     /* Color palette. COMPONENTS USING CSS VARIABLES SHOULD **NOT** ACCESS THESE DIRECTLY. */
     --palette-black: #000000;
     --palette-white: #ffffff;
@@ -74,7 +77,7 @@
     h2 {
         color: var(--color-text-header);
         font-size: 19px;
-        font-weight: 600;
+        font-weight: 400;
     }
 
     h3 {
@@ -99,5 +102,24 @@
          */
         background-color: var(--color-text-selection-bg);
         color: var(--color-text-selection-text);
+    }
+
+
+    /* TODO: Remove this when we upgrade to Ant versions that provide support for
+     * ConfigProvider. 
+     */
+    .ant-btn-primary {
+        background-color: var(--color-button-primary-bg);
+        color: var(--color-button-primary-text);
+        border-color: var(--color-button-primary-bg);
+    }
+
+    .ant-btn:hover {
+        background-color: var(--color-button-primary-hover-bg);
+        border-color: var(--color-button-primary-hover-bg);
+    }
+
+    .ant-btn:active {
+        border: 1px solid var(--color-button-primary-active-outline);
     }
 }

--- a/src/aics-image-viewer/styles/ant-vars.less
+++ b/src/aics-image-viewer/styles/ant-vars.less
@@ -1,5 +1,5 @@
 @dark-gray: #313131;
-@purple: #8048f3;
+@purple: #9e6aff;
 @light-gray: #6e6e6e;
 @bright-green: #b2d030;
 

--- a/src/landing-page/components/LandingPage/content.ts
+++ b/src/landing-page/components/LandingPage/content.ts
@@ -8,5 +8,14 @@ export const landingPageContent: ProjectEntry[] = [
     publicationLink: new URL("https://google.com"),
     publicationName: "This is the name of the associated publication that the user can click to open in a new tab",
     inReview: true,
+    loadParams: {
+      baseurl: "",
+      cellid: 0,
+      cellPath: "",
+      fovPath: "",
+      fovDownloadHref: "",
+      cellDownloadHref: "",
+      viewerSettings: { groups: [] },
+    },
   },
 ];

--- a/src/landing-page/components/LandingPage/index.tsx
+++ b/src/landing-page/components/LandingPage/index.tsx
@@ -116,6 +116,11 @@ const ProjectCard = styled.li`
   & h3 {
     font-weight: 600;
   }
+
+  & p,
+  & h3 {
+    margin: 0;
+  }
 `;
 
 const DatasetList = styled.ol`
@@ -233,8 +238,10 @@ export default function LandingPage(props: LandingPageProps): ReactElement {
     return (
       <ProjectCard key={index}>
         {projectNameElement}
-        <p>{project.description}</p>
-        {publicationElement}
+        <FlexColumn $gap={6}>
+          <p>{project.description}</p>
+          {publicationElement}
+        </FlexColumn>
         {loadButton}
         {datasetList}
       </ProjectCard>

--- a/src/landing-page/components/LandingPage/index.tsx
+++ b/src/landing-page/components/LandingPage/index.tsx
@@ -87,7 +87,7 @@ const Divider = styled.hr`
   display: block;
   width: 100%;
   height: 1px;
-  background-color: var(--color-borders);
+  background-color: var(--color-layout-dividers);
   border-style: none;
 `;
 
@@ -104,7 +104,7 @@ const ProjectList = styled.ul`
     display: block;
     width: 100%;
     height: 1px;
-    background-color: var(--color-borders);
+    background-color: var(--color-layout-dividers);
     margin-bottom: 10px;
   }
 `;
@@ -198,7 +198,7 @@ export default function LandingPage(props: LandingPageProps): ReactElement {
 
   const renderProject = (project: ProjectEntry, index: number): ReactElement => {
     const projectNameElement = project.inReview ? (
-      <FlexRow style={{ justifyContent: "space-between" }} $gap={10}>
+      <FlexRow $gap={10}>
         <h3>{project.name}</h3>
         <Tooltip title="Final version of dataset will be released when associated paper is published">
           <InReviewFlag>

--- a/src/landing-page/components/LandingPage/index.tsx
+++ b/src/landing-page/components/LandingPage/index.tsx
@@ -24,7 +24,6 @@ const BannerTextContainer = styled(FlexColumn)`
   --total-padding-x: calc(2 * var(--padding-x) + 2 * var(--container-padding-x));
   width: calc(90vw - var(--total-padding-x));
   border-radius: 5px;
-  // Fallback in case color-mix is unsupported.
   background-color: var(--color-landingpage-banner-highlight-bg);
   gap: 10px;
 
@@ -156,14 +155,14 @@ const DatasetCard = styled.li`
 const InReviewFlag = styled(FlexRowAlignCenter)`
   border-radius: 4px;
   padding: 1px 6px;
-  background-color: var(--color-flag-background);
+  background-color: var(--color-statusflag-bg);
   height: 22px;
   flex-wrap: wrap;
 
   & > p {
-    color: var(--color-flag-text);
+    color: var(--color-statusflag-text);
     font-size: 10px;
-    font-weight: 700;
+    font-weight: 600;
     white-space: nowrap;
   }
 `;

--- a/src/landing-page/components/LandingPage/index.tsx
+++ b/src/landing-page/components/LandingPage/index.tsx
@@ -25,9 +25,7 @@ const BannerTextContainer = styled(FlexColumn)`
   width: calc(90vw - var(--total-padding-x));
   border-radius: 5px;
   // Fallback in case color-mix is unsupported.
-  background-color: var(--color-background);
-  // Make the background slightly transparent. Note that this may fail on internet explorer.
-  background-color: color-mix(in srgb, #020202 86%, transparent);
+  background-color: var(--color-landingpage-banner-highlight-bg);
   gap: 10px;
 
   & > h1 {
@@ -252,7 +250,7 @@ export default function LandingPage(props: LandingPageProps): ReactElement {
   });
 
   return (
-    <>
+    <div style={{ backgroundColor: "var(--color-landingpage-bg)" }}>
       {/* <Header>
         <FlexRowAlignCenter $gap={15}>
           <LoadDatasetButton onLoad={onDatasetLoad} currentResourceUrl={""} />
@@ -260,12 +258,12 @@ export default function LandingPage(props: LandingPageProps): ReactElement {
         </FlexRowAlignCenter>
       </Header> */}
       <Banner>
-        <BannerVideoContainer>
+        <BannerVideoContainer style={{ zIndex: 1 }}>
           <video autoPlay={allowMotion} loop muted>
             <source src="/videos/banner-video.mp4" type="video/mp4" />
           </video>
         </BannerVideoContainer>
-        <BannerTextContainer>
+        <BannerTextContainer style={{ zIndex: 1 }}>
           <h1>Welcome to 3D Volume Viewer</h1>
           <p>
             The 3D Volume Viewer is an open-use web-based tool designed to visualize, analyze and interpret
@@ -303,6 +301,6 @@ export default function LandingPage(props: LandingPageProps): ReactElement {
         </FlexColumnAlignCenter>
         <ProjectList>{landingPageContent.map(renderProject)}</ProjectList>
       </ContentContainer>
-    </>
+    </div>
   );
 }

--- a/src/landing-page/components/LandingPage/index.tsx
+++ b/src/landing-page/components/LandingPage/index.tsx
@@ -1,7 +1,7 @@
 import { faUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Button, Tooltip } from "antd";
-import React, { ReactElement } from "react";
+import React, { ReactElement, useEffect, useState } from "react";
 
 import { landingPageContent } from "./content";
 import { DatasetEntry, ProjectEntry, ViewerArgs } from "../../types";
@@ -51,6 +51,7 @@ const BannerVideoContainer = styled.div`
   & > video {
     width: 100%;
     height: 100%;
+    object-position: 50% 30%;
     object-fit: cover;
   }
 `;
@@ -242,7 +243,14 @@ export default function LandingPage(props: LandingPageProps): ReactElement {
     );
   };
 
-  // TODO: Add accessibility check here for `prefers-reduced-motion`
+  const [allowMotion, setAllowMotion] = useState(window.matchMedia("(prefers-reduced-motion: no-preference)").matches);
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: no-preference)");
+    mediaQuery.addEventListener("change", () => {
+      setAllowMotion(mediaQuery.matches);
+    });
+  });
+
   return (
     <>
       {/* <Header>
@@ -253,7 +261,7 @@ export default function LandingPage(props: LandingPageProps): ReactElement {
       </Header> */}
       <Banner>
         <BannerVideoContainer>
-          <video autoPlay loop muted>
+          <video autoPlay={allowMotion} loop muted>
             <source src="/videos/banner-video.mp4" type="video/mp4" />
           </video>
         </BannerVideoContainer>

--- a/src/landing-page/components/LandingPage/index.tsx
+++ b/src/landing-page/components/LandingPage/index.tsx
@@ -160,6 +160,7 @@ const InReviewFlag = styled(FlexRowAlignCenter)`
   flex-wrap: wrap;
 
   & > p {
+    margin-bottom: 0;
     color: var(--color-statusflag-text);
     font-size: 10px;
     font-weight: 600;

--- a/src/landing-page/components/LandingPage/index.tsx
+++ b/src/landing-page/components/LandingPage/index.tsx
@@ -27,7 +27,7 @@ const BannerTextContainer = styled(FlexColumn)`
   // Fallback in case color-mix is unsupported.
   background-color: var(--color-background);
   // Make the background slightly transparent. Note that this may fail on internet explorer.
-  background-color: color-mix(in srgb, var(--color-background) 80%, transparent);
+  background-color: color-mix(in srgb, #020202 86%, transparent);
   gap: 10px;
 
   & > h1 {
@@ -52,8 +52,6 @@ const BannerVideoContainer = styled.div`
     width: 100%;
     height: 100%;
     object-fit: cover;
-    // Fixes a bug where a single pixel black outline would appear around the video.
-    clip-path: inset(1px 1px);
   }
 `;
 
@@ -244,6 +242,7 @@ export default function LandingPage(props: LandingPageProps): ReactElement {
     );
   };
 
+  // TODO: Add accessibility check here for `prefers-reduced-motion`
   return (
     <>
       {/* <Header>
@@ -255,7 +254,7 @@ export default function LandingPage(props: LandingPageProps): ReactElement {
       <Banner>
         <BannerVideoContainer>
           <video autoPlay loop muted>
-            <source src="/banner_video.mp4" type="video/mp4" />
+            <source src="/videos/banner-video.mp4" type="video/mp4" />
           </video>
         </BannerVideoContainer>
         <BannerTextContainer>

--- a/src/landing-page/components/LandingPage/index.tsx
+++ b/src/landing-page/components/LandingPage/index.tsx
@@ -50,7 +50,7 @@ const BannerVideoContainer = styled.div`
   & > video {
     width: 100%;
     height: 100%;
-    object-position: 50% 30%;
+    object-position: 50% 40%;
     object-fit: cover;
   }
 `;

--- a/src/landing-page/components/LandingPage/index.tsx
+++ b/src/landing-page/components/LandingPage/index.tsx
@@ -8,18 +8,20 @@ import { DatasetEntry, ProjectEntry, ViewerArgs } from "../../types";
 import styled from "styled-components";
 import { FlexColumnAlignCenter, FlexColumn, FlexRowAlignCenter, VisuallyHidden, FlexRow } from "./utils";
 
+const MAX_CONTENT_WIDTH_PX = 1060;
+
 const Banner = styled(FlexColumnAlignCenter)`
   position: relative;
   --container-padding-x: 20px;
-  padding: 30px var(--container-padding-x);
+  padding: 40px var(--container-padding-x);
   overflow: hidden;
   margin: 0;
 `;
 
 const BannerTextContainer = styled(FlexColumn)`
   --padding-x: 30px;
-  padding: var(--padding-x);
-  max-width: calc(1060px - 2 * var(--padding-x));
+  padding: 26px var(--padding-x);
+  max-width: calc(${MAX_CONTENT_WIDTH_PX}px - 2 * var(--padding-x));
 
   --total-padding-x: calc(2 * var(--padding-x) + 2 * var(--container-padding-x));
   width: calc(90vw - var(--total-padding-x));
@@ -54,7 +56,7 @@ const BannerVideoContainer = styled.div`
 `;
 
 const ContentContainer = styled(FlexColumn)`
-  max-width: 1060px;
+  max-width: ${MAX_CONTENT_WIDTH_PX}px;
   width: calc(90vw - 40px);
   margin: auto;
   padding: 0 20px;
@@ -69,7 +71,7 @@ const FeatureHighlightsContainer = styled.li`
   padding: 0;
   justify-content: space-evenly;
   gap: 12px 24px;
-  margin: 20px 0;
+  margin: 30px 0 0 0;
 `;
 
 const FeatureHighlightsItem = styled(FlexColumn)`
@@ -258,7 +260,12 @@ export default function LandingPage(props: LandingPageProps): ReactElement {
     mediaQuery.addEventListener("change", () => {
       setAllowMotion(mediaQuery.matches);
     });
-  });
+    return () => {
+      mediaQuery.removeEventListener("change", () => {
+        setAllowMotion(mediaQuery.matches);
+      });
+    };
+  }, []);
 
   return (
     <div style={{ backgroundColor: "var(--color-landingpage-bg)", height: "100%" }}>

--- a/src/landing-page/components/LandingPage/index.tsx
+++ b/src/landing-page/components/LandingPage/index.tsx
@@ -58,6 +58,7 @@ const ContentContainer = styled(FlexColumn)`
   width: calc(90vw - 40px);
   margin: auto;
   padding: 0 20px;
+  gap: 20px;
 `;
 
 const FeatureHighlightsContainer = styled.li`
@@ -67,7 +68,7 @@ const FeatureHighlightsContainer = styled.li`
   grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
   padding: 0;
   justify-content: space-evenly;
-  gap: 10px;
+  gap: 12px 24px;
   margin: 20px 0;
 `;
 
@@ -78,6 +79,7 @@ const FeatureHighlightsItem = styled(FlexColumn)`
 
   & > h3 {
     font-weight: 600;
+    margin: 0;
   }
 `;
 
@@ -227,9 +229,11 @@ export default function LandingPage(props: LandingPageProps): ReactElement {
 
     const loadParams = project.loadParams;
     const loadButton = loadParams ? (
-      <Button type="primary" onClick={() => props.load(loadParams)}>
-        Load<VisuallyHidden> dataset {project.name}</VisuallyHidden>
-      </Button>
+      <div>
+        <Button type="primary" onClick={() => props.load(loadParams)}>
+          Load<VisuallyHidden> dataset {project.name}</VisuallyHidden>
+        </Button>
+      </div>
     ) : null;
 
     // TODO: Break up list of datasets when too long and hide under collapsible section.
@@ -257,7 +261,7 @@ export default function LandingPage(props: LandingPageProps): ReactElement {
   });
 
   return (
-    <div style={{ backgroundColor: "var(--color-landingpage-bg)" }}>
+    <div style={{ backgroundColor: "var(--color-landingpage-bg)", height: "100%" }}>
       {/* <Header>
         <FlexRowAlignCenter $gap={15}>
           <LoadDatasetButton onLoad={onDatasetLoad} currentResourceUrl={""} />
@@ -280,7 +284,6 @@ export default function LandingPage(props: LandingPageProps): ReactElement {
         </BannerTextContainer>
       </Banner>
 
-      <br />
       <ContentContainer $gap={10}>
         <FeatureHighlightsContainer>
           <FeatureHighlightsItem>


### PR DESCRIPTION
Implements styling of the landing page, Pt. II of #188. I expect to maybe have 1-2 more PRs before this issue is fully closed.

*Estimated size: medium, 20 minutes.*

Changes:
- Adds the banner video MP4, which autoplays when loaded.
  - Also added an accessibility feature, where the video playback is disabled if `prefers-reduced-motion` is set to true.
- Adds `Open Sans` via Google fonts. Existing fonts are still included to ensure compatibility with embedded use cases, but will be removed in the future.
- Adds the `StyleProvider` component, which will wrap the `LandingPage` and `App` in the future to provide a central location for CSS variables.
- Implements styling for the landing page.

| Design | Implementation |
| --- | --- | 
| ![image](https://github.com/allen-cell-animated/website-3d-cell-viewer/assets/30200665/657835fb-81c0-4172-82e9-295ea1972e0e) | ![image](https://github.com/allen-cell-animated/website-3d-cell-viewer/assets/30200665/f0d2aeb1-ebc3-4d7b-bb3e-09da146d67d3) |

Thanks for contributing!
