### PR TITLE
fix `SmarterSlider` memo function

### DIFF
--- a/src/aics-image-viewer/components/shared/SmarterSlider.tsx
+++ b/src/aics-image-viewer/components/shared/SmarterSlider.tsx
@@ -5,7 +5,7 @@ type CallbackArgs = Parameters<NonNullable<NouisliderProps["onStart"]>>;
 
 const MemoedNouislider = React.memo(
   Nouislider as React.ComponentType<NouisliderProps & { noUpdate: boolean }>,
-  ({ noUpdate }) => noUpdate
+  (_prevProps, { noUpdate }) => noUpdate
 );
 
 /** A wrapper around `Nouislider` that prevents updates while the slider is being dragged. */


### PR DESCRIPTION
Review time: tiny <1min (+ a few minutes for this longish description)

Resolves #280: time slider can get into "stuck" condition: after the user has interacted with the slider manually, it no longer updates while playing through time series.

This was caused by a dumb mistake I made while converting the `SmarterSlider` component to a function component.

## Why we even need `SmarterSlider`

`SmarterSlider` is a very thin wrapper around the `Nouislider` React component, which is itself a smallish wrapper around the nouislider library. `SmarterSlider` adds a `React.memo` around `Nouislider` to skip rendering under certain conditions, but `Nouislider` [already has a `memo`](https://github.com/mmarkelov/react-nouislider/blob/d567861674ac2ab76a78d307c09932a5aeb99433/src/index.js#L273). What's going on?

One of the changes that can cause that inner `memo` to allow a re-render is a change in the `start` prop, which ostensibly sets the "initial value" of the slider handles. However, it's also the only way to externally change the value of an already mounted slider for some reason other than user interaction. We need to change the slider value during playback, so we treat the slider as a "fully controlled component:" keeping its current value in our own state, and passing that state in as the `start` prop.

But that state also gets changed and passed back in while the user is dragging the slider, causing `Nouislider` to re-render a bunch. This creates terrible, choppy performance, presumably because re-rendering `Nouislider` means imperatively destroying the slider and re-creating it in the underlying nouislider library via vanilla DOM manipulations. Since that nouislider library is perfectly capable of handling user interactions on its own, my workaround was to create `SmarterSlider` to optimize this fully-controlled case by `memo`ing `Nouislider` and avoiding renders whenever the slider is actively being dragged.

## So where did I mess it up?

`React.memo` accepts a function to ostensibly determine whether props are equal and rendering can be skipped. In `SmarterSlider`, this just returns whether the slider is currently being dragged. But I accidentally read this value out of the _previous_ props (the first argument) rather than the _current_ props (the second argument). Therefore, once the last rendered value of `noUpdate` was `true` and rendering was skipped the first time, the last rendered value of `noUpdate` was `true` forever and rendering was skipped forever. Replacing this first argument with a dummy arg solves the issue.