### PR TITLE
feat: Save control point info to URL

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -303,10 +303,9 @@ const App: React.FC<AppProps> = (props) => {
 
     // If this is the first load of this image, auto-generate initial LUTs
     if (initialLoadRef.current || !thisChannelsSettings.controlPoints || !thisChannelsSettings.ramp) {
-      const newControlPoints = initializeLut(aimg, channelIndex, props.viewerChannelSettings);
-      const ramp = controlPointsToRamp(newControlPoints);
-      changeChannelSetting(channelIndex, "controlPoints", newControlPoints);
-      changeChannelSetting(channelIndex, "ramp", ramp);
+      const { ramp, controlPoints } = initializeLut(aimg, channelIndex, props.viewerChannelSettings);
+      changeChannelSetting(channelIndex, "controlPoints", controlPoints);
+      changeChannelSetting(channelIndex, "ramp", controlPointsToRamp(ramp));
     } else {
       // try not to update lut from here if we are in play mode
       // if (playingAxis !== null) {

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -187,8 +187,8 @@ const initializeOneChannelSetting = (
     isovalue: initSettings.isovalue ?? defaultChannelState.isovalue,
     opacity: initSettings.surfaceOpacity ?? defaultChannelState.opacity,
     color: colorHexToArray(initSettings.color ?? "") ?? defaultColor,
-    useControlPoints: defaultChannelState.useControlPoints,
-    controlPoints: defaultChannelState.controlPoints,
+    useControlPoints: initSettings.controlPointsEnabled ?? defaultChannelState.useControlPoints,
+    controlPoints: initSettings.controlPoints ?? defaultChannelState.controlPoints,
     ramp: defaultChannelState.ramp,
   };
 };

--- a/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
+++ b/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
@@ -99,12 +99,12 @@ export function initializeLut(
   const name = aimg.channelNames[channelIndex];
   const initSettings = channelSettings && findFirstChannelMatch(name, channelIndex, channelSettings);
 
-  // Attempt to load a lut from the settings, which will be used to initialize the control points and ramp
-  // if they are not defined.
+  // Attempt to load a LUT from the settings, which will be used to initialize the control points and ramp
   if (initSettings && initSettings.lut) {
     lut = parseLutFromSettings(histogram, initSettings) ?? defaultLut;
   }
-  // Override the lut's control points with the provided control points and/or ramp
+  // Initialize the control points + ramp using the LUT.
+  // Optionally, override the LUT's control points with the provided control points and/or ramp.
   controlPoints = initSettings?.controlPoints ? initSettings.controlPoints : [...lut.controlPoints];
   ramp = initSettings?.ramp ? rampToControlPoints(initSettings.ramp) : [...lut.controlPoints];
 

--- a/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
+++ b/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
@@ -27,6 +27,13 @@ export function initializeLut(
   if (channelSettings) {
     const initSettings = findFirstChannelMatch(name, channelIndex, channelSettings);
     if (initSettings) {
+      // Use control points if provided; otherwise calculate from `lut` values.
+      if (initSettings.controlPoints) {
+        const controlPoints = initSettings.controlPoints;
+        lutObject = new Lut().createFromControlPoints(controlPoints);
+        aimg.setLut(channelIndex, lutObject);
+        return initSettings.controlPoints;
+      }
       if (initSettings.lut !== undefined && initSettings.lut.length === 2) {
         let lutmod = "";
         let lvalue = 0;

--- a/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
+++ b/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
@@ -1,5 +1,5 @@
-import { Channel, ControlPoint, Lut, Volume } from "@aics/volume-viewer";
-import { findFirstChannelMatch, ViewerChannelSettings } from "./viewerChannelSettings";
+import { Channel, ControlPoint, Histogram, Lut, Volume } from "@aics/volume-viewer";
+import { findFirstChannelMatch, ViewerChannelSetting, ViewerChannelSettings } from "./viewerChannelSettings";
 import { LUT_MAX_PERCENTILE, LUT_MIN_PERCENTILE } from "../constants";
 import { TFEDITOR_DEFAULT_COLOR, TFEDITOR_MAX_BIN } from "../../components/TfEditor";
 
@@ -10,73 +10,119 @@ export function controlPointsToLut(controlPoints: ControlPoint[]): Lut {
   return lut;
 }
 
+/** Returns a default lookup table based on a min/max percentile of the current volume's data. */
+function getDefaultLut(histogram: Histogram): Lut {
+  const hmin = histogram.findBinOfPercentile(LUT_MIN_PERCENTILE);
+  const hmax = histogram.findBinOfPercentile(LUT_MAX_PERCENTILE);
+  return new Lut().createFromMinMax(hmin, hmax);
+}
+/**
+ * Parses a lookup table (LUT) from a `ViewerChannelSetting` object, where the `lut` field is an
+ * array of two alphanumeric strings.
+ *
+ * @returns a Lut object if the `lut` field is valid; otherwise, undefined.
+ *
+ * Min and max values are determined as following:
+ * - Plain numbers are treated as direct intensity values.
+ * - `p{n}` represents a percentile, where `n` is a percentile in the [0, 100] range.
+ * - `m{n}` represents the median multiplied by `n / 100`.
+ * - `autoij` in either the min or max fields will use the "auto" algorithm
+ * from ImageJ to select the min and max.
+ *
+ * @example
+ * ```
+ * "0:255"    // min: intensity 0, max: intensity 255.
+ * "p50:p90"  // min: 50th percentile, max: 90th percentile.
+ * "m1:p75"   // min: median, max: 75th percentile.
+ * "autoij:0" // use Auto-IJ to calculate min and max.
+ * ```
+ */
+export function parseLutFromSettings(histogram: Histogram, initSettings: ViewerChannelSetting): Lut | undefined {
+  if (initSettings.lut === undefined || initSettings.lut.length !== 2) {
+    return undefined;
+  }
+
+  let lutmod = "";
+  let lvalue = 0;
+  let lutvalues = [0, 0];
+  for (let i = 0; i < 2; ++i) {
+    const lstr = initSettings.lut[i];
+    if (lstr === "autoij") {
+      lutvalues = histogram.findAutoIJBins();
+      break;
+    }
+
+    // look at first char of string.
+    let firstchar = lstr.charAt(0);
+    if (firstchar === "m" || firstchar === "p") {
+      lutmod = firstchar;
+      lvalue = parseFloat(lstr.substring(1)) / 100.0;
+    } else {
+      lutmod = "";
+      lvalue = parseFloat(lstr);
+    }
+    if (lutmod === "m") {
+      lutvalues[i] = histogram.maxBin * lvalue;
+    } else if (lutmod === "p") {
+      lutvalues[i] = histogram.findBinOfPercentile(lvalue);
+    } else {
+      lutvalues[i] = lvalue;
+    }
+  } // end for
+
+  return new Lut().createFromMinMax(Math.min(lutvalues[0], lutvalues[1]), Math.max(lutvalues[0], lutvalues[1]));
+}
+
+/**
+ * Initializes the lookup table (lut) that maps from volume intensity values to color + opacity and applies the lut to the volume.
+ *
+ * @param aimg The loaded volume data.
+ * @param channelIndex The index of the channel to initialize the LUT for.
+ * @param channelSettings The ViewerChannelSettings object that may contain settings for this channel. If relevant
+ * settings are not found, a default LUT will be used.
+ * @returns an object containing the retrieved lut control points for the ramp and control points.
+ *
+ * Lut values will be determined using the following rules:
+ * - If no `lut` is provided in the `channelSettings`, a default LUT is calculated using min/max percentiles of the data.
+ * - Otherwise, `lut` will be parsed as described in `ViewerChannelSettingParams.lut`.
+ * - The `controlPoints` and `ramp` fields in the `channelSettings` will be used to override the returned control points and ramp,
+ * respectively.
+ *
+ * If `controlPointsEnabled` is set to true in the `channelSettings`, the control points will be applied to the volume;
+ * otherwise, the ramp will be applied.
+ */
 export function initializeLut(
   aimg: Volume,
   channelIndex: number,
   channelSettings?: ViewerChannelSettings
-): ControlPoint[] {
+): { ramp: ControlPoint[]; controlPoints: ControlPoint[] } {
   const histogram = aimg.getHistogram(channelIndex);
+  const defaultLut = getDefaultLut(histogram);
 
-  // find channelIndex among viewerChannelSettings.
+  let ramp: ControlPoint[] = [];
+  let controlPoints: ControlPoint[] = [];
+  let lut = defaultLut;
+
   const name = aimg.channelNames[channelIndex];
-  // default to percentiles
-  const hmin = histogram.findBinOfPercentile(LUT_MIN_PERCENTILE);
-  const hmax = histogram.findBinOfPercentile(LUT_MAX_PERCENTILE);
-  let lutObject = new Lut().createFromMinMax(hmin, hmax);
-  // and if init settings dictate, recompute it:
-  if (channelSettings) {
-    const initSettings = findFirstChannelMatch(name, channelIndex, channelSettings);
-    if (initSettings) {
-      // Use control points if provided; otherwise calculate from `lut` values.
-      if (initSettings.controlPoints) {
-        const controlPoints = initSettings.controlPoints;
-        lutObject = new Lut().createFromControlPoints(controlPoints);
-        aimg.setLut(channelIndex, lutObject);
-        return initSettings.controlPoints;
-      }
-      if (initSettings.lut !== undefined && initSettings.lut.length === 2) {
-        let lutmod = "";
-        let lvalue = 0;
-        let lutvalues = [0, 0];
-        for (let i = 0; i < 2; ++i) {
-          const lstr = initSettings.lut[i];
-          if (lstr === "autoij") {
-            lutvalues = histogram.findAutoIJBins();
-            break;
-          }
+  const initSettings = channelSettings && findFirstChannelMatch(name, channelIndex, channelSettings);
 
-          // look at first char of string.
-          let firstchar = lstr.charAt(0);
-          if (firstchar === "m" || firstchar === "p") {
-            lutmod = firstchar;
-            lvalue = parseFloat(lstr.substring(1)) / 100.0;
-          } else {
-            lutmod = "";
-            lvalue = parseFloat(lstr);
-          }
-          if (lutmod === "m") {
-            lutvalues[i] = histogram.maxBin * lvalue;
-          } else if (lutmod === "p") {
-            lutvalues[i] = histogram.findBinOfPercentile(lvalue);
-          } else {
-            lutvalues[i] = lvalue;
-          }
-        } // end for
+  if (initSettings && initSettings.lut) {
+    lut = parseLutFromSettings(histogram, initSettings) ?? defaultLut;
+  }
+  // Override the lut's control points with the provided control points and/or ramp
+  controlPoints = initSettings?.controlPoints ? initSettings.controlPoints : [...lut.controlPoints];
+  ramp = initSettings?.ramp ? rampToControlPoints(initSettings.ramp) : [...lut.controlPoints];
 
-        lutObject = new Lut().createFromMinMax(
-          Math.min(lutvalues[0], lutvalues[1]),
-          Math.max(lutvalues[0], lutvalues[1])
-        );
-      }
-    }
+  // Apply whatever lut is currently visible
+  let visibleLut: Lut;
+  if (initSettings?.controlPointsEnabled) {
+    visibleLut = new Lut().createFromControlPoints(controlPoints);
+  } else {
+    visibleLut = new Lut().createFromControlPoints(ramp);
   }
 
-  const newControlPoints = lutObject.controlPoints.map((controlPoint) => ({
-    ...controlPoint,
-    color: TFEDITOR_DEFAULT_COLOR,
-  }));
-  aimg.setLut(channelIndex, lutObject);
-  return newControlPoints;
+  aimg.setLut(channelIndex, visibleLut);
+  return { ramp, controlPoints };
 }
 
 export function controlPointsToRamp(controlPoints: ControlPoint[]): [number, number] {

--- a/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
+++ b/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
@@ -1,3 +1,4 @@
+import { ControlPoint } from "@aics/volume-viewer";
 import { OTHER_CHANNEL_KEY, SINGLE_GROUP_CHANNEL_KEY } from "../constants";
 
 /** Settings for a single channel, as passed in via props by App users */
@@ -16,10 +17,9 @@ export interface ViewerChannelSetting {
   enabled?: boolean;
   // default to false
   surfaceEnabled?: boolean;
-  // min and max. these are shorthand expressions.
-  // a plain number (intensity), or a "p##", or a "m##" for percentile or median
   /**
-   * Min and max, shorthand expressions. Defaults to [0, 255].
+   * Min and max values for the intensity lookup table, which maps from raw intensity values
+   * in the volume to opacity and color. Defaults to [0, 255].
    *
    * - Plain numbers are treated as direct intensity values.
    * - `p{n}` represents a percentile, where `n` is a percentile in the [0, 100] range.
@@ -28,6 +28,13 @@ export interface ViewerChannelSetting {
    * from ImageJ to select the min and max.
    */
   lut?: [string, string];
+  /**
+   * Whether to show control point controls instead of a simpler ramp control.
+   * If no control points are provided, control points will be derived from the
+   * `lut` values. Defaults to false.
+   */
+  controlPointsEnabled?: boolean;
+  controlPoints?: ControlPoint[];
   // valid when surfaceEnabled = true. default 128 or 0.5 of max intensity range
   isovalue?: number;
   // valid when surfaceEnabled = true. default 1.0 fully opaque

--- a/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
+++ b/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
@@ -30,8 +30,7 @@ export interface ViewerChannelSetting {
   lut?: [string, string];
   /**
    * Whether to show control point controls instead of a simpler ramp control.
-   * If no control points are provided, control points will be derived from the
-   * `lut` values. Defaults to false.
+   * Defaults to false.
    */
   controlPointsEnabled?: boolean;
   controlPoints?: ControlPoint[];

--- a/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
+++ b/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
@@ -35,6 +35,7 @@ export interface ViewerChannelSetting {
    */
   controlPointsEnabled?: boolean;
   controlPoints?: ControlPoint[];
+  ramp?: [number, number];
   // valid when surfaceEnabled = true. default 128 or 0.5 of max intensity range
   isovalue?: number;
   // valid when surfaceEnabled = true. default 1.0 fully opaque

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -183,7 +183,10 @@ describe("Channel state serialization", () => {
     colorizeEnabled: true,
     colorizeAlpha: 0.5,
     useControlPoints: false,
-    controlPoints: [{ x: 0, opacity: 0.5, color: [255, 255, 255] }],
+    controlPoints: [
+      { x: 0, opacity: 0.5, color: [255, 255, 255] },
+      { x: 255, opacity: 1.0, color: [255, 255, 255] },
+    ],
     ramp: [0, 255],
   };
   const DEFAULT_SERIALIZED_CHANNEL_STATE: ViewerChannelSettingParams = {
@@ -194,7 +197,9 @@ describe("Channel state serialization", () => {
     isa: "0.75",
     clz: "1",
     cza: "0.5",
-    // TODO: include LUT and name
+    cpe: "0",
+    cps: "0:0.5:ffffff,255:1:ffffff",
+    lut: "0:255",
   };
 
   // Note that the serialization + deserialization are NOT direct inverses.
@@ -317,7 +322,7 @@ describe("Channel state serialization", () => {
         controlPoints: [],
         ramp: [0, 255],
       };
-      const serializedCustomChannelState: ViewerChannelSettingParams = {
+      const serializedCustomChannelState: Required<ViewerChannelSettingParams> = {
         col: "03ff9d",
         ven: "0",
         sen: "0",
@@ -325,6 +330,9 @@ describe("Channel state serialization", () => {
         isa: "0.54",
         clz: "0",
         cza: "1",
+        cpe: "0",
+        cps: "",
+        lut: "0:255",
       };
       expect(serializeViewerChannelSetting(customChannelState)).toEqual(serializedCustomChannelState);
     });
@@ -658,8 +666,11 @@ describe("serializeViewerUrlParams", () => {
         colorizeEnabled: true,
         colorizeAlpha: 0.5,
         useControlPoints: false,
-        controlPoints: [{ x: 0, opacity: 0.5, color: [255, 255, 255] }],
-        ramp: [0, 255],
+        controlPoints: [
+          { x: 0, opacity: 0, color: [128, 128, 128] },
+          { x: 1, opacity: 1, color: [255, 0, 0] },
+        ],
+        ramp: [-10, 260.1],
       },
       {
         name: "channel1",
@@ -670,33 +681,43 @@ describe("serializeViewerUrlParams", () => {
         opacity: 0.0,
         colorizeEnabled: false,
         colorizeAlpha: 0.2,
-        useControlPoints: false,
-        controlPoints: [{ x: 0, opacity: 0.5, color: [255, 255, 255] }],
-        ramp: [0, 255],
+        useControlPoints: true,
+        controlPoints: [
+          { x: -10, opacity: 0, color: [0, 0, 0] },
+          { x: 50, opacity: 0, color: [0, 0, 0] },
+          { x: 100, opacity: 0.3, color: [0, 16, 255] },
+          { x: 140, opacity: 0.8, color: [0, 255, 255] },
+          { x: 260, opacity: 1.0, color: [0, 255, 180] },
+        ],
+        ramp: [50, 140],
       },
     ];
     const serialized = serializeViewerUrlParams({ channelSettings: channelStates });
     // Format should look like "ven:1,col:ff0000,clz:1,cza:0.75,isa:0.5,sen:1,isv:128", but ordering
     // is not guaranteed. Parse the string and check that the values match the expected values.
-    const expectedChannel0 = {
+    const expectedChannel0: Required<ViewerChannelSettingParams> = {
       ven: "1",
       col: "ff0000",
       clz: "1",
       cza: "0.5",
       isa: "0.75",
-      // lut: "0:255",
       sen: "1",
       isv: "128",
+      lut: "-10:260.1",
+      cps: "0:0:808080,1:1:ff0000",
+      cpe: "0",
     };
-    const expectedChannel1 = {
+    const expectedChannel1: Required<ViewerChannelSettingParams> = {
       ven: "0",
       col: "808080",
       clz: "0",
       cza: "0.2",
       isa: "0",
-      // lut: "0:255",
       sen: "0",
       isv: "57",
+      lut: "50:140",
+      cps: "-10:0:000000,50:0:000000,100:0.3:0010ff,140:0.8:00ffff,260:1:00ffb4",
+      cpe: "1",
     };
 
     expect(serialized["c0"]).toBeDefined();

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -217,7 +217,7 @@ describe("Channel state serialization", () => {
     cza: "0.5",
     cpe: "0",
     cps: "0:0.5:ffffff,255:1:ffffff",
-    lut: "0:255",
+    rmp: "0:255",
   };
 
   // Note that the serialization + deserialization are NOT direct inverses.
@@ -340,7 +340,7 @@ describe("Channel state serialization", () => {
         controlPoints: [],
         ramp: [0, 255],
       };
-      const serializedCustomChannelState: Required<ViewerChannelSettingParams> = {
+      const serializedCustomChannelState: Required<Omit<ViewerChannelSettingParams, "lut">> = {
         col: "03ff9d",
         ven: "0",
         sen: "0",
@@ -350,7 +350,7 @@ describe("Channel state serialization", () => {
         cza: "1",
         cpe: "0",
         cps: "",
-        lut: "0:255",
+        rmp: "0:255",
       };
       expect(serializeViewerChannelSetting(customChannelState)).toEqual(serializedCustomChannelState);
     });
@@ -713,7 +713,8 @@ describe("serializeViewerUrlParams", () => {
     const serialized = serializeViewerUrlParams({ channelSettings: channelStates });
     // Format should look like "ven:1,col:ff0000,clz:1,cza:0.75,isa:0.5,sen:1,isv:128", but ordering
     // is not guaranteed. Parse the string and check that the values match the expected values.
-    const expectedChannel0: Required<ViewerChannelSettingParams> = {
+    // Note that `lut` is not included when serializing from existing viewer state.
+    const expectedChannel0: Required<Omit<ViewerChannelSettingParams, "lut">> = {
       ven: "1",
       col: "ff0000",
       clz: "1",
@@ -721,11 +722,11 @@ describe("serializeViewerUrlParams", () => {
       isa: "0.75",
       sen: "1",
       isv: "128",
-      lut: "-10:260.1",
+      rmp: "-10:260.1",
       cps: "0:0:808080,1:1:ff0000",
       cpe: "0",
     };
-    const expectedChannel1: Required<ViewerChannelSettingParams> = {
+    const expectedChannel1: Required<Omit<ViewerChannelSettingParams, "lut">> = {
       ven: "0",
       col: "808080",
       clz: "0",
@@ -733,7 +734,7 @@ describe("serializeViewerUrlParams", () => {
       isa: "0",
       sen: "0",
       isv: "57",
-      lut: "50:140",
+      rmp: "50:140",
       cps: "-10:0:000000,50:0:000000,100:0.3:0010ff,140:0.8:00ffff,260:1:00ffb4",
       cpe: "1",
     };

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -14,6 +14,7 @@ import {
   deserializeViewerState,
   ViewerStateParams,
   serializeViewerUrlParams,
+  CONTROL_POINTS_REGEX,
 } from "../url_utils";
 import { ChannelState, ViewerState } from "../../../src/aics-image-viewer/components/ViewerStateProvider/types";
 import { ImageType, RenderMode, ViewMode } from "../../../src/aics-image-viewer/shared/enums";
@@ -31,6 +32,23 @@ const defaultSettings: ViewerChannelSetting = {
 };
 
 //// VALUE PARSING ///////////////////////////////////////
+
+describe("CONTROL_POINTS_REGEX", () => {
+  it("accepts single control points", () => {
+    const data = "1:0.5:ffffff";
+    expect(CONTROL_POINTS_REGEX.test(data)).toBe(true);
+  });
+
+  it("accepts multiple control points", () => {
+    const data = "1:0.5:ff0000,128:0.7:ffff00,255:1:ff0000";
+    expect(CONTROL_POINTS_REGEX.test(data)).toBe(true);
+  });
+
+  it("accepts negative numbers", () => {
+    const data = "-1:0.5:ff0000,-255:1:ff0000";
+    expect(CONTROL_POINTS_REGEX.test(data)).toBe(true);
+  });
+});
 
 describe("parseKeyValueList", () => {
   it("returns expected key value pairs", () => {

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -441,7 +441,8 @@ function parseControlPoints(controlPoints: string | undefined): ControlPoint[] |
   const newControlPoints = controlPoints.split(",").map((cp) => {
     const [x, opacity, color] = cp.split(":");
     return {
-      x: parseStringFloat(x, 0, 1) ?? 0,
+      // TODO: Is there a good range of values for x?
+      x: parseStringFloat(x, -Infinity, Infinity) ?? 0,
       opacity: parseStringFloat(opacity, 0, 1) ?? 1.0,
       color: parseHexColorAsColorArray(color) ?? [255, 255, 255],
     };
@@ -471,6 +472,7 @@ export function deserializeViewerChannelSetting(
     surfaceOpacity: parseStringFloat(jsonState[ViewerChannelSettingKeys.IsosurfaceAlpha], 0, 1),
     colorizeEnabled: parseStringBoolean(jsonState[ViewerChannelSettingKeys.Colorize]),
     colorizeAlpha: parseStringFloat(jsonState[ViewerChannelSettingKeys.ColorizeAlpha], 0, 1),
+    controlPointsEnabled: parseStringBoolean(jsonState[ViewerChannelSettingKeys.ControlPointsEnabled]),
   };
   if (jsonState[ViewerChannelSettingKeys.Color] && HEX_COLOR_REGEX.test(jsonState.col)) {
     result.color = jsonState[ViewerChannelSettingKeys.Color];
@@ -478,6 +480,9 @@ export function deserializeViewerChannelSetting(
   if (jsonState[ViewerChannelSettingKeys.Lut] && LUT_REGEX.test(jsonState.lut)) {
     const [min, max] = jsonState[ViewerChannelSettingKeys.Lut].split(":");
     result.lut = [min.trim(), max.trim()];
+  }
+  if (jsonState[ViewerChannelSettingKeys.ControlPoints] && CONTROL_POINTS_REGEX.test(jsonState.cps)) {
+    result.controlPoints = parseControlPoints(jsonState[ViewerChannelSettingKeys.ControlPoints]);
   }
   return result;
 }

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -18,7 +18,7 @@ import { ControlPoint } from "@aics/volume-viewer";
 
 const CHANNEL_STATE_KEY_REGEX = /^c[0-9]+$/;
 /** Match colon-separated pairs of alphanumeric strings */
-const LUT_REGEX = /^\-?[a-z0-9.]*:[ ]*\-?[a-z0-9.]*$/;
+const LUT_REGEX = /^-?[a-z0-9.]*:[ ]*-?[a-z0-9.]*$/;
 /**
  * Match comma-separated triplet of numeric strings.
  */
@@ -33,7 +33,7 @@ const HEX_COLOR_REGEX = /^[0-9a-fA-F]{6}$/;
  * Matches a comma-separated list of control points, where each control point is represented
  * by a triplet of `{x}:{opacity}:{hex color}`.
  */
-export const CONTROL_POINTS_REGEX = /^(\-?[\-0-9.]*:[0-9.]*:[0-9a-fA-F]{6})(,\-?[0-9.]*:[0-9.]*:[0-9a-fA-F]{6})*$/;
+export const CONTROL_POINTS_REGEX = /^(-?[-0-9.]*:[0-9.]*:[0-9a-fA-F]{6})(,-?[0-9.]*:[0-9.]*:[0-9a-fA-F]{6})*$/;
 
 /**
  * Enum keys for URL parameters. These are stored as enums for better readability,

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -1,4 +1,5 @@
 import FirebaseRequest, { DatasetMetaData } from "../../public/firebase";
+import { ControlPoint } from "@aics/volume-viewer";
 
 import type {
   ChannelState,
@@ -14,7 +15,6 @@ import {
 import { ColorArray } from "../../src/aics-image-viewer/shared/utils/colorRepresentations";
 import { PerAxis } from "../../src/aics-image-viewer/shared/types";
 import { clamp } from "./math_utils";
-import { ControlPoint } from "@aics/volume-viewer";
 
 const CHANNEL_STATE_KEY_REGEX = /^c[0-9]+$/;
 /** Match colon-separated pairs of alphanumeric strings */
@@ -35,7 +35,7 @@ const HEX_COLOR_REGEX = /^[0-9a-fA-F]{6}$/;
  * Matches a comma-separated list of control points, where each control point is represented
  * by a triplet of `{x}:{opacity}:{hex color}`.
  */
-export const CONTROL_POINTS_REGEX = /^(-?[-0-9.]*:[0-9.]*:[0-9a-fA-F]{6})(,-?[0-9.]*:[0-9.]*:[0-9a-fA-F]{6})*$/;
+export const CONTROL_POINTS_REGEX = /^(-?[0-9.]*:[0-9.]*:[0-9a-fA-F]{6})(,-?[0-9.]*:[0-9.]*:[0-9a-fA-F]{6})*$/;
 
 /**
  * Enum keys for URL parameters. These are stored as enums for better readability,
@@ -451,7 +451,6 @@ function parseControlPoints(controlPoints: string | undefined): ControlPoint[] |
   const newControlPoints = controlPoints.split(",").map((cp) => {
     const [x, opacity, color] = cp.split(":");
     return {
-      // TODO: Is there an expected range of values for x?
       x: parseStringFloat(x, -Infinity, Infinity) ?? 0,
       opacity: parseStringFloat(opacity, 0, 1) ?? 1.0,
       color: parseHexColorAsColorArray(color) ?? [255, 255, 255],

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -18,7 +18,7 @@ import { ControlPoint } from "@aics/volume-viewer";
 
 const CHANNEL_STATE_KEY_REGEX = /^c[0-9]+$/;
 /** Match colon-separated pairs of alphanumeric strings */
-const LUT_REGEX = /^[a-z0-9.]*:[ ]*[a-z0-9.]*$/;
+const LUT_REGEX = /^\-?[a-z0-9.]*:[ ]*\-?[a-z0-9.]*$/;
 /**
  * Match comma-separated triplet of numeric strings.
  */
@@ -33,7 +33,7 @@ const HEX_COLOR_REGEX = /^[0-9a-fA-F]{6}$/;
  * Matches a comma-separated list of control points, where each control point is represented
  * by a triplet of `{x}:{opacity}:{hex color}`.
  */
-const CONTROL_POINTS_REGEX = /^([0-9.]*:[0-9.]*:[0-9a-fA-F]{6})(,[0-9.]*:[0-9.]*:[0-9a-fA-F]{6})*$/;
+export const CONTROL_POINTS_REGEX = /^(\-?[\-0-9.]*:[0-9.]*:[0-9a-fA-F]{6})(,\-?[0-9.]*:[0-9.]*:[0-9a-fA-F]{6})*$/;
 
 /**
  * Enum keys for URL parameters. These are stored as enums for better readability,


### PR DESCRIPTION
Closes #282, saving the control points to the URL!

*Estimated review size: large, 30 minutes*

This change adds the following properties to the URL:
```
controlPoints - 'cps'
controlPointsEnabled - 'cpe'
ramp - 'rmp'
```
(^ I'm open to feedback on any of these abbreviations)

These capture the current control point and ramp information, as well as whether the control points OR ramp should be visible 
 in the UI (now shown under the 'Advanced' checkbox in the volume settings editor).

Note that `rmp` is slightly redundant with the existing `lut` field in the URL; I elected to keep them separate as we expect `lut` to be a user input property, while the `ramp` and `controlPoints` are only used when capturing existing state from the user interacting with the viewer.

## Changes

- Adds `controlPoints`, `controlPointsEnabled`, and `ramp` fields to the `ViewerChannelSettings`.
- Added serializing/deserializing for control point arrays.
- Refactored the LUT initialization logic to choose between the `lut`, `ramp`, and `controlPoints` fields in the initial settings.

## Validation
- Clone and run the project locally.
- Open this link; you should see a similar channel setup to below. http://localhost:9020/viewer?url=https%253A%252F%252Fallencell.s3.amazonaws.com%252Faics%252Fnuc_morph_data%252Fdata_for_analysis%252Fbaseline_colonies%252F20200323_06_mid%252Fraw.ome.zarr%2Chttps%253A%252F%252Fallencell.s3.amazonaws.com%252Faics%252Fnuc_morph_data%252Fdata_for_analysis%252Fbaseline_colonies%252F20200323_06_mid%252Fseg.ome.zarr&mode=volumetric&mask=0&image=cell&axes=0&bb=0&bbcol=ffffff&bgcol=000000&rot=0&bright=70&dens=2.5&interp=1&reg=0%3A1%2C0%3A1%2C0%3A1&slice=0.5%2C0.5%2C0.5&lvl=35%2C140%2C255&t=0&view=Z&c0=ven%3A1%2Csen%3A0%2Cisv%3A128%2Cisa%3A1%2Cclz%3A0%2Ccza%3A1%2Ccol%3Ac3c3c3%2Ccps%3A-26.64179104477612%253A0%253Affffff%252C58.66417910447761%253A0%253A88f739%252C93.65951742627347%253A0.5412371134020619%253A88f739%252C114.85254691689009%253A0.9123711340206185%253Aff0000%252C131.26005361930297%253A0.654639175257732%253A3944f7%252C279.73880597014926%253A1%253Affffff%2Ccpe%3A1%2Crmp%3A58.66417910447761%253A136.7611940298507&c1=ven%3A0%2Csen%3A0%2Cisv%3A128%2Cisa%3A1%2Cclz%3A0%2Ccza%3A1%2Ccol%3A6fba11%2Ccps%3A0%253A0%253Affffff%252C98%253A0%253Affffff%252C115%253A1%253Affffff%252C255%253A1%253Affffff%2Ccpe%3A0%2Crmp%3A98%253A115&c2=ven%3A1%2Csen%3A0%2Cisv%3A128%2Cisa%3A1%2Cclz%3A1%2Ccza%3A1.00%2Ccol%3A8da3c0%2Ccps%3A0%253A0%253Affffff%252C88%253A1%253Affffff%252C144.24932975871315%253A0.41752577319587625%253Affffff%252C255%253A1%253Affffff%2Ccpe%3A0%2Crmp%3A226.2868632707775%253A255

![image](https://github.com/user-attachments/assets/b445578a-2e1d-4380-8f1d-2ee2b5b399e6)

