### PR TITLE
Use control point remap function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.9.1",
       "license": "ISC",
       "dependencies": {
-        "@aics/volume-viewer": "^3.9.1",
+        "@aics/volume-viewer": "^3.10.0",
         "@ant-design/icons": "^5.2.5",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
@@ -102,9 +102,9 @@
       }
     },
     "node_modules/@aics/volume-viewer": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.9.1.tgz",
-      "integrity": "sha512-LycOzCicLtZWR84TLTscJnYZEtvoIuC4LISQW5ViKNxiO+jZG4+TND6gTOuCtDaWkMbRB6aGmTWefk3kNsWmbQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.10.0.tgz",
+      "integrity": "sha512-8eaV1q5gOLpPgC9XkvWAeiYCzkad1Z9AH32C51NuiDKKPtL4SW2VolLMJaa0pgf2mhSpOiEYNih0C6lcXF7ciQ==",
       "dependencies": {
         "geotiff": "^2.0.5",
         "serialize-error": "^11.0.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/volume-viewer": "^3.9.1",
+    "@aics/volume-viewer": "^3.10.0",
     "@ant-design/icons": "^5.2.5",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",

--- a/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
+++ b/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
@@ -1,4 +1,4 @@
-import { Channel, ControlPoint, Lut, Volume } from "@aics/volume-viewer";
+import { Channel, ControlPoint, Lut, Volume, remapControlPoints } from "@aics/volume-viewer";
 import { findFirstChannelMatch, ViewerChannelSettings } from "./viewerChannelSettings";
 import { LUT_MAX_PERCENTILE, LUT_MIN_PERCENTILE } from "../constants";
 import { TFEDITOR_DEFAULT_COLOR, TFEDITOR_MAX_BIN } from "../../components/TfEditor";
@@ -100,8 +100,5 @@ export function remapControlPointsForChannel(
     return controlPoints;
   }
 
-  // TODO: this creates a redundant Uint8Array and algorithmically fills it twice. Can we avoid this?
-  const remapLut = new Lut().createFromControlPoints(controlPoints);
-  remapLut.remapDomains(oldRange[0], oldRange[1], rawMin, rawMax);
-  return remapLut.controlPoints;
+  return remapControlPoints(controlPoints, oldRange[0], oldRange[1], rawMin, rawMax);
 }


### PR DESCRIPTION
Review time: tiny (<5min)

#294 introduced the need to remap a set of control points manually, independent of volume-viewer's normal update cycle. Currently, this is accomplished by creating an instance of volume-viewer's `Lut` object and remapping it. This is both unnecessarily verbose and inefficient, since this causes the `Lut` to automatically create a `Uint8Array` and fill it in multiple times with lookup table values that will never be used.

allen-cell-animated/volume-viewer#227 exported the underlying function which `Lut` uses to remap control points. This PR picks up that change.