### PR TITLE
fix: 3DVV landing page layout

### DIFF
--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -99,6 +99,7 @@ const theme = {
     },
     landingPage: {
       bg: palette.veryDarkGrey,
+      bgAlt: palette.darkGrey,
       text: palette.ltGrey,
       bannerBg: "#020202DB",
     },
@@ -197,6 +198,7 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
       --color-controlpanel-drawer-bg: ${$theme.colors.controlPanel.drawerBg};
 
       --color-landingpage-bg: ${$theme.colors.landingPage.bg};
+      --color-landingpage-bg-alt: ${$theme.colors.landingPage.bgAlt};
       --color-landingpage-text: ${$theme.colors.landingPage.text};
       --color-landingpage-banner-highlight-bg: ${$theme.colors.landingPage.bannerBg};
 

--- a/website/components/LandingPage/index.tsx
+++ b/website/components/LandingPage/index.tsx
@@ -101,6 +101,7 @@ const FeatureHighlightsItem = styled(FlexColumn)`
   display: grid;
   grid-template-rows: subgrid;
   grid-row: span 2;
+  margin-bottom: 20px;
 
   & > h3 {
     font-weight: 600;
@@ -108,13 +109,13 @@ const FeatureHighlightsItem = styled(FlexColumn)`
   }
 
   & > p {
-    margin: 0 0 20px 0;
+    margin: 0;
   }
 `;
 
 const LoadPromptContainer = styled(FlexColumnAlignCenter)`
   background-color: var(--color-landingpage-bg-alt);
