### PR TITLE
fix: Shorten URLs

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -42,8 +42,8 @@ import {
   CACHE_MAX_SIZE,
   QUEUE_MAX_SIZE,
   QUEUE_MAX_LOW_PRIORITY_SIZE,
-  DEFAULT_VIEWER_SETTINGS,
-  DEFAULT_CHANNEL_STATE,
+  getDefaultChannelState,
+  getDefaultViewerState,
 } from "../../shared/constants";
 import PlayControls from "../../shared/utils/playControls";
 
@@ -111,7 +111,7 @@ const defaultProps: AppProps = {
 
   appHeight: "100vh",
   visibleControls: defaultVisibleControls,
-  viewerSettings: DEFAULT_VIEWER_SETTINGS,
+  viewerSettings: getDefaultViewerState(),
   cellId: "",
   imageDownloadHref: "",
   parentImageDownloadHref: "",
@@ -132,7 +132,7 @@ const initializeOneChannelSetting = (
   index: number,
   defaultColor: ColorArray,
   viewerChannelSettings?: ViewerChannelSettings,
-  defaultChannelState = DEFAULT_CHANNEL_STATE
+  defaultChannelState = getDefaultChannelState()
 ): ChannelState => {
   let initSettings = {} as Partial<ViewerChannelSetting>;
   if (viewerChannelSettings) {

--- a/src/aics-image-viewer/components/ChannelsWidget.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidget.tsx
@@ -12,7 +12,7 @@ import ChannelsWidgetRow from "./ChannelsWidgetRow";
 import SharedCheckBox from "./shared/SharedCheckBox";
 import { connectToViewerState } from "./ViewerStateProvider";
 import type { ChannelSettingUpdater, ChannelState, ChannelStateKey } from "./ViewerStateProvider/types";
-import { DEFAULT_CHANNEL_STATE, PRESET_COLOR_MAP } from "../shared/constants";
+import { getDefaultChannelState, PRESET_COLOR_MAP } from "../shared/constants";
 import { controlPointsToRamp, getDefaultLut } from "../shared/utils/controlPointsToLut";
 
 export type ChannelsWidgetProps = {
@@ -123,7 +123,8 @@ const ChannelsWidget: React.FC<ChannelsWidgetProps> = (props: ChannelsWidgetProp
     if (!channelDataChannels) {
       return;
     }
-    const allChannelStateKeys = Object.keys(DEFAULT_CHANNEL_STATE) as ChannelStateKey[];
+    const defaultChannelState = getDefaultChannelState();
+    const allChannelStateKeys = Object.keys(defaultChannelState) as ChannelStateKey[];
     const excludedKeys: ChannelStateKey[] = ["name", "controlPoints", "ramp", "useControlPoints"];
     const channelStateKeysToReset = allChannelStateKeys.filter((key) => !excludedKeys.includes(key));
 
@@ -142,7 +143,7 @@ const ChannelsWidget: React.FC<ChannelsWidgetProps> = (props: ChannelsWidgetProp
           props.changeChannelSetting(index, key, true);
           continue;
         }
-        props.changeChannelSetting(index, key, DEFAULT_CHANNEL_STATE[key]);
+        props.changeChannelSetting(index, key, defaultChannelState[key]);
       }
     });
 
@@ -152,7 +153,7 @@ const ChannelsWidget: React.FC<ChannelsWidgetProps> = (props: ChannelsWidgetProp
     // the color map length, so we need to reset the colors manually.
     if (channelDataChannels.length > PRESET_COLOR_MAP[0].colors.length) {
       for (let i = PRESET_COLOR_MAP[0].colors.length; i < channelDataChannels.length; i++) {
-        props.changeChannelSetting(i, "color", DEFAULT_CHANNEL_STATE["color"]);
+        props.changeChannelSetting(i, "color", defaultChannelState["color"]);
       }
     }
   };

--- a/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
@@ -4,7 +4,7 @@ import { CheckboxChangeEvent } from "antd/lib/checkbox";
 import { Channel } from "@aics/volume-viewer";
 
 import TfEditor from "../TfEditor";
-import { DEFAULT_CHANNEL_STATE, ISOSURFACE_OPACITY_SLIDER_MAX, PRESET_COLOR_MAP } from "../../shared/constants";
+import { getDefaultChannelState, ISOSURFACE_OPACITY_SLIDER_MAX, PRESET_COLOR_MAP } from "../../shared/constants";
 import ColorPicker from "../ColorPicker";
 import { ColorObject, colorObjectToArray, colorArrayToObject } from "../../shared/utils/colorRepresentations";
 import {
@@ -89,23 +89,24 @@ const ChannelsWidgetRow: React.FC<ChannelsWidgetRowProps> = (props: ChannelsWidg
    * Resets currently visible settings for this channel to their defaults.
    */
   const resetChannelToDefaults = (): void => {
-    // Only modify settings that are currently visible to the user.
+    // Only modify settings that are currently visible to the user.'
+    const defaultChannelState = getDefaultChannelState();
     if (props.channelState.volumeEnabled) {
       const defaultLut = getDefaultLut(props.channelDataForChannel.histogram);
       props.changeChannelSetting(index, "controlPoints", defaultLut.controlPoints);
       props.changeChannelSetting(index, "ramp", controlPointsToRamp(defaultLut.controlPoints));
-      props.changeChannelSetting(index, "useControlPoints", DEFAULT_CHANNEL_STATE.useControlPoints);
+      props.changeChannelSetting(index, "useControlPoints", defaultChannelState.useControlPoints);
 
-      props.changeChannelSetting(index, "colorizeAlpha", DEFAULT_CHANNEL_STATE.colorizeAlpha);
-      props.changeChannelSetting(index, "colorizeEnabled", DEFAULT_CHANNEL_STATE.colorizeEnabled);
+      props.changeChannelSetting(index, "colorizeAlpha", defaultChannelState.colorizeAlpha);
+      props.changeChannelSetting(index, "colorizeEnabled", defaultChannelState.colorizeEnabled);
     }
 
     if (props.channelState.isosurfaceEnabled) {
-      props.changeChannelSetting(index, "isovalue", DEFAULT_CHANNEL_STATE.isovalue);
-      props.changeChannelSetting(index, "opacity", DEFAULT_CHANNEL_STATE.opacity);
+      props.changeChannelSetting(index, "isovalue", defaultChannelState.isovalue);
+      props.changeChannelSetting(index, "opacity", defaultChannelState.opacity);
     }
 
-    props.changeChannelSetting(index, "color", PRESET_COLOR_MAP[0].colors[index] ?? DEFAULT_CHANNEL_STATE.color);
+    props.changeChannelSetting(index, "color", PRESET_COLOR_MAP[0].colors[index] ?? defaultChannelState.color);
   };
 
   const createTFEditor = (): React.ReactNode => {

--- a/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
+++ b/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
@@ -11,7 +11,7 @@ import type {
 } from "./types";
 import { RenderMode, ViewMode } from "../../shared/enums";
 import { ColorArray } from "../../shared/utils/colorRepresentations";
-import { DEFAULT_VIEWER_SETTINGS } from "../../shared/constants";
+import { getDefaultViewerState } from "../../shared/constants";
 
 const isObject = <T,>(val: T): val is Extract<T, Record<string, unknown>> =>
   typeof val === "object" && val !== null && !Array.isArray(val);
@@ -120,7 +120,7 @@ const channelSettingsReducer = <K extends keyof ChannelState>(
 const nullfn = (): void => {};
 
 const DEFAULT_VIEWER_CONTEXT: ViewerStateContextType = {
-  ...DEFAULT_VIEWER_SETTINGS,
+  ...getDefaultViewerState(),
   channelSettings: [],
   changeViewerSetting: nullfn,
   setChannelSettings: nullfn,
@@ -139,7 +139,7 @@ export const ViewerStateContext = React.createContext<{ ref: ContextRefType }>(D
 
 /** Provides a central store for the state of the viewer, and the methods to update it. */
 const ViewerStateProvider: React.FC<{ viewerSettings?: Partial<ViewerState> }> = (props) => {
-  const [viewerSettings, viewerDispatch] = useReducer(viewerSettingsReducer, { ...DEFAULT_VIEWER_SETTINGS });
+  const [viewerSettings, viewerDispatch] = useReducer(viewerSettingsReducer, { ...getDefaultViewerState() });
   const [channelSettings, channelDispatch] = useReducer(channelSettingsReducer, []);
   // Provide viewer state via a ref, so that closures that run asynchronously can capture the ref instead of the
   // specific values they need and always have the most up-to-date state.

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -93,9 +93,6 @@ export const PRESET_COLOR_MAP = Object.freeze([
   },
 ]);
 
-export const ENCODED_COMMA_REGEX = /%2C/g;
-export const ENCODED_COLON_REGEX = /%3A/g;
-
 export const DEFAULT_VIEWER_SETTINGS: ViewerState = {
   viewMode: ViewMode.threeD, // "XY", "XZ", "YZ"
   renderMode: RenderMode.volumetric, // "pathtrace", "maxproject"
@@ -122,6 +119,8 @@ export const DEFAULT_VIEWER_SETTINGS: ViewerState = {
   },
 };
 
+// TODO: Make this and the default viewer settings lambda functions that return
+// new objects to prevent accidental mutation of the default state.
 export const DEFAULT_CHANNEL_STATE: ChannelState = {
   name: "",
   volumeEnabled: false,

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -110,6 +110,7 @@ export const DEFAULT_VIEWER_SETTINGS: ViewerState = {
   region: { x: [0, 1], y: [0, 1], z: [0, 1] },
   slice: { x: 0.5, y: 0.5, z: 0.5 },
   time: 0,
+  cameraState: undefined,
 };
 
 export const DEFAULT_CHANNEL_STATE: ChannelState = {

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -93,6 +93,9 @@ export const PRESET_COLOR_MAP = Object.freeze([
   },
 ]);
 
+export const ENCODED_COMMA_REGEX = /%2C/g;
+export const ENCODED_COLON_REGEX = /%3A/g;
+
 export const DEFAULT_VIEWER_SETTINGS: ViewerState = {
   viewMode: ViewMode.threeD, // "XY", "XZ", "YZ"
   renderMode: RenderMode.volumetric, // "pathtrace", "maxproject"

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -93,7 +93,7 @@ export const PRESET_COLOR_MAP = Object.freeze([
   },
 ]);
 
-export const DEFAULT_VIEWER_SETTINGS: ViewerState = {
+export const getDefaultViewerState = (): ViewerState => ({
   viewMode: ViewMode.threeD, // "XY", "XZ", "YZ"
   renderMode: RenderMode.volumetric, // "pathtrace", "maxproject"
   imageType: ImageType.segmentedCell,
@@ -117,11 +117,11 @@ export const DEFAULT_VIEWER_SETTINGS: ViewerState = {
     fov: 20,
     orthoScale: 0.5,
   },
-};
+});
 
 // TODO: Make this and the default viewer settings lambda functions that return
 // new objects to prevent accidental mutation of the default state.
-export const DEFAULT_CHANNEL_STATE: ChannelState = {
+export const getDefaultChannelState = (): ChannelState => ({
   name: "",
   volumeEnabled: false,
   isosurfaceEnabled: false,
@@ -136,4 +136,4 @@ export const DEFAULT_CHANNEL_STATE: ChannelState = {
     { x: 0, opacity: 0, color: [255, 255, 255] },
     { x: 255, opacity: 1, color: [255, 255, 255] },
   ],
-};
+});

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -110,7 +110,13 @@ export const DEFAULT_VIEWER_SETTINGS: ViewerState = {
   region: { x: [0, 1], y: [0, 1], z: [0, 1] },
   slice: { x: 0.5, y: 0.5, z: 0.5 },
   time: 0,
-  cameraState: undefined,
+  cameraState: {
+    position: [0, 0, 5],
+    target: [0, 0, 0],
+    up: [0, 1, 0],
+    fov: 20,
+    orthoScale: 0.5,
+  },
 };
 
 export const DEFAULT_CHANNEL_STATE: ChannelState = {

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -119,8 +119,6 @@ export const getDefaultViewerState = (): ViewerState => ({
   },
 });
 
-// TODO: Make this and the default viewer settings lambda functions that return
-// new objects to prevent accidental mutation of the default state.
 export const getDefaultChannelState = (): ChannelState => ({
   name: "",
   volumeEnabled: false,

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -50,11 +50,10 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
     serializedViewerParams = { url: serializedUrl, ...serializedViewerParams };
   }
 
-  // TODO: Don't use URLSearchParams here because it will encode commas and colons?
   const params: URLSearchParams = new URLSearchParams(serializedViewerParams);
   let shareUrl = params.size > 0 ? `${baseUrl}?${params.toString()}` : baseUrl;
 
-  // Decode specifically colons and commas
+  // Decode specifically colons and commas for better readability + decreased char count
   shareUrl = shareUrl.replace(ENCODED_COLON_REGEX, ":").replace(ENCODED_COMMA_REGEX, ",");
 
   const onClickCopy = (): void => {

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -37,7 +37,8 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
     ...props,
     cameraState: props.view3dRef?.current?.getCameraState(),
   };
-  let serializedViewerParams = serializeViewerUrlParams(paramProps) as Record<string, string>;
+
+  const urlParams: string[] = [];
 
   if (props.appProps.imageUrl) {
     let serializedUrl;
@@ -46,15 +47,20 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
     } else {
       serializedUrl = encodeURIComponent(props.appProps.imageUrl);
     }
-    // Place URL at front of serialized params
-    serializedViewerParams = { url: serializedUrl, ...serializedViewerParams };
+    urlParams.push(`url=${serializedUrl}`);
   }
 
-  const params: URLSearchParams = new URLSearchParams(serializedViewerParams);
-  let shareUrl = params.size > 0 ? `${baseUrl}?${params.toString()}` : baseUrl;
+  let serializedViewerParams = new URLSearchParams(serializeViewerUrlParams(paramProps) as Record<string, string>);
+  if (serializedViewerParams.size > 0) {
+    // Decode specifically colons and commas for better readability + decreased char count
+    let viewerParamString = serializedViewerParams
+      .toString()
+      .replace(ENCODED_COLON_REGEX, ":")
+      .replace(ENCODED_COMMA_REGEX, ",");
+    urlParams.push(viewerParamString);
+  }
 
-  // Decode specifically colons and commas for better readability + decreased char count
-  shareUrl = shareUrl.replace(ENCODED_COLON_REGEX, ":").replace(ENCODED_COMMA_REGEX, ",");
+  const shareUrl = urlParams.length > 0 ? `${baseUrl}?${urlParams.join("&")}` : baseUrl;
 
   const onClickCopy = (): void => {
     navigator.clipboard.writeText(shareUrl);

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -1,17 +1,18 @@
 import { Button, Input, Modal, notification } from "antd";
+import { ShareAltOutlined } from "@ant-design/icons";
 import React, { useState, useRef } from "react";
 import styled from "styled-components";
+import { View3d } from "@aics/volume-viewer";
 
 import { FlexRow } from "../LandingPage/utils";
 import { AppDataProps } from "../../types";
-import { ShareAltOutlined } from "@ant-design/icons";
 import {
   ALL_VIEWER_STATE_KEYS,
   connectToViewerState,
 } from "../../../src/aics-image-viewer/components/ViewerStateProvider";
 import { ViewerStateContextType } from "../../../src/aics-image-viewer/components/ViewerStateProvider/types";
 import { serializeViewerUrlParams } from "../../utils/url_utils";
-import { View3d } from "@aics/volume-viewer";
+import { ENCODED_COLON_REGEX, ENCODED_COMMA_REGEX } from "../../../src/aics-image-viewer/shared/constants";
 
 type ShareModalProps = {
   appProps: AppDataProps;
@@ -55,7 +56,7 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
   let shareUrl = params.size > 0 ? `${baseUrl}?${params.toString()}` : baseUrl;
 
   // Decode specifically colons and commas
-  shareUrl = shareUrl.replace(/%3A/g, ":").replace(/%2C/g, ",");
+  shareUrl = shareUrl.replace(ENCODED_COLON_REGEX, ":").replace(ENCODED_COMMA_REGEX, ",");
 
   const onClickCopy = (): void => {
     navigator.clipboard.writeText(shareUrl);

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -11,8 +11,7 @@ import {
   connectToViewerState,
 } from "../../../src/aics-image-viewer/components/ViewerStateProvider";
 import { ViewerStateContextType } from "../../../src/aics-image-viewer/components/ViewerStateProvider/types";
-import { serializeViewerUrlParams } from "../../utils/url_utils";
-import { ENCODED_COLON_REGEX, ENCODED_COMMA_REGEX } from "../../../src/aics-image-viewer/shared/constants";
+import { ENCODED_COLON_REGEX, ENCODED_COMMA_REGEX, serializeViewerUrlParams } from "../../utils/url_utils";
 
 type ShareModalProps = {
   appProps: AppDataProps;

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -43,8 +43,13 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
     serializedViewerParams = { url: serializedUrl, ...serializedViewerParams };
   }
 
+  console.log("serializedViewerParams", serializedViewerParams);
+  // TODO: Don't use URLSearchParams here because it will encode commas and colons?
   const params: URLSearchParams = new URLSearchParams(serializedViewerParams);
-  const shareUrl = params.size > 0 ? `${baseUrl}?${params.toString()}` : baseUrl;
+  let shareUrl = params.size > 0 ? `${baseUrl}?${params.toString()}` : baseUrl;
+
+  // Decode specifically colons and commas
+  shareUrl = shareUrl.replace(/%3A/g, ":").replace(/%2C/g, ",");
 
   const onClickCopy = (): void => {
     navigator.clipboard.writeText(shareUrl);

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -43,7 +43,6 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
     serializedViewerParams = { url: serializedUrl, ...serializedViewerParams };
   }
 
-  console.log("serializedViewerParams", serializedViewerParams);
   // TODO: Don't use URLSearchParams here because it will encode commas and colons?
   const params: URLSearchParams = new URLSearchParams(serializedViewerParams);
   let shareUrl = params.size > 0 ? `${baseUrl}?${params.toString()}` : baseUrl;

--- a/website/utils/datatype_utils.ts
+++ b/website/utils/datatype_utils.ts
@@ -1,3 +1,5 @@
+import { isEqual } from "lodash";
+
 /**
  * Returns a (shallow) copy of an object with all properties that are
  * `undefined` removed.
@@ -12,56 +14,6 @@ export function removeUndefinedProperties<T>(obj: T): Partial<T> {
   return result;
 }
 
-function isArrayDeepEqual(a: unknown[], b: unknown[]): boolean {
-  if (!Array.isArray(a) || !Array.isArray(b)) {
-    return false;
-  }
-  if (a.length !== b.length) {
-    return false;
-  }
-
-  return a.every((val, i) => {
-    return isDeepEqual(val, b[i]);
-  });
-}
-
-function isObjectDeepEqual(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
-  if (Object.keys(a).length !== Object.keys(b).length) {
-    return false;
-  }
-  for (const key in a) {
-    if (!isDeepEqual(a[key], b[key])) {
-      return false;
-    }
-  }
-  return true;
-}
-
-/**
- * Recursively checks for deep equality between two elements, including objects or arrays.
- * @returns true if `a` and `b` are deeply equal, false otherwise. Handles NaN values
- * and nested arrays.
- */
-export function isDeepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) {
-    return true;
-  }
-  if (a === null || b === null) {
-    return false;
-  }
-  if (Number.isNaN(a) && Number.isNaN(b)) {
-    return true;
-  }
-  if (typeof a === "object" && typeof b === "object") {
-    if (Array.isArray(a) && Array.isArray(b)) {
-      return isArrayDeepEqual(a, b);
-    } else {
-      return isObjectDeepEqual(a as Record<string, unknown>, b as Record<string, unknown>);
-    }
-  }
-  return false;
-}
-
 /**
  * Returns a copy of `obj` where all properties with values that match the properties of `match`
  * are removed. Matching is determined by deep equality (see `isDeepEqual()`).
@@ -69,7 +21,7 @@ export function isDeepEqual(a: unknown, b: unknown): boolean {
 export function removeMatchingProperties<T extends Object>(obj: Partial<T>, match: T): Partial<T> {
   const result: Partial<T> = {};
   for (const key in obj) {
-    if (!isDeepEqual(obj[key], match[key])) {
+    if (!isEqual(obj[key], match[key])) {
       result[key] = obj[key];
     }
   }

--- a/website/utils/datatype_utils.ts
+++ b/website/utils/datatype_utils.ts
@@ -39,8 +39,6 @@ function isObjectDeepEqual(a: Record<string, unknown>, b: Record<string, unknown
 
 /**
  * Recursively checks for deep equality between two elements, including objects or arrays.
- * @param a
- * @param b
  * @returns true if `a` and `b` are deeply equal, false otherwise. Handles NaN values
  * and nested arrays.
  */
@@ -65,8 +63,8 @@ export function isDeepEqual(a: unknown, b: unknown): boolean {
 }
 
 /**
- * Returns a copy of `obj` where all properties with values that match the properties of `match` are removed.
- * Matching is determined by deep equality (see `isDeepEqual()`).
+ * Returns a copy of `obj` where all properties with values that match the properties of `match`
+ * are removed. Matching is determined by deep equality (see `isDeepEqual()`).
  */
 export function removeMatchingProperties<T extends Object>(obj: Partial<T>, match: T): Partial<T> {
   const result: Partial<T> = {};

--- a/website/utils/datatype_utils.ts
+++ b/website/utils/datatype_utils.ts
@@ -1,0 +1,44 @@
+/**
+ * Returns a (shallow) copy of an object with all properties that are
+ * `undefined` removed.
+ */
+export function removeUndefinedProperties<T>(obj: T): Partial<T> {
+  const result: Partial<T> = {};
+  for (const key in obj) {
+    if (obj[key] !== undefined) {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+}
+
+/**
+ * Returns whether two (1-dimensional) arrays have values that are
+ * strictly equal. Note that this does not handle nested arrays.
+ */
+export function isArrayEqual(a: unknown[], b: unknown[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((val, i) => val === b[i]);
+}
+
+/**
+ * Returns a copy of `obj` where all properties with values that match the properties of `match` are removed.
+ * Equality checks arrays with `isArrayEqual` and values with strict equality. Note that this
+ * equality check will fail for objects.
+ */
+export function removeMatchingProperties<T extends Object>(obj: Partial<T>, match: T): Partial<T> {
+  const result: Partial<T> = {};
+  for (const key in obj) {
+    const valueMatches = obj[key] === match[key];
+    const arrayMatches =
+      Array.isArray(obj[key]) &&
+      Array.isArray(match[key]) &&
+      isArrayEqual(obj[key] as unknown[], match[key] as unknown[]);
+    if (!valueMatches && !arrayMatches) {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+}

--- a/website/utils/datatype_utils.ts
+++ b/website/utils/datatype_utils.ts
@@ -1,5 +1,3 @@
-import { ControlPoint } from "@aics/volume-viewer";
-
 /**
  * Returns a (shallow) copy of an object with all properties that are
  * `undefined` removed.
@@ -14,43 +12,68 @@ export function removeUndefinedProperties<T>(obj: T): Partial<T> {
   return result;
 }
 
-/**
- * Returns whether two (1-dimensional) arrays have values that are
- * strictly equal. Note that this does not handle nested arrays and will only
- * compare objects by reference.
- */
-export function isArrayEqual(a: unknown[], b: unknown[]): boolean {
+function isArrayDeepEqual(a: unknown[], b: unknown[]): boolean {
+  if (!Array.isArray(a) || !Array.isArray(b)) {
+    return false;
+  }
   if (a.length !== b.length) {
     return false;
   }
-  return a.every((val, i) => val === b[i]);
+
+  return a.every((val, i) => {
+    return isDeepEqual(val, b[i]);
+  });
+}
+
+function isObjectDeepEqual(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  if (Object.keys(a).length !== Object.keys(b).length) {
+    return false;
+  }
+  for (const key in a) {
+    if (!isDeepEqual(a[key], b[key])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Recursively checks for deep equality between two elements, including objects or arrays.
+ * @param a
+ * @param b
+ * @returns true if `a` and `b` are deeply equal, false otherwise. Handles NaN values
+ * and nested arrays.
+ */
+export function isDeepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a === null || b === null) {
+    return false;
+  }
+  if (Number.isNaN(a) && Number.isNaN(b)) {
+    return true;
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    if (Array.isArray(a) && Array.isArray(b)) {
+      return isArrayDeepEqual(a, b);
+    } else {
+      return isObjectDeepEqual(a as Record<string, unknown>, b as Record<string, unknown>);
+    }
+  }
+  return false;
 }
 
 /**
  * Returns a copy of `obj` where all properties with values that match the properties of `match` are removed.
- * Equality checks arrays with `isArrayEqual` and values with strict equality. Note that this
- * equality check will fail for objects.
+ * Matching is determined by deep equality (see `isDeepEqual()`).
  */
 export function removeMatchingProperties<T extends Object>(obj: Partial<T>, match: T): Partial<T> {
   const result: Partial<T> = {};
   for (const key in obj) {
-    const valueMatches = obj[key] === match[key];
-    const arrayMatches =
-      Array.isArray(obj[key]) &&
-      Array.isArray(match[key]) &&
-      isArrayEqual(obj[key] as unknown[], match[key] as unknown[]);
-    if (!valueMatches && !arrayMatches) {
+    if (!isDeepEqual(obj[key], match[key])) {
       result[key] = obj[key];
     }
   }
   return result;
-}
-
-export function areControlPointsEqual(a: ControlPoint[], b: ControlPoint[]): boolean {
-  if (a.length !== b.length) {
-    return false;
-  }
-  return a.every((val, i) => {
-    return val.x === b[i].x && val.opacity === b[i].opacity && isArrayEqual(val.color, b[i].color);
-  });
 }

--- a/website/utils/datatype_utils.ts
+++ b/website/utils/datatype_utils.ts
@@ -1,3 +1,5 @@
+import { ControlPoint } from "@aics/volume-viewer";
+
 /**
  * Returns a (shallow) copy of an object with all properties that are
  * `undefined` removed.
@@ -14,7 +16,8 @@ export function removeUndefinedProperties<T>(obj: T): Partial<T> {
 
 /**
  * Returns whether two (1-dimensional) arrays have values that are
- * strictly equal. Note that this does not handle nested arrays.
+ * strictly equal. Note that this does not handle nested arrays and will only
+ * compare objects by reference.
  */
 export function isArrayEqual(a: unknown[], b: unknown[]): boolean {
   if (a.length !== b.length) {
@@ -41,4 +44,13 @@ export function removeMatchingProperties<T extends Object>(obj: Partial<T>, matc
     }
   }
   return result;
+}
+
+export function areControlPointsEqual(a: ControlPoint[], b: ControlPoint[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((val, i) => {
+    return val.x === b[i].x && val.opacity === b[i].opacity && isArrayEqual(val.color, b[i].color);
+  });
 }

--- a/website/utils/test/datatype_utils.test.ts
+++ b/website/utils/test/datatype_utils.test.ts
@@ -20,6 +20,11 @@ describe("isDeepEqual", () => {
     expect(isDeepEqual(NaN, 1)).toBe(false);
   });
 
+  it("handles undefined and null", () => {
+    expect(isDeepEqual(undefined, undefined)).toBe(true);
+    expect(isDeepEqual(null, null)).toBe(true);
+  });
+
   it("handles empty object", () => {
     expect(isDeepEqual({}, {})).toBe(true);
   });

--- a/website/utils/test/datatype_utils.test.ts
+++ b/website/utils/test/datatype_utils.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "@jest/globals";
+import { isDeepEqual } from "../datatype_utils";
+import { ControlPoint } from "@aics/volume-viewer";
+
+describe("isDeepEqual", () => {
+  it("handles primitive types", () => {
+    expect(isDeepEqual(1, 1)).toBe(true);
+    expect(isDeepEqual(1, 2)).toBe(false);
+
+    expect(isDeepEqual("a", "a")).toBe(true);
+    expect(isDeepEqual("a", "b")).toBe(false);
+
+    expect(isDeepEqual(true, true)).toBe(true);
+    expect(isDeepEqual(true, false)).toBe(false);
+    expect(isDeepEqual(false, false)).toBe(true);
+  });
+
+  it("handles NaN", () => {
+    expect(isDeepEqual(NaN, NaN)).toBe(true);
+    expect(isDeepEqual(NaN, 1)).toBe(false);
+  });
+
+  it("handles empty object", () => {
+    expect(isDeepEqual({}, {})).toBe(true);
+  });
+
+  it("handles 1D arrays", () => {
+    expect(isDeepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(isDeepEqual([1, 2, 3], [4, 5, 6])).toBe(false);
+  });
+
+  it("handles null and undefined comparison with objects", () => {
+    expect(isDeepEqual({}, null)).toBe(false);
+    expect(isDeepEqual(null, {})).toBe(false);
+    expect(isDeepEqual({}, undefined)).toBe(false);
+    expect(isDeepEqual(undefined, {})).toBe(false);
+  });
+
+  it("handles null and undefined comparison with arrays", () => {
+    expect(isDeepEqual([], null)).toBe(false);
+    expect(isDeepEqual(null, [])).toBe(false);
+    expect(isDeepEqual([], undefined)).toBe(false);
+    expect(isDeepEqual(undefined, [])).toBe(false);
+  });
+
+  it("handles nested arrays", () => {
+    const a = [1, [1, 2], [1, 2, [3]]];
+    let b = [1, [1, 2], [1, 2, [3]]];
+    expect(isDeepEqual(a, b)).toBe(true);
+
+    b = [1, [1, 2], [1, 2, [4]]];
+    expect(isDeepEqual(a, b)).toBe(false);
+  });
+
+  it("handles basic object comparison", () => {
+    const getObject = (): Record<string, unknown> => ({ a: 1, b: true, c: undefined, d: null, e: NaN, f: "something" });
+    const a = getObject();
+    let b = getObject();
+    expect(isDeepEqual(a, b)).toBe(true);
+
+    b = { ...getObject(), a: 2 };
+    expect(isDeepEqual(a, b)).toBe(false);
+  });
+
+  it("handles objects with array properties", () => {
+    const getObject = (): { a: number; b: number; c: number[] } => ({ a: 1, b: 0.24, c: [1, 2, 3] });
+    const a = getObject();
+    let b = getObject();
+    expect(isDeepEqual(a, b)).toBe(true);
+
+    b = { ...getObject(), c: [1, 2, 4] };
+    expect(isDeepEqual(a, b)).toBe(false);
+  });
+
+  it("handles arrays of objects", () => {
+    const getObject = (): ControlPoint[] => {
+      return [
+        { x: 1, opacity: 1, color: [255, 255, 255] },
+        { x: 2, opacity: 1, color: [128, 128, 255] },
+        { x: 3, opacity: 0.5, color: [0, 255, 0] },
+      ];
+    };
+    const a = getObject();
+    let b = getObject();
+    expect(isDeepEqual(a, b)).toBe(true);
+
+    b = [
+      { x: 1, opacity: 1, color: [255, 255, 255] },
+      { x: 50, opacity: 4.7, color: [128, 128, 255] },
+      { x: 128, opacity: 0.5, color: [0, 255, 1] },
+    ];
+    expect(isDeepEqual(a, b)).toBe(false);
+  });
+});

--- a/website/utils/test/datatype_utils.test.ts
+++ b/website/utils/test/datatype_utils.test.ts
@@ -1,83 +1,9 @@
 import { describe, expect, it } from "@jest/globals";
-import { isDeepEqual } from "../datatype_utils";
 import { ControlPoint } from "@aics/volume-viewer";
+import { isEqual } from "lodash";
 
-describe("isDeepEqual", () => {
-  it("handles primitive types", () => {
-    expect(isDeepEqual(1, 1)).toBe(true);
-    expect(isDeepEqual(1, 2)).toBe(false);
-
-    expect(isDeepEqual("a", "a")).toBe(true);
-    expect(isDeepEqual("a", "b")).toBe(false);
-
-    expect(isDeepEqual(true, true)).toBe(true);
-    expect(isDeepEqual(true, false)).toBe(false);
-    expect(isDeepEqual(false, false)).toBe(true);
-  });
-
-  it("handles NaN", () => {
-    expect(isDeepEqual(NaN, NaN)).toBe(true);
-    expect(isDeepEqual(NaN, 1)).toBe(false);
-  });
-
-  it("handles undefined and null", () => {
-    expect(isDeepEqual(undefined, undefined)).toBe(true);
-    expect(isDeepEqual(null, null)).toBe(true);
-  });
-
-  it("handles empty object", () => {
-    expect(isDeepEqual({}, {})).toBe(true);
-  });
-
-  it("handles 1D arrays", () => {
-    expect(isDeepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
-    expect(isDeepEqual([1, 2, 3], [4, 5, 6])).toBe(false);
-  });
-
-  it("handles null and undefined comparison with objects", () => {
-    expect(isDeepEqual({}, null)).toBe(false);
-    expect(isDeepEqual(null, {})).toBe(false);
-    expect(isDeepEqual({}, undefined)).toBe(false);
-    expect(isDeepEqual(undefined, {})).toBe(false);
-  });
-
-  it("handles null and undefined comparison with arrays", () => {
-    expect(isDeepEqual([], null)).toBe(false);
-    expect(isDeepEqual(null, [])).toBe(false);
-    expect(isDeepEqual([], undefined)).toBe(false);
-    expect(isDeepEqual(undefined, [])).toBe(false);
-  });
-
-  it("handles nested arrays", () => {
-    const a = [1, [1, 2], [1, 2, [3]]];
-    let b = [1, [1, 2], [1, 2, [3]]];
-    expect(isDeepEqual(a, b)).toBe(true);
-
-    b = [1, [1, 2], [1, 2, [4]]];
-    expect(isDeepEqual(a, b)).toBe(false);
-  });
-
-  it("handles basic object comparison", () => {
-    const getObject = (): Record<string, unknown> => ({ a: 1, b: true, c: undefined, d: null, e: NaN, f: "something" });
-    const a = getObject();
-    let b = getObject();
-    expect(isDeepEqual(a, b)).toBe(true);
-
-    b = { ...getObject(), a: 2 };
-    expect(isDeepEqual(a, b)).toBe(false);
-  });
-
-  it("handles objects with array properties", () => {
-    const getObject = (): { a: number; b: number; c: number[] } => ({ a: 1, b: 0.24, c: [1, 2, 3] });
-    const a = getObject();
-    let b = getObject();
-    expect(isDeepEqual(a, b)).toBe(true);
-
-    b = { ...getObject(), c: [1, 2, 4] };
-    expect(isDeepEqual(a, b)).toBe(false);
-  });
-
-  it("handles arrays of objects", () => {
+describe("isEqual", () => {
+  it("can determine equality for control points", () => {
     const getObject = (): ControlPoint[] => {
       return [
         { x: 1, opacity: 1, color: [255, 255, 255] },
@@ -87,13 +13,17 @@ describe("isDeepEqual", () => {
     };
     const a = getObject();
     let b = getObject();
-    expect(isDeepEqual(a, b)).toBe(true);
+    expect(isEqual(a, b)).toBe(true);
 
     b = [
       { x: 1, opacity: 1, color: [255, 255, 255] },
       { x: 50, opacity: 4.7, color: [128, 128, 255] },
       { x: 128, opacity: 0.5, color: [0, 255, 1] },
     ];
-    expect(isDeepEqual(a, b)).toBe(false);
+    expect(isEqual(a, b)).toBe(false);
+
+    const c = getObject();
+    c[2].color = [0, 255, 1];
+    expect(isEqual(a, c)).toBe(false);
   });
 });

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -822,17 +822,17 @@ describe("serializeViewerUrlParams", () => {
     expect(urlParams.toString()).toEqual("c0=" + expectedEncodedParams);
   });
 
-  // it("does not use object reference comparison on control points when excluding defaults", () => {
-  //   // Expand control points so it isn't comparing an object reference
-  //   const customChannelState: Partial<ChannelState> = {
-  //     controlPoints: [{ ...DEFAULT_CHANNEL_STATE.controlPoints[0] }, { ...DEFAULT_CHANNEL_STATE.controlPoints[1] }],
-  //   };
+  it("does not use object reference comparison on control points when excluding defaults", () => {
+    // Expand control points so it isn't comparing an object reference
+    const customChannelState: Partial<ChannelState> = {
+      controlPoints: [{ ...DEFAULT_CHANNEL_STATE.controlPoints[0] }, { ...DEFAULT_CHANNEL_STATE.controlPoints[1] }],
+    };
 
-  //   const serializedParams = serializeViewerUrlParams(
-  //     { ...DEFAULT_VIEWER_SETTINGS, channelSettings: [{ ...DEFAULT_CHANNEL_STATE, ...customChannelState }] },
-  //     true
-  //   ) as Record<string, string>;
-  //   const urlParams = new URLSearchParams(serializedParams);
-  //   expect(urlParams.toString()).toEqual("c0=");
-  // });
+    const serializedParams = serializeViewerUrlParams(
+      { ...DEFAULT_VIEWER_SETTINGS, channelSettings: [{ ...DEFAULT_CHANNEL_STATE, ...customChannelState }] },
+      true
+    ) as Record<string, string>;
+    const urlParams = new URLSearchParams(serializedParams);
+    expect(urlParams.toString()).toEqual("c0=");
+  });
 });

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -20,6 +20,7 @@ import {
 import { ChannelState, ViewerState } from "../../../src/aics-image-viewer/components/ViewerStateProvider/types";
 import { ImageType, RenderMode, ViewMode } from "../../../src/aics-image-viewer/shared/enums";
 import { ViewerChannelSetting } from "../../../src/aics-image-viewer/shared/utils/viewerChannelSettings";
+import { DEFAULT_VIEWER_SETTINGS } from "../../../src/aics-image-viewer/shared/constants";
 
 const defaultSettings: ViewerChannelSetting = {
   match: 0,
@@ -457,7 +458,7 @@ describe("Viewer state serialization", () => {
     reg: "0:0.5,0:1,0:1",
     slice: "0.25,0.75,0.5",
     t: "100",
-    cam: "pos:-1.05%2C-4%2C45,tar:0%2C0%2C0,up:0%2C1%2C0,ort:3.534,fov:43.5",
+    cam: "pos:-1.05:-4:45,tar:0:0:0,up:0:1:0,ort:3.534,fov:43.5",
   };
 
   describe("serializeViewerState", () => {
@@ -477,7 +478,7 @@ describe("Viewer state serialization", () => {
           fov: 43.5,
         },
       };
-      const serializedState = "pos:1%2C-1.4%2C45,up:0%2C1%2C0,fov:43.5";
+      const serializedState = "pos:1:-1.4:45,up:0:1:0,fov:43.5";
       expect(deserializeViewerState({ cam: serializedState })).toEqual(state);
     });
   });
@@ -688,28 +689,6 @@ describe("parseViewerUrlParams", () => {
     expect(channelSettings.channels[2].colorizeEnabled).toEqual(true);
   });
 
-  it("parses encoded colons and commas", async () => {
-    const queryString = "c0=ven%3A0&c1=ven%3A1%2Clut%3Aautoij%3A&c2=ven%3A1%2Cclz%3A1";
-    const params = new URLSearchParams(queryString);
-    const { args, viewerSettings } = await parseViewerUrlParams(params);
-
-    // Check that channel settings have been loaded in.
-    // Should be one group with three channels.
-    let channelSettings = args.viewerChannelSettings?.groups[0];
-    expect(channelSettings).toBeDefined();
-    channelSettings = channelSettings!;
-
-    expect(channelSettings.channels).toHaveLength(3);
-    expect(channelSettings.channels[0].match).toEqual(0);
-    expect(channelSettings.channels[0].enabled).toEqual(false);
-    expect(channelSettings.channels[1].match).toEqual(1);
-    expect(channelSettings.channels[1].enabled).toEqual(true);
-    expect(channelSettings.channels[1].lut).toEqual(["autoij", ""]);
-    expect(channelSettings.channels[2].match).toEqual(2);
-    expect(channelSettings.channels[2].enabled).toEqual(true);
-    expect(channelSettings.channels[2].colorizeEnabled).toEqual(true);
-  });
-
   it("parses viewer settings", async () => {
     const queryString = "mask=30&view=X";
     const params = new URLSearchParams(queryString);
@@ -803,4 +782,26 @@ describe("serializeViewerUrlParams", () => {
     expect(serialized["c1"]).toBeDefined();
     expect(parseKeyValueList(serialized["c1"]!)).toEqual(expectedChannel1);
   });
+
+  // it("can remove viewer settings that match the default", () => {
+  //   const customViewerState: Partial<ViewerState> = {
+  //     viewMode: ViewMode.xy,
+  //     density: 100,
+  //     time: 40,
+  //     cameraState: {
+  //       position: [1.2, 3.4, 5.6],
+  //     },
+  //   };
+
+  //   const serializedParams = serializeViewerUrlParams(
+  //     { ...DEFAULT_VIEWER_SETTINGS, ...customViewerState },
+  //     true
+  //   ) as Record<string, string>;
+  //   const urlParams = new URLSearchParams(serializedParams);
+  //   expect(urlParams.toString()).toEqual("dens=100,t=40,cam=pos:1.2%2C3.4%2C5.6");
+  // });
+
+  // it("can remove channel state that matches the default", () => {
+  //   throw new Error("Test not implemented");
+  // });
 });

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -688,9 +688,28 @@ describe("parseViewerUrlParams", () => {
     expect(channelSettings.channels[2].colorizeEnabled).toEqual(true);
   });
 
-  // Test existing viewer settings as a regression test
-  // TODO: Replace this with a full integration test, testing serializing + deserializing all viewer state
-  // when URLs are fully implemented.
+  it("parses encoded colons and commas", async () => {
+    const queryString = "c0=ven%3A0&c1=ven%3A1%2Clut%3Aautoij%3A&c2=ven%3A1%2Cclz%3A1";
+    const params = new URLSearchParams(queryString);
+    const { args, viewerSettings } = await parseViewerUrlParams(params);
+
+    // Check that channel settings have been loaded in.
+    // Should be one group with three channels.
+    let channelSettings = args.viewerChannelSettings?.groups[0];
+    expect(channelSettings).toBeDefined();
+    channelSettings = channelSettings!;
+
+    expect(channelSettings.channels).toHaveLength(3);
+    expect(channelSettings.channels[0].match).toEqual(0);
+    expect(channelSettings.channels[0].enabled).toEqual(false);
+    expect(channelSettings.channels[1].match).toEqual(1);
+    expect(channelSettings.channels[1].enabled).toEqual(true);
+    expect(channelSettings.channels[1].lut).toEqual(["autoij", ""]);
+    expect(channelSettings.channels[2].match).toEqual(2);
+    expect(channelSettings.channels[2].enabled).toEqual(true);
+    expect(channelSettings.channels[2].colorizeEnabled).toEqual(true);
+  });
+
   it("parses viewer settings", async () => {
     const queryString = "mask=30&view=X";
     const params = new URLSearchParams(queryString);

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -20,7 +20,7 @@ import {
 import { ChannelState, ViewerState } from "../../../src/aics-image-viewer/components/ViewerStateProvider/types";
 import { ImageType, RenderMode, ViewMode } from "../../../src/aics-image-viewer/shared/enums";
 import { ViewerChannelSetting } from "../../../src/aics-image-viewer/shared/utils/viewerChannelSettings";
-import { DEFAULT_CHANNEL_STATE, DEFAULT_VIEWER_SETTINGS } from "../../../src/aics-image-viewer/shared/constants";
+import { getDefaultChannelState, getDefaultViewerState } from "../../../src/aics-image-viewer/shared/constants";
 
 const defaultSettings: ViewerChannelSetting = {
   match: 0,
@@ -391,7 +391,6 @@ describe("Channel state serialization", () => {
 });
 
 describe("Viewer state serialization", () => {
-  // Copy of DEFAULT_VIEWER_SETTINGS.
   const DEFAULT_VIEWER_STATE: ViewerState = {
     viewMode: ViewMode.threeD, // "XY", "XZ", "YZ"
     renderMode: RenderMode.volumetric, // "pathtrace", "maxproject"
@@ -833,19 +832,20 @@ describe("serializeViewerUrlParams", () => {
   });
 
   it("can remove viewer settings that match the default", () => {
+    const defaultViewerSettings = getDefaultViewerState();
     const customViewerState: Partial<ViewerState> = {
       viewMode: ViewMode.xy,
       density: 100,
       time: 40,
       cameraState: {
         position: [1.2, 3.4, 5.6],
-        target: DEFAULT_VIEWER_SETTINGS.cameraState?.target,
-        up: DEFAULT_VIEWER_SETTINGS.cameraState?.up,
+        target: defaultViewerSettings.cameraState?.target,
+        up: defaultViewerSettings.cameraState?.up,
       },
     };
 
     const serializedParams = serializeViewerUrlParams(
-      { ...DEFAULT_VIEWER_SETTINGS, ...customViewerState },
+      { ...defaultViewerSettings, ...customViewerState },
       true
     ) as Record<string, string>;
     const urlParams = new URLSearchParams(serializedParams);
@@ -862,7 +862,7 @@ describe("serializeViewerUrlParams", () => {
       isovalue: 49,
     };
     const serializedParams = serializeViewerUrlParams(
-      { ...DEFAULT_VIEWER_SETTINGS, channelSettings: [{ ...DEFAULT_CHANNEL_STATE, ...customChannelState }] },
+      { ...getDefaultViewerState(), channelSettings: [{ ...getDefaultChannelState(), ...customChannelState }] },
       true
     ) as Record<string, string>;
     const urlParams = new URLSearchParams(serializedParams);
@@ -873,12 +873,13 @@ describe("serializeViewerUrlParams", () => {
 
   it("does not use object reference comparison on control points when excluding defaults", () => {
     // Expand control points so it isn't comparing an object reference
+    const defaultChannelState = getDefaultChannelState();
     const customChannelState: Partial<ChannelState> = {
-      controlPoints: [{ ...DEFAULT_CHANNEL_STATE.controlPoints[0] }, { ...DEFAULT_CHANNEL_STATE.controlPoints[1] }],
+      controlPoints: [{ ...defaultChannelState.controlPoints[0] }, { ...defaultChannelState.controlPoints[1] }],
     };
 
     const serializedParams = serializeViewerUrlParams(
-      { ...DEFAULT_VIEWER_SETTINGS, channelSettings: [{ ...DEFAULT_CHANNEL_STATE, ...customChannelState }] },
+      { ...getDefaultViewerState(), channelSettings: [{ ...defaultChannelState, ...customChannelState }] },
       true
     ) as Record<string, string>;
     const urlParams = new URLSearchParams(serializedParams);

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -516,11 +516,37 @@ describe("Viewer state serialization", () => {
   });
 });
 
+//// DESERIALIZE STATES ///////////////////////
+
+describe("Channel state deserialization", () => {
+  const DEFAULT_CONTROL_POINTS = [
+    { x: -10, opacity: 0, color: [0, 0, 0] },
+    { x: 50, opacity: 0, color: [0, 0, 0] },
+    { x: 100, opacity: 0.3, color: [0, 16, 255] },
+    { x: 140, opacity: 0.8, color: [0, 255, 255] },
+    { x: 260, opacity: 1, color: [0, 255, 180] },
+  ];
+
+  it("parses comma-separated control points", () => {
+    const result = deserializeViewerChannelSetting(0, {
+      cps: "-10:0:000000,50:0:000000,100:0.3:0010ff,140:0.8:00ffff,260:1:00ffb4",
+    });
+    expect(result.controlPoints).toEqual(DEFAULT_CONTROL_POINTS);
+  });
+
+  it("parses colon-separated control points", () => {
+    const result = deserializeViewerChannelSetting(0, {
+      cps: "-10:0:000000:50:0:000000:100:0.3:0010ff:140:0.8:00ffff:260:1:00ffb4",
+    });
+    expect(result.controlPoints).toEqual(DEFAULT_CONTROL_POINTS);
+  });
+});
+
 //// URL parsing /////////////////////////////////
 
 describe("parseViewerUrlParams", () => {
   // Tests will try parsing both unencoded and encoded URL params.
-  const channelParamToSetting: [string, string, ViewerChannelSetting][] = [
+  const channelParamToSetting: [string, string, Partial<ViewerChannelSetting>][] = [
     [
       "c3=ven:1,col:ff00ff,clz:0,cza:0.9,isa:0.4,lut:p50:p99,sen:1,isv:129",
       "c3=ven%3A1%2Ccol%3Aff00ff%2Cclz%3A0%2Ccza%3A0.9%2Cisa%3A0.4%2Clut%3Ap50%3Ap99%2Csen%3A1%2Cisv%3A129",
@@ -763,7 +789,6 @@ describe("serializeViewerUrlParams", () => {
       cps: "0:0:808080:1:1:ff0000",
       cpe: "0",
     };
-    // TODO: Check that this can handle control points (cps) with comma separators.
     const expectedChannel1: Required<Omit<ViewerChannelSettingParams, "lut">> = {
       ven: "0",
       col: "808080",

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -52,7 +52,7 @@ describe("LEGACY_CONTROL_POINTS_REGEX", () => {
   });
 
   it("allows 'w' as a placeholder for color strings", () => {
-    const data = "1:0.5:w,255:1:w";
+    const data = "1:0.5:1,255:1:1";
     expect(LEGACY_CONTROL_POINTS_REGEX.test(data)).toBe(true);
   });
 });
@@ -74,7 +74,7 @@ describe("CONTROL_POINTS_REGEX", () => {
   });
 
   it("allows empty color strings", () => {
-    const data = "1:0.5:w:255:1:w";
+    const data = "1:0.5:1:255:1:1";
     expect(CONTROL_POINTS_REGEX.test(data)).toBe(true);
   });
 });
@@ -144,8 +144,8 @@ describe("parseHexColorAsColorArray", () => {
     expect(parseHexColorAsColorArray("hjklmn")).toBeUndefined();
   });
 
-  it("parses the 'w' code for white", () => {
-    expect(parseHexColorAsColorArray("w")).toEqual([255, 255, 255]);
+  it("parses the '1' code as white", () => {
+    expect(parseHexColorAsColorArray("1")).toEqual([255, 255, 255]);
   });
 });
 
@@ -249,7 +249,7 @@ describe("Channel state serialization", () => {
     clz: "1",
     cza: "0.5",
     cpe: "0",
-    cps: "0:0.5:w:255:1:w",
+    cps: "0:0.5:1:255:1:1",
     rmp: "0:255",
   };
 
@@ -555,9 +555,9 @@ describe("Channel state deserialization", () => {
     expect(result.controlPoints).toEqual(DEFAULT_CONTROL_POINTS);
   });
 
-  it("replaces empty color strings with default color #ffffff", () => {
+  it("replaces '1' color strings with default color #ffffff", () => {
     const result = deserializeViewerChannelSetting(0, {
-      cps: "0:0:w:50:1:w",
+      cps: "0:0:1:50:1:1",
     });
     expect(result.controlPoints).toEqual([
       { x: 0, opacity: 0, color: [255, 255, 255] },

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -51,8 +51,8 @@ describe("LEGACY_CONTROL_POINTS_REGEX", () => {
     expect(LEGACY_CONTROL_POINTS_REGEX.test(data)).toBe(true);
   });
 
-  it("allows empty color strings", () => {
-    const data = "1:0.5:,255:1:";
+  it("allows 'w' as a placeholder for color strings", () => {
+    const data = "1:0.5:w,255:1:w";
     expect(LEGACY_CONTROL_POINTS_REGEX.test(data)).toBe(true);
   });
 });
@@ -74,7 +74,7 @@ describe("CONTROL_POINTS_REGEX", () => {
   });
 
   it("allows empty color strings", () => {
-    const data = "1:0.5::255:1:";
+    const data = "1:0.5:w:255:1:w";
     expect(CONTROL_POINTS_REGEX.test(data)).toBe(true);
   });
 });
@@ -142,6 +142,10 @@ describe("parseHexColorAsColorArray", () => {
     expect(parseHexColorAsColorArray("fff")).toBeUndefined();
     expect(parseHexColorAsColorArray("fffffff")).toBeUndefined();
     expect(parseHexColorAsColorArray("hjklmn")).toBeUndefined();
+  });
+
+  it("parses the 'w' code for white", () => {
+    expect(parseHexColorAsColorArray("w")).toEqual([255, 255, 255]);
   });
 });
 
@@ -245,7 +249,7 @@ describe("Channel state serialization", () => {
     clz: "1",
     cza: "0.5",
     cpe: "0",
-    cps: "0:0.5::255:1:",
+    cps: "0:0.5:w:255:1:w",
     rmp: "0:255",
   };
 
@@ -553,7 +557,7 @@ describe("Channel state deserialization", () => {
 
   it("replaces empty color strings with default color #ffffff", () => {
     const result = deserializeViewerChannelSetting(0, {
-      cps: "0:0::50:1:",
+      cps: "0:0:w:50:1:w",
     });
     expect(result.controlPoints).toEqual([
       { x: 0, opacity: 0, color: [255, 255, 255] },

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -744,6 +744,7 @@ describe("serializeViewerUrlParams", () => {
       cps: "0:0:808080:1:1:ff0000",
       cpe: "0",
     };
+    // TODO: Check that this can handle control points (cps) with comma separators.
     const expectedChannel1: Required<Omit<ViewerChannelSettingParams, "lut">> = {
       ven: "0",
       col: "808080",
@@ -753,7 +754,7 @@ describe("serializeViewerUrlParams", () => {
       sen: "0",
       isv: "57",
       rmp: "50:140",
-      cps: "-10:0:000000,50:0:000000,100:0.3:0010ff,140:0.8:00ffff,260:1:00ffb4",
+      cps: "-10:0:000000:50:0:000000:100:0.3:0010ff:140:0.8:00ffff:260:1:00ffb4",
       cpe: "1",
     };
 

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -50,6 +50,11 @@ describe("LEGACY_CONTROL_POINTS_REGEX", () => {
     const data = "-1:0.5:ff0000,-255:1:ff0000";
     expect(LEGACY_CONTROL_POINTS_REGEX.test(data)).toBe(true);
   });
+
+  it("allows empty color strings", () => {
+    const data = "1:0.5:,255:1:";
+    expect(LEGACY_CONTROL_POINTS_REGEX.test(data)).toBe(true);
+  });
 });
 
 describe("CONTROL_POINTS_REGEX", () => {
@@ -65,6 +70,11 @@ describe("CONTROL_POINTS_REGEX", () => {
 
   it("accepts negative numbers", () => {
     const data = "-1:0.5:ff0000:-255:1:ff0000";
+    expect(CONTROL_POINTS_REGEX.test(data)).toBe(true);
+  });
+
+  it("allows empty color strings", () => {
+    const data = "1:0.5::255:1:";
     expect(CONTROL_POINTS_REGEX.test(data)).toBe(true);
   });
 });
@@ -539,6 +549,16 @@ describe("Channel state deserialization", () => {
       cps: "-10:0:000000:50:0:000000:100:0.3:0010ff:140:0.8:00ffff:260:1:00ffb4",
     });
     expect(result.controlPoints).toEqual(DEFAULT_CONTROL_POINTS);
+  });
+
+  it("replaces empty color strings with default color #ffffff", () => {
+    const result = deserializeViewerChannelSetting(0, {
+      cps: "0:0::50:1:",
+    });
+    expect(result.controlPoints).toEqual([
+      { x: 0, opacity: 0, color: [255, 255, 255] },
+      { x: 50, opacity: 1, color: [255, 255, 255] },
+    ]);
   });
 });
 

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -16,12 +16,7 @@ import { ColorArray } from "../../src/aics-image-viewer/shared/utils/colorRepres
 import { PerAxis } from "../../src/aics-image-viewer/shared/types";
 import { clamp } from "./math_utils";
 import { DEFAULT_CHANNEL_STATE, DEFAULT_VIEWER_SETTINGS } from "../../src/aics-image-viewer/shared/constants";
-import {
-  removeMatchingProperties,
-  isArrayEqual,
-  removeUndefinedProperties,
-  areControlPointsEqual,
-} from "./datatype_utils";
+import { removeMatchingProperties, removeUndefinedProperties, isDeepEqual } from "./datatype_utils";
 
 export const ENCODED_COMMA_REGEX = /%2C/g;
 export const ENCODED_COLON_REGEX = /%3A/g;
@@ -551,7 +546,7 @@ function serializeControlPoints(controlPoints: ControlPoint[]): string {
       const x = formatFloat(cp.x);
       const opacity = formatFloat(cp.opacity);
       // Default color is empty string
-      const color = isArrayEqual(cp.color, DEFAULT_CONTROL_POINT_COLOR) ? "" : colorArrayToHex(cp.color);
+      const color = isDeepEqual(cp.color, DEFAULT_CONTROL_POINT_COLOR) ? "" : colorArrayToHex(cp.color);
       return `${x}:${opacity}:${color}`;
     })
     .join(":");
@@ -644,12 +639,6 @@ export function serializeViewerChannelSetting(
 ): Partial<ViewerChannelSettingParams> {
   if (removeDefaults) {
     channelSetting = removeMatchingProperties(channelSetting, DEFAULT_CHANNEL_STATE);
-    // NOTE: `removeMatchingProperties` does not do deep equality checking, so we need to handle
-    // control points separately.
-    const controlPoints = channelSetting.controlPoints;
-    if (controlPoints && areControlPointsEqual(controlPoints, DEFAULT_CHANNEL_STATE.controlPoints)) {
-      channelSetting.controlPoints = undefined;
-    }
   }
   return removeUndefinedProperties({
     [ViewerChannelSettingKeys.VolumeEnabled]: serializeBoolean(channelSetting.volumeEnabled),
@@ -745,9 +734,6 @@ export function serializeViewerState(state: Partial<ViewerState>, removeDefaults
     [ViewerStateKeys.CameraState]:
       state.cameraState && serializeCameraState(state.cameraState as CameraState, removeDefaults),
   };
-
-  console.log("state.cameraState", state.cameraState);
-  console.log("result.cam", result[ViewerStateKeys.CameraState]);
 
   const viewModeToViewParam = {
     [ViewMode.threeD]: "3D",

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -329,8 +329,8 @@ export function parseKeyValueList(data: string): Record<string, string> {
   return result;
 }
 
-function escapeCommas(str: string): string {
-  return str.replace(/,/g, "%2C");
+function decodeColons(str: string): string {
+  return str.replace(/%3A/g, ":");
 }
 
 export function objectToKeyValueList(obj: Record<string, string | undefined>): string {
@@ -340,7 +340,9 @@ export function objectToKeyValueList(obj: Record<string, string | undefined>): s
     if (value === undefined) {
       continue;
     }
-    keyValuePairs.push(`${encodeURIComponent(key)}:${escapeCommas(value.trim())}`);
+    // Allow colon separators to remain unencoded to save URL character length.
+    const escapedValue = decodeColons(encodeURIComponent(value.trim()));
+    keyValuePairs.push(`${encodeURIComponent(key.trim())}:${escapedValue}`);
   }
   return keyValuePairs.join(",");
 }
@@ -532,11 +534,12 @@ function parseCameraState(cameraSettings: string | undefined): Partial<CameraSta
 
 function serializeCameraState(cameraState: CameraState): string {
   return objectToKeyValueList({
-    [CameraTransformKeys.Position]: cameraState.position.join(","),
-    [CameraTransformKeys.Target]: cameraState.target.join(","),
-    [CameraTransformKeys.Up]: cameraState.up.join(","),
-    [CameraTransformKeys.OrthoScale]: cameraState.orthoScale?.toString(),
-    [CameraTransformKeys.Fov]: cameraState.fov?.toString(),
+    [CameraTransformKeys.Position]: cameraState.position.map((value) => formatFloat(value)).join(","),
+    [CameraTransformKeys.Target]: cameraState.target.map((value) => formatFloat(value)).join(","),
+    [CameraTransformKeys.Up]: cameraState.up.map((value) => formatFloat(value)).join(","),
+    [CameraTransformKeys.OrthoScale]:
+      cameraState.orthoScale === undefined ? undefined : formatFloat(cameraState.orthoScale),
+    [CameraTransformKeys.Fov]: cameraState.fov === undefined ? undefined : formatFloat(cameraState.fov),
   });
 }
 

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -460,10 +460,13 @@ function parseStringRegion(region: string | undefined): PerAxis<[number, number]
   return { x, y, z };
 }
 
-function formatFloat(value: number): string {
+function formatFloat(value: number, maxPrecision = 5): string {
   // TODO: Make this smarter for integers, precision, etc.
   // Ideally should have a fixed max precision
-  return value.toFixed(2);
+  if (Number.isInteger(value)) {
+    return value.toString();
+  }
+  return Number(value.toPrecision(maxPrecision)).toString();
 }
 
 function serializeBoolean(value: boolean | undefined): "1" | "0" | undefined {
@@ -829,14 +832,16 @@ export async function parseViewerUrlParams(urlSearchParams: URLSearchParams): Pr
  * Serializes the ViewerState and ChannelState of a ViewerStateContext into a URLSearchParams object.
  * @param state ViewerStateContext to serialize.
  */
-export function serializeViewerUrlParams(state: Partial<ViewerStateContextType>): AppParams {
+export function serializeViewerUrlParams(state: Partial<ViewerStateContextType>, removeDefaults = true): AppParams {
   // TODO: Unit tests for this function
-  const params = serializeViewerState(state);
+  const params = serializeViewerState(state, removeDefaults);
 
   const channelParams = state.channelSettings?.reduce<Record<string, string>>(
     (acc, channelSetting, index): Record<string, string> => {
       const key = `c${index}`;
-      acc[key] = objectToKeyValueList(serializeViewerChannelSetting(channelSetting) as Record<string, string>);
+      acc[key] = objectToKeyValueList(
+        serializeViewerChannelSetting(channelSetting, removeDefaults) as Record<string, string>
+      );
       return acc;
     },
     {} as Record<string, string>

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -579,7 +579,11 @@ export function serializeViewerChannelSetting(
     [ViewerChannelSettingKeys.ControlPoints]:
       channelSetting.controlPoints && serializeControlPoints(channelSetting.controlPoints),
     [ViewerChannelSettingKeys.ControlPointsEnabled]: serializeBoolean(channelSetting.useControlPoints),
-    [ViewerChannelSettingKeys.Ramp]: channelSetting.ramp?.map(formatFloat).join(":"),
+    [ViewerChannelSettingKeys.Ramp]: channelSetting.ramp
+      ?.map((value) => {
+        return formatFloat(value);
+      })
+      .join(":"),
     // Note that Lut is not saved here, as it is expected as user input and is redundant with
     // the control points and ramp.
   });

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -643,7 +643,7 @@ export function deserializeViewerChannelSetting(
     const [min, max] = jsonState[ViewerChannelSettingKeys.Ramp].split(":");
     result.ramp = [Number.parseFloat(min), Number.parseFloat(max)];
   }
-  if (jsonState[ViewerChannelSettingKeys.ControlPoints] && CONTROL_POINTS_REGEX.test(jsonState.cps)) {
+  if (jsonState[ViewerChannelSettingKeys.ControlPoints]) {
     result.controlPoints = parseControlPoints(jsonState[ViewerChannelSettingKeys.ControlPoints]);
   }
   return result;
@@ -733,7 +733,6 @@ export function deserializeViewerState(params: ViewerStateParams): Partial<Viewe
  * @returns A `ViewerStateParams` object with the serialized parameters. Undefined values are removed.
  */
 export function serializeViewerState(state: Partial<ViewerState>, removeDefaults: boolean): ViewerStateParams {
-  // TODO: Enforce decimal places for floats/decimals?
   if (removeDefaults) {
     state = removeMatchingProperties(state, DEFAULT_VIEWER_SETTINGS);
   }
@@ -939,7 +938,6 @@ export function serializeViewerUrlParams(
   state: Partial<ViewerStateContextType>,
   removeDefaults: boolean = true
 ): AppParams {
-  // TODO: Unit tests for this function
   const params = serializeViewerState(state, removeDefaults);
 
   const channelParams = state.channelSettings?.reduce<Record<string, string>>(

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -15,7 +15,13 @@ import {
 import { ColorArray } from "../../src/aics-image-viewer/shared/utils/colorRepresentations";
 import { PerAxis } from "../../src/aics-image-viewer/shared/types";
 import { clamp } from "./math_utils";
-import { DEFAULT_CHANNEL_STATE, DEFAULT_VIEWER_SETTINGS } from "../../src/aics-image-viewer/shared/constants";
+import {
+  DEFAULT_CHANNEL_STATE,
+  DEFAULT_VIEWER_SETTINGS,
+  ENCODED_COLON_REGEX,
+} from "../../src/aics-image-viewer/shared/constants";
+
+const DEFAULT_CONTROL_POINT_COLOR: [number, number, number] = [255, 255, 255];
 
 const CHANNEL_STATE_KEY_REGEX = /^c[0-9]+$/;
 /** Match colon-separated pairs of alphanumeric strings */
@@ -330,7 +336,7 @@ export function parseKeyValueList(data: string): Record<string, string> {
 }
 
 function decodeColons(str: string): string {
-  return str.replace(/%3A/g, ":");
+  return str.replace(ENCODED_COLON_REGEX, ":");
 }
 
 export function objectToKeyValueList(obj: Record<string, string | undefined>): string {
@@ -576,7 +582,8 @@ function serializeControlPoints(controlPoints: ControlPoint[]): string {
     .map((cp) => {
       const x = formatFloat(cp.x);
       const opacity = formatFloat(cp.opacity);
-      const color = colorArrayToHex(cp.color);
+      // Default color is empty string
+      const color = isArrayEqual(cp.color, DEFAULT_CONTROL_POINT_COLOR) ? "" : colorArrayToHex(cp.color);
       return `${x}:${opacity}:${color}`;
     })
     .join(":");
@@ -609,7 +616,7 @@ function parseControlPoints(controlPoints: string | undefined): ControlPoint[] |
     return {
       x: parseStringFloat(x, -Infinity, Infinity) ?? 0,
       opacity: parseStringFloat(opacity, 0, 1) ?? 1.0,
-      color: parseHexColorAsColorArray(color) ?? [255, 255, 255],
+      color: parseHexColorAsColorArray(color) ?? DEFAULT_CONTROL_POINT_COLOR,
     };
   });
   // Sort control points by x value

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -15,9 +15,9 @@ import {
 import { ColorArray } from "../../src/aics-image-viewer/shared/utils/colorRepresentations";
 import { PerAxis } from "../../src/aics-image-viewer/shared/types";
 import { clamp } from "./math_utils";
-import { DEFAULT_CHANNEL_STATE, DEFAULT_VIEWER_SETTINGS } from "../../src/aics-image-viewer/shared/constants";
 import { removeMatchingProperties, removeUndefinedProperties } from "./datatype_utils";
 import { isEqual } from "lodash";
+import { getDefaultChannelState, getDefaultViewerState } from "../../src/aics-image-viewer/shared/constants";
 
 export const ENCODED_COMMA_REGEX = /%2C/g;
 export const ENCODED_COLON_REGEX = /%3A/g;
@@ -575,7 +575,7 @@ function parseCameraState(cameraSettings: string | undefined): Partial<CameraSta
 
 function serializeCameraState(cameraState: Partial<CameraState>, removeDefaults: boolean): string | undefined {
   if (removeDefaults) {
-    cameraState = removeMatchingProperties(cameraState, DEFAULT_VIEWER_SETTINGS.cameraState ?? {});
+    cameraState = removeMatchingProperties(cameraState, getDefaultViewerState().cameraState ?? {});
     if (Object.keys(cameraState).length === 0) {
       return undefined;
     }
@@ -685,7 +685,7 @@ export function deserializeViewerChannelSetting(
  * Serializes a single viewer channel setting into a dictionary of URL parameters
  * (`ViewerChannelSettingParams`).
  * @param channelSetting The channel state object to serialize.
- * @param removeDefaults Whether to remove properties that match the `DEFAULT_CHANNEL_STATE`.
+ * @param removeDefaults Whether to remove properties that match the output of `GET_DEFAULT_CHANNEL_STATE`.
  * @returns A `ViewerChannelSettingParams` object with the serialized parameters. Undefined values are removed.
  */
 export function serializeViewerChannelSetting(
@@ -693,7 +693,7 @@ export function serializeViewerChannelSetting(
   removeDefaults: boolean
 ): Partial<ViewerChannelSettingParams> {
   if (removeDefaults) {
-    channelSetting = removeMatchingProperties(channelSetting, DEFAULT_CHANNEL_STATE);
+    channelSetting = removeMatchingProperties(channelSetting, getDefaultChannelState());
   }
   return removeUndefinedProperties({
     [ViewerChannelSettingKeys.VolumeEnabled]: serializeBoolean(channelSetting.volumeEnabled),
@@ -761,12 +761,12 @@ export function deserializeViewerState(params: ViewerStateParams): Partial<Viewe
 /**
  * Serializes a ViewerState object into a dictionary of URL parameters.
  * @param state The ViewerState to serialize.
- * @param removeDefaults If true, remove properties that match the `DEFAULT_VIEWER_SETTINGS` value.
+ * @param removeDefaults If true, remove properties that match the output of `GET_DEFAULT_VIEWER_STATE`.
  * @returns A `ViewerStateParams` object with the serialized parameters. Undefined values are removed.
  */
 export function serializeViewerState(state: Partial<ViewerState>, removeDefaults: boolean): ViewerStateParams {
   if (removeDefaults) {
-    state = removeMatchingProperties(state, DEFAULT_VIEWER_SETTINGS);
+    state = removeMatchingProperties(state, getDefaultViewerState());
   }
   const result: ViewerStateParams = {
     [ViewerStateKeys.Mode]: state.renderMode,
@@ -966,7 +966,7 @@ export async function parseViewerUrlParams(urlSearchParams: URLSearchParams): Pr
  * Serializes the ViewerState and ChannelState of a ViewerStateContext into a URLSearchParams object.
  * @param state ViewerStateContext to serialize.
  * @param removeDefaults If true, shortens parameters by removing any properties that match the default state.
- * This includes DEFAULT_VIEWER_SETTINGS and DEFAULT_CHANNEL_STATE.
+ * This includes the output of GET_DEFAULT_VIEWER_STATE and GET_DEFAULT_CHANNEL_STATE.
  */
 export function serializeViewerUrlParams(
   state: Partial<ViewerStateContextType>,

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -449,6 +449,14 @@ function parseStringSlice(region: string | undefined): PerAxis<number> | undefin
 
 /**
  * Parses an array of three numbers from a string.
+ * @param levels The string to parse. Should be three numbers separated by a separator.
+ * @param options Optional parameters for parsing:
+ * - `min`: Minimum value for each number. Default is negative infinity.
+ * - `max`: Maximum value for each number. Default is positive infinity.
+ * - `separator`: Separator between numbers. Default is `,`.
+ * @returns
+ * - undefined if the string is undefined or could not be parsed.
+ * - An array of three numbers, clamped to the [min, max] range.
  */
 function parseThreeNumberArray(
   levels: string | undefined,
@@ -489,9 +497,24 @@ function parseStringRegion(region: string | undefined): PerAxis<[number, number]
   return { x, y, z };
 }
 
+/**
+ * Formats a float or integer value to a string with a maximum precision for float values.
+ * @param value The number to format.
+ * @param maxPrecision The maximum number of significant digits to display for float values.
+ * Default is 5.
+ * @returns
+ * - For integers, the integer value as a string.
+ * - For floats, the float value as a string with a maximum of `maxPrecision` significant digits
+ * and any trailing zeroes removed.
+ *
+ * @example
+ * ```
+ * formatFloat(1.23456, 3) // "1.23"
+ * formatFloat(123456, 3) // "123456"
+ * formatFloat(1.3999999999999999, 3) // "1.4"
+ * ```
+ */
 function formatFloat(value: number, maxPrecision: number = 5): string {
-  // TODO: Make this smarter for integers, precision, etc.
-  // Ideally should have a fixed max precision
   if (Number.isInteger(value)) {
     return value.toString();
   }

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -41,12 +41,13 @@ const HEX_COLOR_REGEX = /^[0-9a-fA-F]{6}$/;
  * LEGACY: Matches a COMMA-separated list of control points, where each control point is represented
  * by a triplet of `{x}:{opacity}:{hex color}`.
  */
-export const LEGACY_CONTROL_POINTS_REGEX = /^(-?[0-9.]*:[0-9.]*:[0-9a-fA-F]{6})(,-?[0-9.]*:[0-9.]*:[0-9a-fA-F]{6})*$/;
+export const LEGACY_CONTROL_POINTS_REGEX =
+  /^(-?[0-9.]*:[0-9.]*:([0-9a-fA-F]{6})?)(,-?[0-9.]*:[0-9.]*:([0-9a-fA-F]{6})?)*$/;
 /**
  * Matches a COLON-separated list of control points, where each control point is represented
  * by a triplet of `{x}:{opacity}:{hex color}`.
  */
-export const CONTROL_POINTS_REGEX = /^(-?[0-9.]*:[0-9.]*:[0-9a-fA-F]{6})(:-?[0-9.]*:[0-9.]*:[0-9a-fA-F]{6})*$/;
+export const CONTROL_POINTS_REGEX = /^(-?[0-9.]*:[0-9.]*:([0-9a-fA-F]{6})?)(:-?[0-9.]*:[0-9.]*:([0-9a-fA-F]{6})?)*$/;
 
 /**
  * Enum keys for URL parameters. These are stored as enums for better readability,

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -50,7 +50,7 @@ const HEX_COLOR_STR_REGEX = new RegExp(`^${HEX_COLOR_REGEX.source}$`);
 /**
  * LEGACY: Matches a COMMA-separated list of control points, where each control point is represented
  * by a triplet of `{x}:{opacity}:{hex color}`.
- * The hex color can be replaced with `w` to represent white, or `ffffff`.
+ * The hex color can be replaced with `w` to represent white (`ffffff`).
  */
 export const LEGACY_CONTROL_POINTS_REGEX = new RegExp(
   `^${CONTROL_POINT_REGEX.source}(,${CONTROL_POINT_REGEX.source})*$`
@@ -58,7 +58,7 @@ export const LEGACY_CONTROL_POINTS_REGEX = new RegExp(
 /**
  * Matches a COLON-separated list of control points, where each control point is represented
  * by a triplet of `{x}:{opacity}:{hex color}`.
- * The hex color can be replaced with `w` to represent white, or `ffffff`.
+ * The hex color can be replaced with `w` to represent white (`ffffff`).
  */
 export const CONTROL_POINTS_REGEX = new RegExp(`^${CONTROL_POINT_REGEX.source}(:${CONTROL_POINT_REGEX.source})*$`);
 

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -22,8 +22,18 @@ import { isEqual } from "lodash";
 export const ENCODED_COMMA_REGEX = /%2C/g;
 export const ENCODED_COLON_REGEX = /%3A/g;
 const DEFAULT_CONTROL_POINT_COLOR: [number, number, number] = [255, 255, 255];
-// Substitutes for default control point color (ffffff)
-const DEFAULT_CONTROL_POINT_COLOR_CODE = "w";
+const DEFAULT_CONTROL_POINT_COLOR_CODE = "1";
+
+// TODO: refactor regexes to be composed of one another rather than duplicating code
+// const COLOR_CODES: Record<string, ColorArray> = {
+//   "0": [0, 0, 0],
+//   "1": [255, 255, 255],
+//   "-1": [255, 255, 255],
+//   w: [255, 255, 255],
+//   k: [0, 0, 0],
+// };
+// const COLOR_CODE_REGEX = new RegExp(`(${Object.keys(COLOR_CODES).join("|")})`);
+// const HEX_COLOR_REGEX = new RegExp(`(([0-9a-fA-F]{6})|${COLOR_CODE_REGEX.source})`);
 
 const CHANNEL_STATE_KEY_REGEX = /^c[0-9]+$/;
 /** Match colon-separated pairs of alphanumeric strings */
@@ -40,13 +50,12 @@ const SLICE_REGEX = /^[0-9.]*,[0-9.]*,[0-9.]*$/;
  */
 const REGION_REGEX = /^([0-9.]*:[0-9.]*)(,[0-9.]*:[0-9.]*){2}$/;
 
-const HEX_COLOR_REGEX = /(([0-9a-fA-F]{6})|(w))/;
+const HEX_COLOR_REGEX = new RegExp(`(([0-9a-fA-F]{6})|${DEFAULT_CONTROL_POINT_COLOR_CODE})`);
 const NUMERIC_REGEX = /-?[0-9.]*/;
 const CONTROL_POINT_REGEX = new RegExp(`(${NUMERIC_REGEX.source}:${NUMERIC_REGEX.source}:${HEX_COLOR_REGEX.source})`);
 
 const HEX_COLOR_STR_REGEX = new RegExp(`^${HEX_COLOR_REGEX.source}$`);
 
-// TODO: refactor regexes to be composed of one another rather than duplicating code
 /**
  * LEGACY: Matches a COMMA-separated list of control points, where each control point is represented
  * by a triplet of `{x}:{opacity}:{hex color}`.
@@ -437,6 +446,9 @@ export function parseHexColorAsColorArray(hexColor: string | undefined): ColorAr
   if (!hexColor || !HEX_COLOR_STR_REGEX.test(hexColor)) {
     return undefined;
   }
+  // if (hexColor in COLOR_CODES) {
+  //   return COLOR_CODES[hexColor];
+  // }
   if (hexColor === DEFAULT_CONTROL_POINT_COLOR_CODE) {
     return DEFAULT_CONTROL_POINT_COLOR;
   }
@@ -586,6 +598,7 @@ function serializeControlPoints(controlPoints: ControlPoint[]): string {
       const x = formatFloat(cp.x);
       const opacity = formatFloat(cp.opacity);
       // Default color is empty string
+      // TODO: Substitute
       const color = isEqual(cp.color, DEFAULT_CONTROL_POINT_COLOR)
         ? DEFAULT_CONTROL_POINT_COLOR_CODE
         : colorArrayToHex(cp.color);


### PR DESCRIPTION
Closes #302, decreasing URL length.

*Estimated review size: large, 30-40 minutes*
(Many of the changes are unit tests.)

Before:
> https://volumeviewer.allencell.org/viewer?url=https%253A%252F%252Fallencell.s3.amazonaws.com%252Faics%252Fnuc_morph_data%252Fdata_for_analysis%252Fbaseline_colonies%252F20200323_06_mid%252Fraw.ome.zarr%2Chttps%253A%252F%252Fallencell.s3.amazonaws.com%252Faics%252Fnuc_morph_data%252Fdata_for_analysis%252Fbaseline_colonies%252F20200323_06_mid%252Fseg.ome.zarr&mode=volumetric&mask=0&image=cell&axes=0&bb=0&bbcol=ffffff&bgcol=000000&rot=0&bright=70&dens=2.5&interp=1&reg=0%3A1%2C0%3A1%2C0%3A1&slice=0.5%2C0.5%2C0.5&lvl=35%2C140%2C255&t=0&view=Z&c0=ven%3A1%2Csen%3A0%2Cisv%3A128%2Cisa%3A1%2Cclz%3A0%2Ccza%3A1%2Ccol%3Ac3c3c3%2Ccps%3A-26.64179104477612%253A0%253Affffff%252C58.66417910447761%253A0%253Affffff%252C136.7611940298507%253A1%253Affffff%252C279.73880597014926%253A1%253Affffff%2Ccpe%3A0%2Crmp%3A58.66417910447761%253A136.7611940298507&c1=ven%3A0%2Csen%3A0%2Cisv%3A128%2Cisa%3A1%2Cclz%3A0%2Ccza%3A1%2Ccol%3A6fba11%2Ccps%3A0%253A0%253Affffff%252C98%253A0%253Affffff%252C115%253A1%253Affffff%252C255%253A1%253Affffff%2Ccpe%3A0%2Crmp%3A98%253A115&c2=ven%3A1%2Csen%3A0%2Cisv%3A128%2Cisa%3A1%2Cclz%3A1%2Ccza%3A1%2Ccol%3A8da3c0%2Ccps%3A0%253A0%253Affffff%252C88%253A1%253Affffff%252C255%253A1%253Affffff%2Ccpe%3A0%2Crmp%3A0%253A255

After:
> http://volumeviewer.allencell.org/viewer?url=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc_morph_data%2Fdata_for_analysis%2Fbaseline_colonies%2F20200323_06_mid%2Fraw.ome.zarr,https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc_morph_data%2Fdata_for_analysis%2Fbaseline_colonies%2F20200323_06_mid%2Fseg.ome.zarr&dens=2.5&view=Z&c0=ven:1,col:c3c3c3,cps:0:0:1:88.701:0:1:111.53:1:1:255:1:1,rmp:26.035:138.78&c1=col:6fba11,cps:0:0:1:98:0:1:115:1:1:255:1:1,rmp:98:115&c2=ven:1,clz:1,col:8da3c0,cps:0:0:1:88:1:1:255:1:1

## Changes
- Channel settings no longer have `:` and `,` characters escaped.
- Changes the arrays for control points in the channel settings and camera vectors to use `:` as separators (instead of a mix of `,` and `:`) to reduce escaped characters.
  - Instead of `x1:y1:z1`**`,`**`x2:y2:z2`, sequences of number arrays/vectors are stored as `x1:y1:z1`**`:`**`x2:y2:z2`, with a colon in between.
  - Also adds backwards compatibility with the older control points encodings.
  - Cameras do not have backwards compatibility because they were just merged in #299 and are not in production yet.
- The `ffffff` default control point color is replaced with a designated placeholder (`1`).
- Default settings are not included in the exported URL.
- Adds formatting for float values to shorten the number of digits they display.