### PR TITLE
feature: Help menu implementation

### DIFF
--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -41,6 +41,9 @@ const ControlTabNames = {
 export default function ControlPanel(props: ControlPanelProps): React.ReactElement {
   const [tab, setTab] = React.useState(ControlTab.Channels);
 
+  const controlPanelContainerRef = React.useRef<HTMLDivElement>(null);
+  const getDropdownContainer = controlPanelContainerRef.current ? () => controlPanelContainerRef.current! : undefined;
+
   const { viewerChannelSettings, showControls, hasImage } = props;
 
   // TODO key is a number, but MenuInfo assumes keys will always be strings
@@ -56,7 +59,7 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
       onClick: makeTurnOnPresetFn,
     };
     return (
-      <Dropdown trigger={["click"]} menu={dropDownMenuProps}>
+      <Dropdown trigger={["click"]} menu={dropDownMenuProps} getPopupContainer={getDropdownContainer}>
         <Button>
           <div style={{ display: "flex", flexDirection: "row", alignItems: "center", gap: "4px" }}>
             Apply palette
@@ -80,7 +83,7 @@ export default function ControlPanel(props: ControlPanelProps): React.ReactEleme
   );
 
   return (
-    <div className="control-panel-col-container">
+    <div className="control-panel-col-container" ref={controlPanelContainerRef}>
       <div className="control-panel-tab-col" style={{ flex: "0 0 50px" }}>
         <Button
           className={"ant-btn-icon-only btn-collapse" + (props.collapsed ? " btn-collapse-collapsed" : "")}

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -110,7 +110,10 @@ const theme = {
       split: palette.white,
     },
     menu: {
-      selectedBg: palette.ltPurple,
+      hoverText: palette.white,
+      hoverBg: palette.ltPurple,
+      selectedText: palette.white,
+      selectedBg: palette.medGrey,
       textPlaceholder: palette.ltPurple,
     },
     tooltip: {
@@ -138,6 +141,8 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
     return css`
       /* Component and color variables. */
       // TODO: Fix inconsistent use of border vs. outline
+      // TODO: Remove variables that aren't used in other CSS files. These should be set directly
+      // from the $theme object to reduce unnecessary variables.
       --color-text-link: ${$theme.colors.text.link};
       --color-text-header: ${$theme.colors.text.header};
       --color-text-section: ${$theme.colors.text.section};
@@ -197,6 +202,9 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
       --color-layout-dividers: ${$theme.colors.layout.dividers};
 
       --color-modal-border: ${$theme.colors.modal.border};
+
+      --color-menu-hover-text: ${$theme.colors.menu.hoverText};
+      --color-menu-selected-text: ${$theme.colors.menu.selectedText};
 
       --color-checkbox-bg: ${$theme.colors.checkbox.bg};
 
@@ -336,6 +344,22 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
   & .ant-modal-content {
     border: 1px solid var(--color-modal-border);
   }
+
+  & .ant-dropdown-menu-item-active {
+    color: var(--color-menu-hover-text);
+  }
+
+  // Remove padding in dropdown menus so items can be flush with the edge
+  & .ant-dropdown-menu,
+  & .ant-select-dropdown {
+    padding: 0;
+    overflow: hidden;
+
+    & .ant-dropdown-menu-item,
+    & .ant-select-item {
+      border-radius: 0;
+    }
+  }
 `;
 
 /**
@@ -358,6 +382,9 @@ export default function StyleProvider(props: PropsWithChildren<{}>): ReactElemen
           colorPrimaryTextHover: theme.colors.text.selectionText,
           fontWeightStrong: 400,
           colorBgElevated: palette.darkGrey,
+          controlItemBgHover: theme.colors.menu.hoverBg,
+          controlItemBgActiveHover: theme.colors.menu.hoverBg,
+          controlItemBgActive: theme.colors.menu.selectedBg,
         },
         components: {
           Button: {
@@ -385,7 +412,8 @@ export default function StyleProvider(props: PropsWithChildren<{}>): ReactElemen
           },
           Radio: {},
           Select: {
-            optionSelectedBg: theme.colors.menu.selectedBg,
+            // optionSelectedBg: theme.colors.menu.selectedBg,
+            // optionActiveBg: theme.colors.menu.hoverBg,
           },
           Tooltip: {
             colorBgSpotlight: theme.colors.tooltip.bg,

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -137,6 +137,7 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
   ${({ $theme }) => {
     return css`
       /* Component and color variables. */
+      // TODO: Fix inconsistent use of border vs. outline
       --color-text-link: ${$theme.colors.text.link};
       --color-text-header: ${$theme.colors.text.header};
       --color-text-section: ${$theme.colors.text.section};
@@ -194,6 +195,8 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
       --color-statusflag-text: ${$theme.colors.statusFlag.text};
 
       --color-layout-dividers: ${$theme.colors.layout.dividers};
+
+      --color-modal-border: ${$theme.colors.modal.border};
 
       --color-checkbox-bg: ${$theme.colors.checkbox.bg};
 
@@ -325,6 +328,13 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
 
   & .ant-checkbox-indeterminate.checked .ant-checkbox-inner {
     background-color: var(--color-checkbox-bg);
+  }
+
+  // Add outlines to modals and dropdowns
+  & .ant-select-dropdown,
+  & .ant-dropdown-menu,
+  & .ant-modal-content {
+    border: 1px solid var(--color-modal-border);
   }
 `;
 

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -345,11 +345,12 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
     border: 1px solid var(--color-modal-border);
   }
 
+  // Force active/hovered text to be white instead of grey for better contrast
   & .ant-dropdown-menu-item-active {
     color: var(--color-menu-hover-text);
   }
 
-  // Remove padding in dropdown menus so items can be flush with the edge
+  // Remove padding in dropdown menus and make items reactangular + flush with the edge
   & .ant-dropdown-menu,
   & .ant-select-dropdown {
     padding: 0;
@@ -409,11 +410,6 @@ export default function StyleProvider(props: PropsWithChildren<{}>): ReactElemen
             colorBgContainer: theme.colors.checkbox.bg,
             colorPrimary: theme.colors.checkbox.bg,
             colorPrimaryHover: theme.colors.checkbox.hoverBg,
-          },
-          Radio: {},
-          Select: {
-            // optionSelectedBg: theme.colors.menu.selectedBg,
-            // optionActiveBg: theme.colors.menu.hoverBg,
           },
           Tooltip: {
             colorBgSpotlight: theme.colors.tooltip.bg,

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -66,6 +66,11 @@ const theme = {
       },
       secondary: {
         bg: "transparent",
+        text: palette.medPurple,
+        outline: palette.medPurple,
+      },
+      tertiary: {
+        bg: "transparent",
         text: palette.ltGrey,
         outline: palette.ltGrey,
         hoverOutline: palette.ltPurple,
@@ -152,15 +157,19 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
 
       --color-button-link-text: ${$theme.colors.button.link.text};
 
-      --color-button-default-bg: transparent;
-      --color-button-default-text: ${$theme.colors.button.secondary.text};
-      --color-button-default-outline: ${$theme.colors.button.secondary.outline};
-      --color-button-default-hover-outline: ${$theme.colors.button.secondary.hoverOutline};
-      --color-button-default-hover-text: ${$theme.colors.button.secondary.hoverText};
-      --color-button-default-active-outline: ${$theme.colors.button.secondary.activeOutline};
-      --color-button-default-active-text: ${$theme.colors.button.secondary.hoverText};
+      --color-button-secondary-bg: ${$theme.colors.button.secondary.bg};
+      --color-button-secondary-text: ${$theme.colors.button.secondary.text};
+      --color-button-secondary-outline: ${$theme.colors.button.secondary.outline};
 
-      --color-button-icon-disabled-text: ${$theme.colors.button.secondary.disabledText};
+      --color-button-tertiary-bg: transparent;
+      --color-button-tertiary-text: ${$theme.colors.button.tertiary.text};
+      --color-button-tertiary-outline: ${$theme.colors.button.tertiary.outline};
+      --color-button-tertiary-hover-outline: ${$theme.colors.button.tertiary.hoverOutline};
+      --color-button-tertiary-hover-text: ${$theme.colors.button.tertiary.hoverText};
+      --color-button-tertiary-active-outline: ${$theme.colors.button.tertiary.activeOutline};
+      --color-button-tertiary-active-text: ${$theme.colors.button.tertiary.hoverText};
+
+      --color-button-icon-disabled-text: ${$theme.colors.button.tertiary.disabledText};
 
       --color-toolbar-button-bg: ${$theme.colors.toolbar.buttonBg};
 
@@ -273,21 +282,21 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
    * purple outline on hover.
    */
   .ant-btn-default:not(.ant-btn-icon-only) {
-    background-color: var(--color-button-default-bg);
-    color: var(--color-button-default-text);
-    border-color: var(--color-button-default-outline);
+    background-color: var(--color-button-tertiary-bg);
+    color: var(--color-button-tertiary-text);
+    border-color: var(--color-button-tertiary-outline);
 
     &:hover:not(:disabled),
     &:focus-visible:not(:disabled) {
       background-color: transparent;
-      border-color: var(--color-button-default-hover-bg);
-      color: var(--color-button-default-hover-text);
+      border-color: var(--color-button-tertiary-hover-bg);
+      color: var(--color-button-tertiary-hover-text);
     }
 
     &:active:not(:disabled) {
       background-color: transparent;
-      border-color: var(--color-button-default-active-outline);
-      color: var(--color-button-default-active-text);
+      border-color: var(--color-button-tertiary-active-outline);
+      color: var(--color-button-tertiary-active-text);
     }
   }
 
@@ -339,7 +348,7 @@ export default function StyleProvider(props: PropsWithChildren<{}>): ReactElemen
             primaryColor: theme.colors.button.primary.text,
             defaultHoverBg: theme.colors.button.secondary.bg,
             defaultActiveBg: theme.colors.button.secondary.bg,
-            defaultActiveBorderColor: theme.colors.button.secondary.activeOutline,
+            defaultActiveBorderColor: theme.colors.button.tertiary.activeOutline,
           },
           Card: {
             borderRadiusLG: 0,

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -46,6 +46,7 @@ interface ToolbarState {
 const RESIZE_DEBOUNCE_DELAY = 50;
 
 export default class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
+  containerRef: React.RefObject<HTMLDivElement>;
   barRef: React.RefObject<HTMLDivElement>;
   leftRef: React.RefObject<HTMLDivElement>;
   rightRef: React.RefObject<HTMLDivElement>;
@@ -58,6 +59,7 @@ export default class Toolbar extends React.Component<ToolbarProps, ToolbarState>
       scrollBtnLeft: false,
       scrollBtnRight: false,
     };
+    this.containerRef = React.createRef();
     this.barRef = React.createRef();
     this.leftRef = React.createRef();
     this.rightRef = React.createRef();
@@ -140,8 +142,10 @@ export default class Toolbar extends React.Component<ToolbarProps, ToolbarState>
     const boundingBoxToggleTitle = showBoundingBox ? "Hide bounding box" : "Show bounding box";
     const turntableToggleTitle = autorotate ? "Turn off turntable" : "Turn on turntable";
 
+    const getPopupContainer = this.containerRef.current ? () => this.containerRef.current! : undefined;
+
     return (
-      <div className={`viewer-toolbar-container${scrollMode ? " viewer-toolbar-scroll" : ""}`}>
+      <div className={`viewer-toolbar-container${scrollMode ? " viewer-toolbar-scroll" : ""}`} ref={this.containerRef}>
         <div
           className="viewer-toolbar-scroll-left"
           style={{ display: scrollBtnLeft ? "flex" : "none" }}
@@ -204,6 +208,7 @@ export default class Toolbar extends React.Component<ToolbarProps, ToolbarState>
                 popupClassName="viewer-toolbar-dropdown"
                 value={props.renderMode}
                 onChange={(value) => changeViewerSetting("renderMode", value)}
+                getPopupContainer={getPopupContainer}
               >
                 <Select.Option value={RenderMode.volumetric} key={RenderMode.volumetric}>
                   Volumetric

--- a/website/components/AppWrapper.tsx
+++ b/website/components/AppWrapper.tsx
@@ -6,11 +6,11 @@ import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { FlexRowAlignCenter } from "./LandingPage/utils";
 import LoadModal from "./LoadModal";
 import Header, { HEADER_HEIGHT_PX } from "./Header";
+import HelpDropdown from "./HelpDropdown";
 import { ImageViewerApp, RenderMode, ViewMode } from "../../src";
 import { GlobalViewerSettings } from "../../src/aics-image-viewer/components/App/types";
 import { AppDataProps } from "../types";
 import { getArgsFromParams } from "../utils/url_utils";
-import HelpDropdown from "./HelpDropdown";
 
 type AppWrapperProps = {
   viewerSettings?: Partial<GlobalViewerSettings>;

--- a/website/components/AppWrapper.tsx
+++ b/website/components/AppWrapper.tsx
@@ -10,6 +10,7 @@ import { ImageViewerApp, RenderMode, ViewMode } from "../../src";
 import { GlobalViewerSettings } from "../../src/aics-image-viewer/components/App/types";
 import { AppDataProps } from "../types";
 import { getArgsFromParams } from "../utils/url_utils";
+import HelpDropdown from "./HelpDropdown";
 
 type AppWrapperProps = {
   viewerSettings?: Partial<GlobalViewerSettings>;
@@ -116,7 +117,7 @@ export default function AppWrapper(inputProps: AppWrapperProps): ReactElement {
               Share
             </Button>
           </FlexRowAlignCenter>
-          {/* <HelpDropdown /> */}
+          <HelpDropdown />
         </FlexRowAlignCenter>
       </Header>
       <ImageViewerApp

--- a/website/components/Buttons/index.tsx
+++ b/website/components/Buttons/index.tsx
@@ -2,14 +2,19 @@ import { Button } from "antd";
 import React from "react";
 import styled from "styled-components";
 
+// TODO: Make exports here for primary/tertiary buttons to abstract away
+// Ant button styling.
+
 // Enforce the primary type for behavior on hover.
 const PrimaryButton = React.forwardRef<HTMLButtonElement>((props, ref) => (
   <Button {...props} ref={ref} type="primary">
     {props.children}
   </Button>
 ));
-PrimaryButton.displayName = "PrimaryButton"; // Used for debugging in React
+// Used for debugging in React. Eslint complains if not set.
+PrimaryButton.displayName = "PrimaryButton";
 
+// Secondary button is outlined but turns solid on hover (uses primary button behavior).
 export const SecondaryButton = styled(PrimaryButton)`
   &&& {
     background-color: var(--color-button-secondary-bg);

--- a/website/components/Buttons/index.tsx
+++ b/website/components/Buttons/index.tsx
@@ -1,0 +1,18 @@
+import { Button } from "antd";
+import React from "react";
+import styled from "styled-components";
+
+// Enforce the primary type for behavior on hover.
+const PrimaryButton = React.forwardRef<HTMLButtonElement>((props, ref) => (
+  <Button {...props} ref={ref} type="primary">
+    {props.children}
+  </Button>
+));
+
+export const SecondaryButton = styled(PrimaryButton)`
+  &&& {
+    background-color: var(--color-button-secondary-bg);
+    border: 1px solid var(--color-button-secondary-outline);
+    color: var(--color-button-secondary-text);
+  }
+` as typeof Button;

--- a/website/components/Buttons/index.tsx
+++ b/website/components/Buttons/index.tsx
@@ -8,6 +8,7 @@ const PrimaryButton = React.forwardRef<HTMLButtonElement>((props, ref) => (
     {props.children}
   </Button>
 ));
+PrimaryButton.displayName = "PrimaryButton"; // Used for debugging in React
 
 export const SecondaryButton = styled(PrimaryButton)`
   &&& {

--- a/website/components/HelpDropdown.tsx
+++ b/website/components/HelpDropdown.tsx
@@ -2,10 +2,11 @@ import { Button, Dropdown, MenuProps, Modal } from "antd";
 import React, { ReactElement, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
-import { FlexColumnAlignCenter, FlexRowAlignCenter } from "./LandingPage/utils";
-import { SecondaryButton } from "./Buttons";
 import { DropdownSVG } from "../assets/icons";
+import { SecondaryButton } from "./Buttons";
+import { FlexColumnAlignCenter, FlexRowAlignCenter } from "./LandingPage/utils";
 
+// Defined in webpack config
 declare const WEBSITE3DCELLVIEWER_VERSION: string;
 declare const VOLUMEVIEWER_VERSION: string;
 
@@ -57,11 +58,12 @@ export default function HelpDropdown(): ReactElement {
     },
   ];
 
-  const getContainer = container !== null ? () => container! : undefined;
-
+  // Use state update here to force a re-render so Dropdown is rendered with a valid `getContainer` callback.
+  // Otherwise, the `getContainer` callback will be undefined on the first render.
   useEffect(() => {
     setContainer(containerRef.current);
   }, [containerRef.current]);
+  const getContainer = container !== null ? () => container! : undefined;
 
   return (
     <div ref={containerRef}>

--- a/website/components/HelpDropdown.tsx
+++ b/website/components/HelpDropdown.tsx
@@ -1,0 +1,90 @@
+import { Button, Dropdown, MenuProps, Modal } from "antd";
+import React, { ReactElement, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { FlexColumnAlignCenter } from "./LandingPage/utils";
+
+export default function HelpDropdown(): ReactElement {
+  const [container, setContainer] = useState<HTMLDivElement | null>();
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  const [showVersionModal, setShowVersionModal] = useState(false);
+
+  const items: MenuProps["items"] = [
+    {
+      key: "github",
+      label: (
+        <Link
+          to="https://github.com/allen-cell-animated/website-3d-cell-viewer"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          Visit GitHub repository
+        </Link>
+      ),
+    },
+    {
+      key: "github-issue",
+      label: (
+        <Link
+          to="https://github.com/allen-cell-animated/website-3d-cell-viewer/issues/new/choose"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          Report issue via GitHub
+        </Link>
+      ),
+    },
+    {
+      key: "forum",
+      label: (
+        <Link to="https://forum.allencell.org/c/software-code/11" target="_blank" rel="noreferrer noopener">
+          Allen Cell Discussion Forum
+        </Link>
+      ),
+    },
+    {
+      key: "version",
+      label: "Version info",
+      onClick: () => {
+        setShowVersionModal(true);
+      },
+    },
+  ];
+
+  const getContainer = container !== null ? () => container! : undefined;
+
+  useEffect(() => {
+    setContainer(containerRef.current);
+  }, [containerRef.current]);
+
+  return (
+    <div ref={containerRef}>
+      <Dropdown menu={{ items: items }} getPopupContainer={getContainer}>
+        <Button>Help</Button>
+      </Dropdown>
+      <Modal
+        open={showVersionModal}
+        title="Version info"
+        onCancel={() => {
+          setShowVersionModal(false);
+        }}
+        footer={() => {
+          return (
+            <Button
+              onClick={() => {
+                setShowVersionModal(false);
+              }}
+            >
+              Close
+            </Button>
+          );
+        }}
+      >
+        <FlexColumnAlignCenter $gap={0}>
+          <p>3D Volume Viewer v{WEBSITE3DCELLVIEWER_VERSION}</p>
+          <p>Volume Viewer v{VOLUMEVIEWER_VERSION}</p>
+        </FlexColumnAlignCenter>
+      </Modal>
+    </div>
+  );
+}

--- a/website/components/HelpDropdown.tsx
+++ b/website/components/HelpDropdown.tsx
@@ -78,20 +78,8 @@ export default function HelpDropdown(): ReactElement {
         open={showVersionModal}
         title="Version info"
         getContainer={getContainer}
-        onCancel={() => {
-          setShowVersionModal(false);
-        }}
-        footer={() => {
-          return (
-            <Button
-              onClick={() => {
-                setShowVersionModal(false);
-              }}
-            >
-              Close
-            </Button>
-          );
-        }}
+        onCancel={() => setShowVersionModal(false)}
+        footer={<Button onClick={() => setShowVersionModal(false)}>Close</Button>}
       >
         <FlexColumnAlignCenter $gap={0}>
           <p style={{ margin: 0 }}>Website v{WEBSITE3DCELLVIEWER_VERSION}</p>

--- a/website/components/HelpDropdown.tsx
+++ b/website/components/HelpDropdown.tsx
@@ -2,8 +2,9 @@ import { Button, Dropdown, MenuProps, Modal } from "antd";
 import React, { ReactElement, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
-import { FlexColumnAlignCenter } from "./LandingPage/utils";
+import { FlexColumnAlignCenter, FlexRowAlignCenter } from "./LandingPage/utils";
 import { SecondaryButton } from "./Buttons";
+import { DropdownSVG } from "../assets/icons";
 
 export default function HelpDropdown(): ReactElement {
   const [container, setContainer] = useState<HTMLDivElement | null>();
@@ -61,8 +62,12 @@ export default function HelpDropdown(): ReactElement {
 
   return (
     <div ref={containerRef}>
-      <Dropdown menu={{ items: items }} getPopupContainer={getContainer}>
-        <SecondaryButton>Help</SecondaryButton>
+      <Dropdown menu={{ items: items }} getPopupContainer={getContainer} trigger={["click", "hover"]}>
+        <SecondaryButton>
+          <FlexRowAlignCenter $gap={6}>
+            Help <DropdownSVG />
+          </FlexRowAlignCenter>
+        </SecondaryButton>
       </Dropdown>
       <Modal
         open={showVersionModal}

--- a/website/components/HelpDropdown.tsx
+++ b/website/components/HelpDropdown.tsx
@@ -62,7 +62,7 @@ export default function HelpDropdown(): ReactElement {
 
   return (
     <div ref={containerRef}>
-      <Dropdown menu={{ items: items }} getPopupContainer={getContainer} trigger={["click", "hover"]}>
+      <Dropdown menu={{ items: items }} getPopupContainer={getContainer} trigger={["click"]}>
         <SecondaryButton>
           <FlexRowAlignCenter $gap={6}>
             Help <DropdownSVG />

--- a/website/components/HelpDropdown.tsx
+++ b/website/components/HelpDropdown.tsx
@@ -65,6 +65,8 @@ export default function HelpDropdown(): ReactElement {
   }, [containerRef.current]);
   const getContainer = container !== null ? () => container! : undefined;
 
+  const closeVersionModal = () => setShowVersionModal(false);
+
   return (
     <div ref={containerRef}>
       <Dropdown menu={{ items: items }} getPopupContainer={getContainer} trigger={["click"]}>
@@ -79,7 +81,7 @@ export default function HelpDropdown(): ReactElement {
         title="Version info"
         getContainer={getContainer}
         onCancel={() => setShowVersionModal(false)}
-        footer={<Button onClick={() => setShowVersionModal(false)}>Close</Button>}
+        footer={<Button onClick={closeVersionModal}>Close</Button>}
       >
         <FlexColumnAlignCenter $gap={0}>
           <p style={{ margin: 0 }}>Website v{WEBSITE3DCELLVIEWER_VERSION}</p>

--- a/website/components/HelpDropdown.tsx
+++ b/website/components/HelpDropdown.tsx
@@ -1,7 +1,9 @@
 import { Button, Dropdown, MenuProps, Modal } from "antd";
 import React, { ReactElement, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+
 import { FlexColumnAlignCenter } from "./LandingPage/utils";
+import { SecondaryButton } from "./Buttons";
 
 export default function HelpDropdown(): ReactElement {
   const [container, setContainer] = useState<HTMLDivElement | null>();
@@ -60,7 +62,7 @@ export default function HelpDropdown(): ReactElement {
   return (
     <div ref={containerRef}>
       <Dropdown menu={{ items: items }} getPopupContainer={getContainer}>
-        <Button>Help</Button>
+        <SecondaryButton>Help</SecondaryButton>
       </Dropdown>
       <Modal
         open={showVersionModal}

--- a/website/components/HelpDropdown.tsx
+++ b/website/components/HelpDropdown.tsx
@@ -75,6 +75,7 @@ export default function HelpDropdown(): ReactElement {
       <Modal
         open={showVersionModal}
         title="Version info"
+        getContainer={getContainer}
         onCancel={() => {
           setShowVersionModal(false);
         }}

--- a/website/components/HelpDropdown.tsx
+++ b/website/components/HelpDropdown.tsx
@@ -65,7 +65,7 @@ export default function HelpDropdown(): ReactElement {
   }, [containerRef.current]);
   const getContainer = container !== null ? () => container! : undefined;
 
-  const closeVersionModal = () => setShowVersionModal(false);
+  const closeVersionModal = (): void => setShowVersionModal(false);
 
   return (
     <div ref={containerRef}>

--- a/website/components/HelpDropdown.tsx
+++ b/website/components/HelpDropdown.tsx
@@ -6,6 +6,9 @@ import { FlexColumnAlignCenter, FlexRowAlignCenter } from "./LandingPage/utils";
 import { SecondaryButton } from "./Buttons";
 import { DropdownSVG } from "../assets/icons";
 
+declare const WEBSITE3DCELLVIEWER_VERSION: string;
+declare const VOLUMEVIEWER_VERSION: string;
+
 export default function HelpDropdown(): ReactElement {
   const [container, setContainer] = useState<HTMLDivElement | null>();
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -88,8 +91,8 @@ export default function HelpDropdown(): ReactElement {
         }}
       >
         <FlexColumnAlignCenter $gap={0}>
-          <p>3D Volume Viewer v{WEBSITE3DCELLVIEWER_VERSION}</p>
-          <p>Volume Viewer v{VOLUMEVIEWER_VERSION}</p>
+          <p style={{ margin: 0 }}>Website v{WEBSITE3DCELLVIEWER_VERSION}</p>
+          <p style={{ margin: 0 }}>Volume viewer plugin v{VOLUMEVIEWER_VERSION}</p>
         </FlexColumnAlignCenter>
       </Modal>
     </div>

--- a/website/components/LandingPage/index.tsx
+++ b/website/components/LandingPage/index.tsx
@@ -13,6 +13,7 @@ import LoadModal from "../LoadModal";
 import { AppDataProps, DatasetEntry, ProjectEntry } from "../../types";
 import { FlexColumnAlignCenter, FlexColumn, FlexRowAlignCenter, VisuallyHidden, FlexRow } from "./utils";
 import { getArgsFromParams } from "../../utils/url_utils";
+import HelpDropdown from "../HelpDropdown";
 
 const MAX_CONTENT_WIDTH_PX = 1060;
 
@@ -321,7 +322,7 @@ export default function LandingPage(): ReactElement {
               Share
             </Button>
           </FlexRowAlignCenter>
-          {/* <HelpDropdown /> */}
+          <HelpDropdown />
         </FlexRowAlignCenter>
       </Header>
       <Banner>


### PR DESCRIPTION
Closes #220, implementing the help menu in the top header bar.

*Estimated size: small-medium, 20 minutes*

## Changes
- Edits CSS variables to reflect the primary/secondary/tertiary styling defined in the the original UX Figma file.
- Adds a `SecondaryButton` styled component. (purple outline that goes to full highlight color when hovered)
- Adds outline to the modals and dropdowns and adjusts content styling.
  - Adds the `getContainer` or `getPopupContainer` to all the places we are using dropdowns to ensure styling is applied.
- Adds the `HelpDropdown` component, containing a menu of buttons and links.

## Screenshots

![image](https://github.com/allen-cell-animated/website-3d-cell-viewer/assets/30200665/4c7f93ee-0f06-414f-9af7-b7ab65128a17)

**Video walkthrough (🔊):**

https://github.com/allen-cell-animated/website-3d-cell-viewer/assets/30200665/40809ec8-a282-493b-8c04-ab0933d130e3