-  // The lower margin on the top is required because of the 20px row gap after the FeatureHighlightsContainer
+  // The lower margin on the top is required because of the 20px margin after FeatureHighlightsItem
   margin: 10px 0 30px 0;
   padding: 30px;
   & h2 {

--- a/website/components/LandingPage/index.tsx
+++ b/website/components/LandingPage/index.tsx
@@ -113,12 +113,12 @@ const FeatureHighlightsItem = styled(FlexColumn)`
   }
 `;
 
-const Divider = styled.hr`
-  display: block;
-  width: 100%;
-  height: 1px;
-  background-color: var(--color-layout-dividers);
-  border-style: none;
+const LoadPromptContainer = styled(FlexRowAlignCenter)`
+  background-color: var(--color-landingpage-bg-alt);
+  // The 20px margin on the top is required because of the 20px row gap after the FeatureHighlightsContainer
+  margin: 20px 0 30px 0;
+  padding: 30px;
+  color: var(--color-text-header);
 `;
 
 const ProjectList = styled.ul`
@@ -365,7 +365,7 @@ export default function LandingPage(): ReactElement {
         </BannerTextContainer>
       </Banner>
 
-      <ContentContainer $gap={30}>
+      <ContentContainer>
         <FeatureHighlightsContainer>
           <FeatureHighlightsItem>
             <h3>Multiresolution OME-Zarr support</h3>
@@ -388,11 +388,9 @@ export default function LandingPage(): ReactElement {
         </FeatureHighlightsContainer>
       </ContentContainer>
 
-      <FlexColumnAlignCenter
-        style={{ backgroundColor: "var(--color-landingpage-bg-alt)", padding: "30px", margin: "30px 0" }}
-      >
+      <LoadPromptContainer>
         <h2 style={{ margin: 0 }}>Load dataset(s) below or your own data to get started</h2>
-      </FlexColumnAlignCenter>
+      </LoadPromptContainer>
 
       <ContentContainer style={{ paddingBottom: "400px" }}>
         <ProjectList>{landingPageContent.map(renderProject)}</ProjectList>

--- a/website/components/LandingPage/index.tsx
+++ b/website/components/LandingPage/index.tsx
@@ -9,7 +9,7 @@ import styled from "styled-components";
 import Header from "../Header";
 import LoadModal from "../Modals/LoadModal";
 import { AppDataProps, DatasetEntry, ProjectEntry } from "../../types";
-import { FlexColumnAlignCenter, FlexColumn, FlexRowAlignCenter, VisuallyHidden, FlexRow } from "./utils";
+import { FlexColumnAlignCenter, FlexColumn, FlexRowAlignCenter, VisuallyHidden } from "./utils";
 import { parseViewerUrlParams } from "../../utils/url_utils";
 import HelpDropdown from "../HelpDropdown";
 import { BannerVideo } from "../../assets/videos";

--- a/website/components/LandingPage/index.tsx
+++ b/website/components/LandingPage/index.tsx
@@ -89,22 +89,23 @@ const ContentContainer = styled(FlexColumn)`
 const FeatureHighlightsContainer = styled.li`
   display: grid;
   width: 100%;
-  grid-template-rows: repeat(2, auto);
+  // Add a 20px dummy row to act as the gap
+  grid-template-rows: auto auto 20px;
   grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
   padding: 0;
   justify-content: space-evenly;
-  gap: 20px;
+  column-gap: 20px;
   margin: 30px 0 0 0;
 `;
 
 const FeatureHighlightsItem = styled(FlexColumn)`
   display: grid;
   grid-template-rows: subgrid;
-  grid-row: span 2;
+  grid-row: span 3;
 
   & > h3 {
     font-weight: 600;
-    margin: 0;
+    margin: 0 0 4px 0;
   }
 
   & > p {
@@ -142,14 +143,18 @@ const ProjectCard = styled.li`
   display: flex;
   width: 100%;
   flex-direction: column;
-  gap: 8px;
+  gap: 0px;
 
   & h3 {
     font-weight: 600;
   }
 
+  & h2 {
+    font-size: 20px;
+  }
+
   & p,
-  & h3,
+  & h2,
   & span {
     margin: 0;
   }
@@ -158,18 +163,25 @@ const ProjectCard = styled.li`
     // Add 2px margin to maintain the same visual gap that text has
     margin-top: 2px;
   }
+
+  & :first-child {
+    // Add some visual separation beneath title element
+    margin-bottom: 2px;
+  }
 `;
 
 const DatasetList = styled.ul`
   padding: 0;
   width: 100%;
   display: grid;
+  margin: 4px 0 0 0;
+
   // Use grid + subgrid to align the title, description, and button for each horizontal
   // row of cards. repeat is used to tile the layout if the cards wrap to a new line.
   grid-template-rows: repeat(3, auto);
   grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
   justify-content: space-around;
-  gap: 10px 20px;
+  gap: 0px 20px;
 `;
 
 const DatasetCard = styled.li`
@@ -177,7 +189,7 @@ const DatasetCard = styled.li`
   grid-template-rows: subgrid;
   grid-row: span 3;
   min-width: 180px;
-  padding: 5px;
+  margin-top: 20px;
 
   & > h3 {
     display: grid;
@@ -188,7 +200,7 @@ const DatasetCard = styled.li`
   }
   & > a,
   & > button {
-    margin-right: auto;
+    margin: 4px auto 0 0;
     display: grid;
   }
 `;
@@ -261,16 +273,16 @@ export default function LandingPage(): ReactElement {
 
   const renderProject = (project: ProjectEntry, index: number): ReactElement => {
     const projectNameElement = project.inReview ? (
-      <FlexRow $gap={10}>
-        <h3>{project.name}</h3>
+      <FlexRowAlignCenter $gap={10}>
+        <h2>{project.name}</h2>
         <Tooltip title="Final version of dataset will be released when associated paper is published">
           <InReviewFlag>
             <p>IN REVIEW</p>
           </InReviewFlag>
         </Tooltip>
-      </FlexRow>
+      </FlexRowAlignCenter>
     ) : (
-      <h3>{project.name}</h3>
+      <h2>{project.name}</h2>
     );
 
     const publicationElement = project.publicationLink ? (
@@ -353,7 +365,7 @@ export default function LandingPage(): ReactElement {
         </BannerTextContainer>
       </Banner>
 
-      <ContentContainer $gap={30} style={{ paddingBottom: "400px" }}>
+      <ContentContainer $gap={30}>
         <FeatureHighlightsContainer>
           <FeatureHighlightsItem>
             <h3>Multiresolution OME-Zarr support</h3>
@@ -374,10 +386,15 @@ export default function LandingPage(): ReactElement {
             </p>
           </FeatureHighlightsItem>
         </FeatureHighlightsContainer>
-        <Divider />
-        <FlexColumnAlignCenter>
-          <h2>Load an example below or your own data to get started.</h2>
-        </FlexColumnAlignCenter>
+      </ContentContainer>
+
+      <FlexColumnAlignCenter
+        style={{ backgroundColor: "var(--color-landingpage-bg-alt)", padding: "30px", margin: "30px 0" }}
+      >
+        <h2 style={{ margin: 0 }}>Load dataset(s) below or your own data to get started</h2>
+      </FlexColumnAlignCenter>
+
+      <ContentContainer style={{ paddingBottom: "400px" }}>
         <ProjectList>{landingPageContent.map(renderProject)}</ProjectList>
       </ContentContainer>
     </div>

--- a/website/components/LandingPage/index.tsx
+++ b/website/components/LandingPage/index.tsx
@@ -89,8 +89,7 @@ const ContentContainer = styled(FlexColumn)`
 const FeatureHighlightsContainer = styled.li`
   display: grid;
   width: 100%;
-  // Add a 20px dummy row to act as the gap
-  grid-template-rows: auto auto 20px;
+  grid-template-rows: repeat(2, auto);
   grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
   padding: 0;
   justify-content: space-evenly;
@@ -101,7 +100,7 @@ const FeatureHighlightsContainer = styled.li`
 const FeatureHighlightsItem = styled(FlexColumn)`
   display: grid;
   grid-template-rows: subgrid;
-  grid-row: span 3;
+  grid-row: span 2;
 
   & > h3 {
     font-weight: 600;
@@ -109,14 +108,14 @@ const FeatureHighlightsItem = styled(FlexColumn)`
   }
 
   & > p {
-    margin: 0;
+    margin: 0 0 20px 0;
   }
 `;
 
 const LoadPromptContainer = styled(FlexColumnAlignCenter)`
   background-color: var(--color-landingpage-bg-alt);
-  // The 20px margin on the top is required because of the 20px row gap after the FeatureHighlightsContainer
-  margin: 20px 0 30px 0;
+  // The lower margin on the top is required because of the 20px row gap after the FeatureHighlightsContainer
+  margin: 10px 0 30px 0;
   padding: 30px;
   & h2 {
     color: var(--color-text-header);
@@ -145,7 +144,6 @@ const ProjectCard = styled.li`
   display: flex;
   width: 100%;
   flex-direction: column;
-  gap: 0px;
 
   & h3 {
     font-weight: 600;

--- a/website/components/LandingPage/index.tsx
+++ b/website/components/LandingPage/index.tsx
@@ -113,12 +113,14 @@ const FeatureHighlightsItem = styled(FlexColumn)`
   }
 `;
 
-const LoadPromptContainer = styled(FlexRowAlignCenter)`
+const LoadPromptContainer = styled(FlexColumnAlignCenter)`
   background-color: var(--color-landingpage-bg-alt);
   // The 20px margin on the top is required because of the 20px row gap after the FeatureHighlightsContainer
   margin: 20px 0 30px 0;
   padding: 30px;
-  color: var(--color-text-header);
+  & h2 {
+    color: var(--color-text-header);
+  }
 `;
 
 const ProjectList = styled.ul`


### PR DESCRIPTION
Problem
=======
Closes #288 , fixing visual hierarchy + layout on landing page.

*Estimated review size: tiny, 5-10 minutes*

Solution
========
- Adjusts spacing on datasets to group titles and paragraph text.
- Adjusts font size on project titles.
- Fixes "In review" label alignment
- Fixes gaps between feature callout titles and text.

Screenshots
=======
Before:
![image](https://github.com/user-attachments/assets/d92ec614-dae0-4416-8225-a176f395f0db)

After:
![image](https://github.com/user-attachments/assets/2a745d33-42e1-4e43-a425-075a8c066e0a)
