### PR TITLE
feat: Store and load camera info from the URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.9.1",
       "license": "ISC",
       "dependencies": {
-        "@aics/volume-viewer": "^3.10.0",
+        "@aics/volume-viewer": "^3.11.0",
         "@ant-design/icons": "^5.2.5",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
@@ -102,9 +102,9 @@
       }
     },
     "node_modules/@aics/volume-viewer": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.10.0.tgz",
-      "integrity": "sha512-8eaV1q5gOLpPgC9XkvWAeiYCzkad1Z9AH32C51NuiDKKPtL4SW2VolLMJaa0pgf2mhSpOiEYNih0C6lcXF7ciQ==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.11.0.tgz",
+      "integrity": "sha512-09u1jGFbUeTw5sPUkbQ2NSSIA3FFIpTKaWS0da7ZdR5CsHBRiGjN1Vqgx3DTnhWPNrlylIkZsDOBCYCrvMzPaw==",
       "dependencies": {
         "geotiff": "^2.0.5",
         "serialize-error": "^11.0.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/volume-viewer": "^3.10.0",
+    "@aics/volume-viewer": "^3.11.0",
     "@ant-design/icons": "^5.2.5",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -123,7 +123,7 @@ const defaultViewerSettings: ViewerState = {
   region: { x: [0, 1], y: [0, 1], z: [0, 1] },
   slice: { x: 0.5, y: 0.5, z: 0.5 },
   time: 0,
-  cameraTransform: undefined,
+  cameraState: undefined,
 };
 
 const DEFAULT_CHANNEL_STATE: ChannelState = {
@@ -600,8 +600,8 @@ const App: React.FC<AppProps> = (props) => {
 
   useImageEffect((_currentImage) => {
     // Set camera transform on initial load only
-    if (viewerSettings.cameraTransform) {
-      view3d.setCameraTransform(viewerSettings.cameraTransform);
+    if (viewerSettings.cameraState) {
+      view3d.setCameraState(viewerSettings.cameraState);
     }
   }, []);
 

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -1,8 +1,9 @@
-import type { RawArrayData, RawArrayInfo, Volume } from "@aics/volume-viewer";
+import type { RawArrayData, RawArrayInfo, View3d, Volume } from "@aics/volume-viewer";
 
 import type { MetadataRecord } from "../../shared/types";
 import type { ViewerChannelSettings } from "../../shared/utils/viewerChannelSettings";
 import type { ViewerState } from "../ViewerStateProvider/types";
+import { MutableRefObject } from "react";
 
 /** `typeof useEffect`, but the effect handler takes a `Volume` as an argument */
 export type UseImageEffectType = (effect: (image: Volume) => void | (() => void), deps: React.DependencyList) => void;
@@ -55,6 +56,7 @@ export interface AppProps {
   };
   metadata?: MetadataRecord;
 
+  view3dRef?: MutableRefObject<View3d | null>;
   metadataFormatter?: (metadata: MetadataRecord) => MetadataRecord;
   onControlPanelToggle?: (collapsed: boolean) => void;
 }

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -1,9 +1,9 @@
 import type { RawArrayData, RawArrayInfo, View3d, Volume } from "@aics/volume-viewer";
+import { MutableRefObject } from "react";
 
 import type { MetadataRecord } from "../../shared/types";
 import type { ViewerChannelSettings } from "../../shared/utils/viewerChannelSettings";
 import type { ViewerState } from "../ViewerStateProvider/types";
-import { MutableRefObject } from "react";
 
 /** `typeof useEffect`, but the effect handler takes a `Volume` as an argument */
 export type UseImageEffectType = (effect: (image: Volume) => void | (() => void), deps: React.DependencyList) => void;

--- a/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
+++ b/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
@@ -41,6 +41,7 @@ const DEFAULT_VIEWER_SETTINGS: ViewerState = {
   region: { x: [0, 1], y: [0, 1], z: [0, 1] },
   slice: { x: 0.5, y: 0.5, z: 0.5 },
   time: 0,
+  cameraTransform: undefined,
 };
 
 // Some viewer settings require custom change behaviors to change related settings simultaneously or guard against

--- a/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
+++ b/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
@@ -41,7 +41,7 @@ const DEFAULT_VIEWER_SETTINGS: ViewerState = {
   region: { x: [0, 1], y: [0, 1], z: [0, 1] },
   slice: { x: 0.5, y: 0.5, z: 0.5 },
   time: 0,
-  cameraTransform: undefined,
+  cameraState: undefined,
 };
 
 // Some viewer settings require custom change behaviors to change related settings simultaneously or guard against

--- a/src/aics-image-viewer/components/ViewerStateProvider/types.ts
+++ b/src/aics-image-viewer/components/ViewerStateProvider/types.ts
@@ -1,4 +1,4 @@
-import { CameraTransform, ControlPoint } from "@aics/volume-viewer";
+import { CameraState, ControlPoint } from "@aics/volume-viewer";
 import type { ImageType, RenderMode, ViewMode } from "../../shared/enums";
 import type { PerAxis } from "../../shared/types";
 import type { ColorArray } from "../../shared/utils/colorRepresentations";
@@ -26,7 +26,7 @@ export interface ViewerState {
   // This state is active in x,y,z single slice modes.
   slice: PerAxis<number>;
   time: number;
-  cameraTransform: Partial<CameraTransform> | undefined;
+  cameraState: Partial<CameraState> | undefined;
 }
 
 export type ViewerStateKey = keyof ViewerState;

--- a/src/aics-image-viewer/components/ViewerStateProvider/types.ts
+++ b/src/aics-image-viewer/components/ViewerStateProvider/types.ts
@@ -1,4 +1,4 @@
-import { ControlPoint } from "@aics/volume-viewer";
+import { CameraTransform, ControlPoint } from "@aics/volume-viewer";
 import type { ImageType, RenderMode, ViewMode } from "../../shared/enums";
 import type { PerAxis } from "../../shared/types";
 import type { ColorArray } from "../../shared/utils/colorRepresentations";
@@ -26,6 +26,7 @@ export interface ViewerState {
   // This state is active in x,y,z single slice modes.
   slice: PerAxis<number>;
   time: number;
+  cameraTransform: Partial<CameraTransform> | undefined;
 }
 
 export type ViewerStateKey = keyof ViewerState;

--- a/website/components/AppWrapper.tsx
+++ b/website/components/AppWrapper.tsx
@@ -10,6 +10,7 @@ import { ImageViewerApp, ViewerStateProvider } from "../../src";
 import { ViewerState } from "../../src/aics-image-viewer/components/ViewerStateProvider/types";
 import { AppDataProps } from "../types";
 import { parseViewerUrlParams } from "../utils/url_utils";
+import { View3d } from "@aics/volume-viewer";
 
 const DEFAULT_APP_PROPS: AppDataProps = {
   imageUrl: "",
@@ -37,6 +38,7 @@ export default function AppWrapper(): ReactElement {
   const location = useLocation();
   const navigation = useNavigate();
 
+  const view3dRef = React.useRef<View3d | null>(null);
   const [viewerSettings, setViewerSettings] = useState<Partial<ViewerState>>({});
   const [viewerProps, setViewerProps] = useState<AppDataProps | null>(null);
   const [searchParams] = useSearchParams();
@@ -94,13 +96,18 @@ export default function AppWrapper(): ReactElement {
           <FlexRowAlignCenter $gap={12}>
             <FlexRowAlignCenter $gap={2}>
               <LoadModal onLoad={onLoad} />
-              {viewerProps && <ShareModal appProps={viewerProps} />}
+              {viewerProps && <ShareModal appProps={viewerProps} view3dRef={view3dRef} />}
             </FlexRowAlignCenter>
             <HelpDropdown />
           </FlexRowAlignCenter>
         </Header>
         {viewerProps && (
-          <ImageViewerApp {...viewerProps} appHeight={`calc(100vh - ${HEADER_HEIGHT_PX}px)`} canvasMargin="0 0 0 0" />
+          <ImageViewerApp
+            {...viewerProps}
+            appHeight={`calc(100vh - ${HEADER_HEIGHT_PX}px)`}
+            canvasMargin="0 0 0 0"
+            view3dRef={view3dRef}
+          />
         )}
       </ViewerStateProvider>
     </div>

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -35,8 +35,9 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
   const baseUrl = location.protocol + "//" + location.host + location.pathname;
   const paramProps = {
     ...props,
-    cameraTransform: props.view3dRef?.current?.getCameraTransform(),
+    cameraState: props.view3dRef?.current?.getCameraState(),
   };
+  console.log(paramProps.cameraState);
   let serializedViewerParams = serializeViewerUrlParams(paramProps) as Record<string, string>;
 
   if (props.appProps.imageUrl) {

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -11,9 +11,12 @@ import {
 } from "../../../src/aics-image-viewer/components/ViewerStateProvider";
 import { ViewerStateContextType } from "../../../src/aics-image-viewer/components/ViewerStateProvider/types";
 import { serializeViewerUrlParams } from "../../utils/url_utils";
+import { View3d } from "@aics/volume-viewer";
 
 type ShareModalProps = {
   appProps: AppDataProps;
+  // Used to retrieve the current camera position information
+  view3dRef?: React.RefObject<View3d | null>;
 } & ViewerStateContextType;
 
 const ModalContainer = styled.div``;
@@ -30,7 +33,11 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
 
   // location.pathname will include up to `.../viewer`
   const baseUrl = location.protocol + "//" + location.host + location.pathname;
-  let serializedViewerParams = serializeViewerUrlParams(props) as Record<string, string>;
+  const paramProps = {
+    ...props,
+    cameraTransform: props.view3dRef?.current?.getCameraTransform(),
+  };
+  let serializedViewerParams = serializeViewerUrlParams(paramProps) as Record<string, string>;
 
   if (props.appProps.imageUrl) {
     let serializedUrl;

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -37,7 +37,6 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
     ...props,
     cameraState: props.view3dRef?.current?.getCameraState(),
   };
-  console.log(paramProps.cameraState);
   let serializedViewerParams = serializeViewerUrlParams(paramProps) as Record<string, string>;
 
   if (props.appProps.imageUrl) {

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -376,6 +376,7 @@ describe("Viewer state serialization", () => {
     region: { x: [0, 1], y: [0, 1], z: [0, 1] },
     slice: { x: 0.5, y: 0.5, z: 0.5 },
     time: 0,
+    cameraTransform: undefined,
   };
   const SERIALIZED_DEFAULT_VIEWER_STATE: ViewerStateParams = {
     mode: "volumetric",
@@ -413,6 +414,12 @@ describe("Viewer state serialization", () => {
     region: { x: [0, 0.5], y: [0, 1], z: [0, 1] },
     slice: { x: 0.25, y: 0.75, z: 0.5 },
     time: 100,
+    cameraTransform: {
+      position: [-1, -4, 45],
+      target: [0, 0, 0],
+      rotation: [-56, 14, 6],
+      up: [0, 1, 0],
+    },
   };
   const SERIALIZED_CUSTOM_VIEWER_STATE: ViewerStateParams = {
     mode: "pathtrace",
@@ -431,6 +438,7 @@ describe("Viewer state serialization", () => {
     reg: "0:0.5,0:1,0:1",
     slice: "0.25,0.75,0.5",
     t: "100",
+    cam: "pos:-1%2C-4%2C45,tar:0%2C0%2C0,up:0%2C1%2C0,rot:-56%2C14%2C6",
   };
 
   describe("serializeViewerState", () => {

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -376,7 +376,7 @@ describe("Viewer state serialization", () => {
     region: { x: [0, 1], y: [0, 1], z: [0, 1] },
     slice: { x: 0.5, y: 0.5, z: 0.5 },
     time: 0,
-    cameraTransform: undefined,
+    cameraState: undefined,
   };
   const SERIALIZED_DEFAULT_VIEWER_STATE: ViewerStateParams = {
     mode: "volumetric",
@@ -414,12 +414,12 @@ describe("Viewer state serialization", () => {
     region: { x: [0, 0.5], y: [0, 1], z: [0, 1] },
     slice: { x: 0.25, y: 0.75, z: 0.5 },
     time: 100,
-    cameraTransform: {
+    cameraState: {
       position: [-1.05, -4, 45],
       target: [0, 0, 0],
-      rotation: [-56, 14, 6],
       up: [0, 1, 0],
-      orthoScales: [0.5, 0.002, 3.498],
+      orthoScale: 3.534,
+      fov: 43.5,
     },
   };
   const SERIALIZED_CUSTOM_VIEWER_STATE: ViewerStateParams = {
@@ -439,7 +439,7 @@ describe("Viewer state serialization", () => {
     reg: "0:0.5,0:1,0:1",
     slice: "0.25,0.75,0.5",
     t: "100",
-    cam: "pos:-1.05%2C-4%2C45,tar:0%2C0%2C0,up:0%2C1%2C0,rot:-56%2C14%2C6,ort:0.5%2C0.002%2C3.498",
+    cam: "pos:-1.05%2C-4%2C45,tar:0%2C0%2C0,up:0%2C1%2C0,ort:3.534,fov:43.5",
   };
 
   describe("serializeViewerState", () => {

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -415,10 +415,11 @@ describe("Viewer state serialization", () => {
     slice: { x: 0.25, y: 0.75, z: 0.5 },
     time: 100,
     cameraTransform: {
-      position: [-1, -4, 45],
+      position: [-1.05, -4, 45],
       target: [0, 0, 0],
       rotation: [-56, 14, 6],
       up: [0, 1, 0],
+      orthoScales: [0.5, 0.002, 3.498],
     },
   };
   const SERIALIZED_CUSTOM_VIEWER_STATE: ViewerStateParams = {
@@ -438,7 +439,7 @@ describe("Viewer state serialization", () => {
     reg: "0:0.5,0:1,0:1",
     slice: "0.25,0.75,0.5",
     t: "100",
-    cam: "pos:-1%2C-4%2C45,tar:0%2C0%2C0,up:0%2C1%2C0,rot:-56%2C14%2C6",
+    cam: "pos:-1.05%2C-4%2C45,tar:0%2C0%2C0,up:0%2C1%2C0,rot:-56%2C14%2C6,ort:0.5%2C0.002%2C3.498",
   };
 
   describe("serializeViewerState", () => {

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -450,6 +450,18 @@ describe("Viewer state serialization", () => {
     it("serializes custom viewer settings", () => {
       expect(serializeViewerState(CUSTOM_VIEWER_STATE)).toEqual(SERIALIZED_CUSTOM_VIEWER_STATE);
     });
+
+    it("deserializes partial camera settings", () => {
+      const state: Partial<ViewerState> = {
+        cameraState: {
+          position: [1.0, -1.4, 45],
+          up: [0, 1, 0],
+          fov: 43.5,
+        },
+      };
+      const serializedState = "pos:1%2C-1.4%2C45,up:0%2C1%2C0,fov:43.5";
+      expect(deserializeViewerState({ cam: serializedState })).toEqual(state);
+    });
   });
 
   describe("deserializeViewerState", () => {

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -206,7 +206,8 @@ export class ViewerStateParams {
    * - `up`: up
    * - `rot`: rotation
    *
-   * All values are an array of three floats, separated by commas.
+   * All values are an array of three floats, separated by commas and
+   * encoded using `encodeURIComponent`.
    */
   [ViewerStateKeys.CameraTransform]?: string = undefined;
 }
@@ -428,15 +429,18 @@ function parseStringSlice(region: string | undefined): PerAxis<number> | undefin
   return { x, y, z };
 }
 
+/**
+ * Parses a Vector3-like array of three numbers from a string.
+ */
 function parseThreeNumberArray(
   levels: string | undefined,
-  min?: number,
-  max?: number
+  min: number = -Infinity,
+  max: number = Infinity
 ): [number, number, number] | undefined {
   if (!levels) {
     return undefined;
   }
-  const [low, middle, high] = levels.split(",").map((val) => parseStringFloat(val, min ?? -Infinity, max ?? Infinity));
+  const [low, middle, high] = levels.split(",").map((val) => parseStringFloat(val, min, max));
   if (low === undefined || middle === undefined || high === undefined) {
     return undefined;
   }

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -437,7 +437,7 @@ function parseStringSlice(region: string | undefined): PerAxis<number> | undefin
 }
 
 /**
- * Parses a Vector3-like array of three numbers from a string.
+ * Parses an array of three numbers from a string.
  */
 function parseThreeNumberArray(
   levels: string | undefined,
@@ -484,7 +484,8 @@ function parseCameraTransform(cameraSettings: string | undefined): Partial<Camer
     target: parseThreeNumberArray(parsedCameraSettings[CameraTransformKeys.Target]),
     up: parseThreeNumberArray(parsedCameraSettings[CameraTransformKeys.Up]),
     rotation: parseThreeNumberArray(parsedCameraSettings[CameraTransformKeys.Rotation]),
-    orthoScales: parseThreeNumberArray(parsedCameraSettings[CameraTransformKeys.OrthoScales]),
+    // Orthographic scales cannot be negative
+    orthoScales: parseThreeNumberArray(parsedCameraSettings[CameraTransformKeys.OrthoScales], 0, Infinity),
   };
   return removeUndefinedProperties(result);
 }

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -428,11 +428,15 @@ function parseStringSlice(region: string | undefined): PerAxis<number> | undefin
   return { x, y, z };
 }
 
-function parseThreeNumberArray(levels: string | undefined): [number, number, number] | undefined {
+function parseThreeNumberArray(
+  levels: string | undefined,
+  min?: number,
+  max?: number
+): [number, number, number] | undefined {
   if (!levels) {
     return undefined;
   }
-  const [low, middle, high] = levels.split(",").map((val) => parseStringFloat(val, 0, 255));
+  const [low, middle, high] = levels.split(",").map((val) => parseStringFloat(val, min ?? -Infinity, max ?? Infinity));
   if (low === undefined || middle === undefined || high === undefined) {
     return undefined;
   }
@@ -571,7 +575,7 @@ export function deserializeViewerState(params: ViewerStateParams): Partial<Viewe
     autorotate: parseStringBoolean(params[ViewerStateKeys.Autorotate]),
     brightness: parseStringFloat(params[ViewerStateKeys.Brightness], 0, 100),
     density: parseStringFloat(params[ViewerStateKeys.Density], 0, 100),
-    levels: parseThreeNumberArray(params[ViewerStateKeys.Levels]),
+    levels: parseThreeNumberArray(params[ViewerStateKeys.Levels], 0, 255),
     interpolationEnabled: parseStringBoolean(params[ViewerStateKeys.Interpolation]),
     region: parseStringRegion(params[ViewerStateKeys.Region]),
     slice: parseStringSlice(params[ViewerStateKeys.Slice]),

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -815,8 +815,6 @@ export async function parseViewerUrlParams(urlSearchParams: URLSearchParams): Pr
     args = { ...args, ...datasetArgs };
   }
 
-  console.log("args", args);
-  console.log("viewer settings", viewerSettings);
   return { args: removeUndefinedProperties(args), viewerSettings: removeUndefinedProperties(viewerSettings) };
 }
 

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -62,10 +62,16 @@ export enum ViewerStateKeys {
 }
 
 export enum CameraTransformKeys {
+  /** Camera position in 3D coordinates. */
   Position = "pos",
+  /** Target position of the trackball controls in 3D coordinates. */
   Target = "tar",
+  /** The up vector of the camera. Will be normalized to magnitude of 1. */
   Up = "up",
+  /** Euler rotation in radians. */
   Rotation = "rot",
+  /** Scale factor for the X, Y, and Z orthographic cameras. */
+  OrthoScales = "ort",
 }
 
 /**
@@ -205,6 +211,7 @@ export class ViewerStateParams {
    * - `tar`: target
    * - `up`: up
    * - `rot`: rotation
+   * - `ort`: orthographic scales
    *
    * All values are an array of three floats, separated by commas and
    * encoded using `encodeURIComponent`.
@@ -477,6 +484,7 @@ function parseCameraTransform(cameraSettings: string | undefined): Partial<Camer
     target: parseThreeNumberArray(parsedCameraSettings[CameraTransformKeys.Target]),
     up: parseThreeNumberArray(parsedCameraSettings[CameraTransformKeys.Up]),
     rotation: parseThreeNumberArray(parsedCameraSettings[CameraTransformKeys.Rotation]),
+    orthoScales: parseThreeNumberArray(parsedCameraSettings[CameraTransformKeys.OrthoScales]),
   };
   return removeUndefinedProperties(result);
 }
@@ -487,6 +495,7 @@ function serializeCameraTransform(cameraTransform: CameraTransform): string {
     [CameraTransformKeys.Target]: cameraTransform.target.join(","),
     [CameraTransformKeys.Up]: cameraTransform.up.join(","),
     [CameraTransformKeys.Rotation]: cameraTransform.rotation.join(","),
+    [CameraTransformKeys.OrthoScales]: cameraTransform.orthoScales.join(","),
   });
 }
 


### PR DESCRIPTION
Closes #283, saving the camera position + rotation to the URL.

**Estimated review size: small, 15 minutes*

## Changes
- Updates `url_utils` to support saving and parsing the camera's position, rotation, target position, and up vector to and from the URL.
- Hoists the `view3d` as a ref up to the top-level `AppWrapper`, so that the current camera transform information can be accessed as soon as the user hits the "Share URL" modal.
  - We do this because saving the current camera transform to the `ViewerState` would cause a state update every time we change the camera transform. This is really expensive, and there isn't a simple way to listen for changes to begin with, so it's best to only query the camera transform when we need it.
  
For a camera with the following properties:
```
position: [0, 0, 5]
rotation: [45, -15, 40]
up: [0, 1, 0]
target: [0, 0, 0]
```
The resulting URL parameter format looks like `cam=pos:0%2C0%2C5,rot:45%2C-15%2C40,up:0%2C1%2C0,target:0%2C0%2C0`.

## Keyfiles
- `url_utils.ts`

## Validation

https://github.com/user-attachments/assets/d8a74bf4-0960-4384-ab2e-5a08dd652374


- Clone the `volume-viewer` repository and check out the `feature/camera-getters` branch.
- Clone this branch. Run `npm install --save {relative path to volume-viewer}`.
- Run `npm run start`.
- Open the local viewer and move the volume around.
- Click the **Share** button, copy the URL, and open in another tab. Your view from the first tab should be replicated.