### PR TITLE
Fix sliders not updating during playback.

### DIFF
--- a/src/aics-image-viewer/components/shared/SmarterSlider.tsx
+++ b/src/aics-image-viewer/components/shared/SmarterSlider.tsx
@@ -4,23 +4,23 @@ import Nouislider, { NouisliderProps } from "nouislider-react";
 type CallbackArgs = Parameters<NonNullable<NouisliderProps["onStart"]>>;
 
 const MemoedNouislider = React.memo(
-  Nouislider as React.ComponentType<NouisliderProps & { shouldUpdate: boolean }>,
-  ({ shouldUpdate }) => shouldUpdate
+  Nouislider as React.ComponentType<NouisliderProps & { noUpdate: boolean }>,
+  ({ noUpdate }) => noUpdate
 );
 
 /** A wrapper around `Nouislider` that prevents updates while the slider is being dragged. */
 const SmarterSlider: React.FC<NouisliderProps> = (props) => {
-  const [shouldUpdate, setShouldUpdate] = React.useState(true);
+  const [noUpdate, setNoUpdate] = React.useState(false);
   const wrapEventHandler = (shouldUpdate: boolean, handler?: (...args: CallbackArgs) => void) => {
     return (...args: CallbackArgs) => {
-      setShouldUpdate(shouldUpdate);
+      setNoUpdate(shouldUpdate);
       if (handler) handler(...args);
     };
   };
 
-  const onStart = wrapEventHandler(false, props.onStart);
-  const onEnd = wrapEventHandler(true, props.onEnd);
-  return <MemoedNouislider {...{ ...props, shouldUpdate, onStart, onEnd }} />;
+  const onStart = wrapEventHandler(true, props.onStart);
+  const onEnd = wrapEventHandler(false, props.onEnd);
+  return <MemoedNouislider {...{ ...props, noUpdate, onStart, onEnd }} />;
 };
 
 export default SmarterSlider;


### PR DESCRIPTION
Review time: tiny (<5min)

Resolves #264: sliders update correctly on playback again.

`SmarterSlider` is a utility component which wraps the (old) React wrapper around nouislider that we use, preventing it from updating while the slider is sliding. This was done to fix a performance issue (which I was unable to replicate?).

In #256, I converted `SmarterSlider` to a function component, which meant moving from the class component way to prevent updates (`shouldComponentUpdate`) to the function component one (`React.memo`). But I missed when I did this that the function passed to `React.memo` has the opposite expectation of `shouldComponentUpdate`: it should return `true` when the component should _skip_ rendering. So I flipped some booleans around and renamed a couple variables and this component seems to be working as normal again.