### PR TITLE
fix: Decreased example nucmorph dataset density

### DIFF
--- a/website/components/LandingPage/content.tsx
+++ b/website/components/LandingPage/content.tsx
@@ -20,6 +20,7 @@ const nucmorphBaseViewerSettings: Partial<AppDataProps> = {
   },
   viewerSettings: {
     viewMode: ViewMode.xy,
+    density: 2.5,
   },
 };
 


### PR DESCRIPTION
Fixes a bug where the starting density made it impossible to actually see the cells. 

*Estimated review size: tiny, 1 minute*

Before:
![image](https://github.com/allen-cell-animated/website-3d-cell-viewer/assets/30200665/f091f188-060f-4590-a091-4d2c2c2cf8ae)

After:
![image](https://github.com/allen-cell-animated/website-3d-cell-viewer/assets/30200665/56b7b648-3111-4b07-9942-819234d055e0)
