### PR TITLE
Use reducers for viewer state

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -157,6 +157,32 @@ const axisToLoaderPriority: Record<AxisName | "t", PrefetchDirection> = {
   x: PrefetchDirection.X_PLUS,
 };
 
+const initializeOneChannelSetting = (
+  channel: string,
+  index: number,
+  defaultColor: ColorArray,
+  viewerChannelSettings?: ViewerChannelSettings,
+  defaultChannelState = DEFAULT_CHANNEL_STATE
+): ChannelState => {
+  let initSettings = {} as Partial<ViewerChannelSetting>;
+  if (viewerChannelSettings) {
+    // search for channel in settings using groups, names and match values
+    initSettings = findFirstChannelMatch(channel, index, viewerChannelSettings) ?? {};
+  }
+
+  return {
+    name: initSettings.name ?? channel ?? "Channel " + index,
+    volumeEnabled: initSettings.enabled ?? defaultChannelState.volumeEnabled,
+    isosurfaceEnabled: initSettings.surfaceEnabled ?? defaultChannelState.isosurfaceEnabled,
+    colorizeEnabled: initSettings.colorizeEnabled ?? defaultChannelState.colorizeEnabled,
+    colorizeAlpha: initSettings.colorizeAlpha ?? defaultChannelState.colorizeAlpha,
+    isovalue: initSettings.isovalue ?? defaultChannelState.isovalue,
+    opacity: initSettings.surfaceOpacity ?? defaultChannelState.opacity,
+    color: colorHexToArray(initSettings.color ?? "") ?? defaultColor,
+    controlPoints: defaultChannelState.controlPoints,
+  };
+};
+
 const setIndicatorPositions = (view3d: View3d, panelOpen: boolean, hasTime: boolean): void => {
   const CLIPPING_PANEL_HEIGHT = 150;
   // Move scale bars this far to the left when showing time series, to make room for timestep indicator
@@ -291,33 +317,6 @@ const App: React.FC<AppProps> = (props) => {
       initialLoadRef.current = false;
       playControls.onImageLoaded();
     }
-  };
-
-  // TODO: Refactor this out of App index?
-  const initializeOneChannelSetting = (
-    channel: string,
-    index: number,
-    defaultColor: ColorArray,
-    viewerChannelSettings?: ViewerChannelSettings,
-    defaultChannelState = DEFAULT_CHANNEL_STATE
-  ): ChannelState => {
-    let initSettings = {} as Partial<ViewerChannelSetting>;
-    if (viewerChannelSettings) {
-      // search for channel in settings using groups, names and match values
-      initSettings = findFirstChannelMatch(channel, index, viewerChannelSettings) ?? {};
-    }
-
-    return {
-      name: initSettings.name ?? channel ?? "Channel " + index,
-      volumeEnabled: initSettings.enabled ?? defaultChannelState.volumeEnabled,
-      isosurfaceEnabled: initSettings.surfaceEnabled ?? defaultChannelState.isosurfaceEnabled,
-      colorizeEnabled: initSettings.colorizeEnabled ?? defaultChannelState.colorizeEnabled,
-      colorizeAlpha: initSettings.colorizeAlpha ?? defaultChannelState.colorizeAlpha,
-      isovalue: initSettings.isovalue ?? defaultChannelState.isovalue,
-      opacity: initSettings.surfaceOpacity ?? defaultChannelState.opacity,
-      color: colorHexToArray(initSettings.color ?? "") ?? defaultColor,
-      controlPoints: defaultChannelState.controlPoints,
-    };
   };
 
   const setChannelStateForNewImage = (channelNames: string[]): ChannelState[] | undefined => {

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -295,16 +295,12 @@ const App: React.FC<AppProps> = (props) => {
 
   // TODO: Refactor this out of App index?
   const initializeOneChannelSetting = (
-    aimg: Volume | null,
     channel: string,
     index: number,
     defaultColor: ColorArray,
     viewerChannelSettings?: ViewerChannelSettings,
     defaultChannelState = DEFAULT_CHANNEL_STATE
   ): ChannelState => {
-    // note that this modifies aimg also
-    const newControlPoints = aimg ? initializeLut(aimg, index) : undefined;
-
     let initSettings = {} as Partial<ViewerChannelSetting>;
     if (viewerChannelSettings) {
       // search for channel in settings using groups, names and match values
@@ -320,7 +316,7 @@ const App: React.FC<AppProps> = (props) => {
       isovalue: initSettings.isovalue ?? defaultChannelState.isovalue,
       opacity: initSettings.surfaceOpacity ?? defaultChannelState.opacity,
       color: colorHexToArray(initSettings.color ?? "") ?? defaultColor,
-      controlPoints: newControlPoints ?? defaultChannelState.controlPoints,
+      controlPoints: defaultChannelState.controlPoints,
     };
   };
 
@@ -335,7 +331,7 @@ const App: React.FC<AppProps> = (props) => {
 
     const newChannelSettings = channelNames.map((channel, index) => {
       const color = (INIT_COLORS[index] ? INIT_COLORS[index].slice() : [226, 205, 179]) as ColorArray;
-      return initializeOneChannelSetting(null, channel, index, color, props.viewerChannelSettings);
+      return initializeOneChannelSetting(channel, index, color, props.viewerChannelSettings);
     });
     setChannelSettings(newChannelSettings);
     return newChannelSettings;

--- a/src/aics-image-viewer/components/ChannelsWidget.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidget.tsx
@@ -11,12 +11,7 @@ import type { IsosurfaceFormat } from "../shared/types";
 import ChannelsWidgetRow from "./ChannelsWidgetRow";
 import SharedCheckBox from "./shared/SharedCheckBox";
 import { connectToViewerState } from "./ViewerStateProvider";
-import type {
-  ChannelSettingUpdater,
-  ChannelState,
-  ChannelStateKey,
-  MultipleChannelSettingsUpdater,
-} from "./ViewerStateProvider/types";
+import type { ChannelSettingUpdater, ChannelState, ChannelStateKey } from "./ViewerStateProvider/types";
 
 export type ChannelsWidgetProps = {
   // From parent
@@ -33,14 +28,13 @@ export type ChannelsWidgetProps = {
   // From viewer state
   channelSettings: ChannelState[];
   changeChannelSetting: ChannelSettingUpdater;
-  changeMultipleChannelSettings: MultipleChannelSettingsUpdater;
 };
 
 const ChannelsWidget: React.FC<ChannelsWidgetProps> = (props: ChannelsWidgetProps) => {
   const { channelGroupedByType, channelSettings, channelDataChannels, filterFunc, viewerChannelSettings } = props;
 
   const createCheckboxHandler = (key: ChannelStateKey, value: boolean) => (channelArray: number[]) => {
-    props.changeMultipleChannelSettings(channelArray, key, value);
+    props.changeChannelSetting(channelArray, key, value);
   };
 
   const showVolumes = createCheckboxHandler("volumeEnabled", true);
@@ -133,8 +127,4 @@ const ChannelsWidget: React.FC<ChannelsWidgetProps> = (props: ChannelsWidgetProp
   return <Collapse bordered={false} defaultActiveKey={firstKey} items={rows} collapsible="icon" />;
 };
 
-export default connectToViewerState(ChannelsWidget, [
-  "channelSettings",
-  "changeChannelSetting",
-  "changeMultipleChannelSettings",
-]);
+export default connectToViewerState(ChannelsWidget, ["channelSettings", "changeChannelSetting"]);

--- a/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
+++ b/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
@@ -170,10 +170,9 @@ const ViewerStateProvider: React.FC<{ viewerSettings?: Partial<ViewerState> }> =
   // infinite render loop, so now it's in a `useMemo`:
   // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
   useMemo(() => {
-    let newSettings = { ...viewerSettings };
     if (props.viewerSettings) {
       for (const key of Object.keys(props.viewerSettings) as (keyof ViewerState)[]) {
-        if (newSettings[key] !== props.viewerSettings[key]) {
+        if (viewerSettings[key] !== props.viewerSettings[key]) {
           changeViewerSetting(key, props.viewerSettings[key] as any);
         }
       }

--- a/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
+++ b/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
@@ -98,14 +98,16 @@ const viewerSettingsReducer = <K extends keyof ViewerState>(
 
 type ChannelStateAction<K extends keyof ChannelState> =
   | {
+      // Update a single setting for one channel, or uniformly for multiple channels
       index: number | number[];
       key: K;
-      value: PartialIfObject<ChannelState[K]>;
+      value: ChannelState[K];
     }
   | {
+      // Update a single setting for all channels from an ordered array of values
       index?: undefined;
       key: K;
-      value: PartialIfObject<ChannelState[K]>[];
+      value: ChannelState[K][];
     };
 
 const channelSettingsReducer = <K extends keyof ChannelState>(

--- a/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
+++ b/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
@@ -137,7 +137,9 @@ const channelSettingsReducer = <K extends keyof ChannelState>(
   } else {
     // ChannelSettingUniformUpdateAction on a single channel
     const newSettings = channelSettings.slice();
-    newSettings[index] = { ...newSettings[index], [key]: value };
+    if (index >= 0 && index < channelSettings.length) {
+      newSettings[index] = { ...newSettings[index], [key]: value };
+    }
     return newSettings;
   }
 };

--- a/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
+++ b/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
@@ -74,7 +74,6 @@ type ViewerStateAction<K extends keyof ViewerState> = {
   value: PartialIfObject<ViewerState[K]>;
 };
 
-/** Changes a key in a given `ViewerState` object, keeping the object in a valid state and applying partial values */
 const viewerSettingsReducer = <K extends keyof ViewerState>(
   viewerSettings: ViewerState,
   { key, value }: ViewerStateAction<K>

--- a/src/aics-image-viewer/components/ViewerStateProvider/types.ts
+++ b/src/aics-image-viewer/components/ViewerStateProvider/types.ts
@@ -66,9 +66,8 @@ export interface ChannelState {
 }
 
 export type ChannelStateKey = keyof ChannelState;
-export type ChannelSettingUpdater = <K extends ChannelStateKey>(index: number, key: K, value: ChannelState[K]) => void;
-export type MultipleChannelSettingsUpdater = <K extends ChannelStateKey>(
-  indices: number[],
+export type ChannelSettingUpdater = <K extends ChannelStateKey>(
+  index: number | number[],
   key: K,
   value: ChannelState[K]
 ) => void;
@@ -78,6 +77,5 @@ export type ViewerStateContextType = ViewerState & {
   changeViewerSetting: ViewerSettingUpdater;
   setChannelSettings: React.Dispatch<React.SetStateAction<ChannelState[]>>;
   changeChannelSetting: ChannelSettingUpdater;
-  changeMultipleChannelSettings: MultipleChannelSettingsUpdater;
   applyColorPresets: (presets: ColorArray[]) => void;
 };

--- a/src/aics-image-viewer/components/ViewerStateProvider/types.ts
+++ b/src/aics-image-viewer/components/ViewerStateProvider/types.ts
@@ -75,7 +75,7 @@ export type ChannelSettingUpdater = <K extends ChannelStateKey>(
 export type ViewerStateContextType = ViewerState & {
   channelSettings: ChannelState[];
   changeViewerSetting: ViewerSettingUpdater;
-  setChannelSettings: React.Dispatch<React.SetStateAction<ChannelState[]>>;
   changeChannelSetting: ChannelSettingUpdater;
+  setChannelSettings: (settings: ChannelState[]) => void;
   applyColorPresets: (presets: ColorArray[]) => void;
 };


### PR DESCRIPTION
Review time: small (10-15min)

## Problem

Currently, if we try to update multiple viewer or channel settings synchronously, only the last update will be applied:

```typescript
changeViewerSetting("maskAlpha", 0.5); // overwritten by next update
changeViewerSetting("autorotate", true); // only this update is applied
```

This is due to the fact that setters like `changeViewerSetting` produce a new value for `viewerSettings` by pulling and updating the current value in state. But since that state value only gets updated on every render, multiple synchronous updates will end up pulling and modifying the same stale state value. So e.g. above, the first call produces a new value for `viewerSettings` by copying the current value and updating `maskAlpha`, then the second call pulls the same value from _before the `maskAlpha` update_ and ends up overwriting that pending update!

## Solution

`useReducer` solves this problem. Rather than pulling and updating state ourselves, `useReducer` lets us define a function which accepts the current state and an action to perform and returns a modified state value. Since the current state value gets passed in from within the bowels of React rather than from the static state value React provides us for a single render, multiple updates can be applied successfully between renders.