### PR TITLE
fix: Fix bug where unspecified camera in URL would cause black screen in Y slice mode.

### DIFF
--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -1,3 +1,5 @@
+import { CameraState } from "@aics/volume-viewer";
+
 import { ChannelState, ViewerState } from "../components/ViewerStateProvider/types";
 import { ViewMode, RenderMode, ImageType } from "./enums";
 import { ColorArray } from "./utils/colorRepresentations";
@@ -93,6 +95,18 @@ export const PRESET_COLOR_MAP = Object.freeze([
   },
 ]);
 
+/**
+ * Reflects the default camera settings the 3D viewer uses on volume load.
+ * These SHOULD NOT be changed.
+ */
+export const getDefaultCameraState = (): CameraState => ({
+  position: [0, 0, 5],
+  target: [0, 0, 0],
+  up: [0, 1, 0],
+  fov: 20,
+  orthoScale: 0.5,
+});
+
 export const getDefaultViewerState = (): ViewerState => ({
   viewMode: ViewMode.threeD, // "XY", "XZ", "YZ"
   renderMode: RenderMode.volumetric, // "pathtrace", "maxproject"
@@ -110,13 +124,7 @@ export const getDefaultViewerState = (): ViewerState => ({
   region: { x: [0, 1], y: [0, 1], z: [0, 1] },
   slice: { x: 0.5, y: 0.5, z: 0.5 },
   time: 0,
-  cameraState: {
-    position: [0, 0, 5],
-    target: [0, 0, 0],
-    up: [0, 1, 0],
-    fov: 20,
-    orthoScale: 0.5,
-  },
+  cameraState: undefined,
 });
 
 export const getDefaultChannelState = (): ChannelState => ({

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -95,9 +95,13 @@ export const PRESET_COLOR_MAP = Object.freeze([
   },
 ]);
 
+/** Allows the 3D viewer to apply the default camera settings for the view mode. */
+const USE_VIEW_MODE_DEFAULT_CAMERA = undefined;
+
 /**
  * Reflects the default camera settings the 3D viewer uses on volume load.
- * These SHOULD NOT be changed.
+ * These SHOULD NOT be changed; otherwise, existing shared links that don't specify the
+ * camera settings will use the new defaults and may be in unexpected orientations or positions.
  */
 export const getDefaultCameraState = (): CameraState => ({
   position: [0, 0, 5],
@@ -124,7 +128,11 @@ export const getDefaultViewerState = (): ViewerState => ({
   region: { x: [0, 1], y: [0, 1], z: [0, 1] },
   slice: { x: 0.5, y: 0.5, z: 0.5 },
   time: 0,
-  cameraState: undefined,
+  // Do not override camera position, target, etc. by default;
+  // instead, let the viewer apply default camera settings based on the view mode.
+  // This prevents a bug where the camera's position and view mode are set to
+  // incompatible states and the viewport becomes blank.
+  cameraState: USE_VIEW_MODE_DEFAULT_CAMERA,
 });
 
 export const getDefaultChannelState = (): ChannelState => ({

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -549,7 +549,8 @@ describe("Camera state", () => {
 
   it("default camera state has not been changed", () => {
     // The default camera state should NOT change unless backwards compatibility
-    // is added to ensure old links still work.
+    // is added to ensure old links still maintain the same camera orientation;
+    // otherwise, cameras will appear in the new default orientation unexpectedly.
     expect(getDefaultCameraState()).toEqual({
       position: [0, 0, 5],
       target: [0, 0, 0],

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -16,11 +16,17 @@ import {
   serializeViewerUrlParams,
   CONTROL_POINTS_REGEX,
   LEGACY_CONTROL_POINTS_REGEX,
+  serializeCameraState,
 } from "../url_utils";
 import { ChannelState, ViewerState } from "../../../src/aics-image-viewer/components/ViewerStateProvider/types";
 import { ImageType, RenderMode, ViewMode } from "../../../src/aics-image-viewer/shared/enums";
 import { ViewerChannelSetting } from "../../../src/aics-image-viewer/shared/utils/viewerChannelSettings";
-import { getDefaultChannelState, getDefaultViewerState } from "../../../src/aics-image-viewer/shared/constants";
+import {
+  getDefaultCameraState,
+  getDefaultChannelState,
+  getDefaultViewerState,
+} from "../../../src/aics-image-viewer/shared/constants";
+import { CameraState } from "@aics/volume-viewer";
 
 const defaultSettings: ViewerChannelSetting = {
   match: 0,
@@ -390,7 +396,7 @@ describe("Channel state serialization", () => {
   });
 });
 
-describe("Viewer state serialization", () => {
+describe("Viewer state", () => {
   const DEFAULT_VIEWER_STATE: ViewerState = {
     viewMode: ViewMode.threeD, // "XY", "XZ", "YZ"
     renderMode: RenderMode.volumetric, // "pathtrace", "maxproject"
@@ -525,6 +531,31 @@ describe("Viewer state serialization", () => {
         const state: ViewerState = { ...DEFAULT_VIEWER_STATE, renderMode };
         expect(deserializeViewerState(serializeViewerState(state, false)).renderMode).toEqual(renderMode);
       }
+    });
+  });
+});
+
+describe("Camera state", () => {
+  it("uses default camera state when choosing elements to exclude/ignore", () => {
+    let cameraState: CameraState = {
+      ...getDefaultCameraState(),
+    };
+    // No changes from default
+    expect(serializeCameraState(cameraState, true)).toEqual(undefined);
+
+    cameraState = { ...cameraState, position: [1, 2, 3] };
+    expect(serializeCameraState(cameraState, true)).toEqual("pos:1:2:3");
+  });
+
+  it("default camera state has not been changed", () => {
+    // The default camera state should NOT change unless backwards compatibility
+    // is added to ensure old links still work.
+    expect(getDefaultCameraState()).toEqual({
+      position: [0, 0, 5],
+      target: [0, 0, 0],
+      up: [0, 1, 0],
+      fov: 20,
+      orthoScale: 0.5,
     });
   });
 });

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -1,3 +1,4 @@
+import { CameraState } from "@aics/volume-viewer";
 import { describe, expect, it } from "@jest/globals";
 
 import {
@@ -26,7 +27,6 @@ import {
   getDefaultChannelState,
   getDefaultViewerState,
 } from "../../../src/aics-image-viewer/shared/constants";
-import { CameraState } from "@aics/volume-viewer";
 
 const defaultSettings: ViewerChannelSetting = {
   match: 0,

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -17,7 +17,11 @@ import { PerAxis } from "../../src/aics-image-viewer/shared/types";
 import { clamp } from "./math_utils";
 import { removeMatchingProperties, removeUndefinedProperties } from "./datatype_utils";
 import { isEqual } from "lodash";
-import { getDefaultChannelState, getDefaultViewerState } from "../../src/aics-image-viewer/shared/constants";
+import {
+  getDefaultCameraState,
+  getDefaultChannelState,
+  getDefaultViewerState,
+} from "../../src/aics-image-viewer/shared/constants";
 
 export const ENCODED_COMMA_REGEX = /%2C/g;
 export const ENCODED_COLON_REGEX = /%3A/g;
@@ -573,9 +577,13 @@ function parseCameraState(cameraSettings: string | undefined): Partial<CameraSta
   return removeUndefinedProperties(result);
 }
 
-function serializeCameraState(cameraState: Partial<CameraState>, removeDefaults: boolean): string | undefined {
+export function serializeCameraState(cameraState: Partial<CameraState>, removeDefaults: boolean): string | undefined {
   if (removeDefaults) {
-    cameraState = removeMatchingProperties(cameraState, getDefaultViewerState().cameraState ?? {});
+    // Note that we use the `getDefaultCameraState()` to get the defaults here,
+    // instead of `getDefaultViewerState().cameraState`. The default viewer state's camera state
+    // is undefined, which signals that the camera should not be modified for backwards compatibility
+    // with old URLs that don't specify it.
+    cameraState = removeMatchingProperties(cameraState, getDefaultCameraState());
     if (Object.keys(cameraState).length === 0) {
       return undefined;
     }

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -580,9 +580,8 @@ function parseCameraState(cameraSettings: string | undefined): Partial<CameraSta
 export function serializeCameraState(cameraState: Partial<CameraState>, removeDefaults: boolean): string | undefined {
   if (removeDefaults) {
     // Note that we use the `getDefaultCameraState()` to get the defaults here,
-    // instead of `getDefaultViewerState().cameraState`. The default viewer state's camera state
-    // is undefined, which signals that the camera should not be modified for backwards compatibility
-    // with old URLs that don't specify it.
+    // instead of `getDefaultViewerState().cameraState`. The latter is undefined, which signals
+    // that the camera should not be modified for URLs that don't specify it.
     cameraState = removeMatchingProperties(cameraState, getDefaultCameraState());
     if (Object.keys(cameraState).length === 0) {
       return undefined;


### PR DESCRIPTION
Closes #310, where unspecified camera parameters in URLs would cause the "XZ" view mode to fail.

*Estimated review size: small, 5 minutes*

The underlying cause was that the default viewer settings were being used, which specify the position `(0, 0, 5)` by default for 3D viewing. In the orthographic Y-slice view mode, however, this led to the camera being at position 0 in the Y axis. This meant that the camera would be "inside" the desired slice, and show only a black screen.

## Changes
- Changes the default viewer state's camera state to be `undefined`. If the camera settings are not specified in the URL, the camera state will be set to `undefined`, which signals the viewer not to edit the camera's position/rotation/etc.
- Added a separate `getDefaultCameraState`, which returns the default camera state the viewer opens with.
  - This means we can still exclude default camera settings from the URL by comparing it to the output of `getDefaultCameraState`.
- Added unit tests to warn about any changes to the default camera state.

## Validation:
- Open this link. You should see nothing but a black screen: https://volumeviewer.allencell.org/viewer?url=https%253A%252F%252Fallencell.s3.amazonaws.com%252Faics%252Femt_timelapse_dataset%252Fdata%252F3500006079_27_raw_converted.ome.zarr&view=Y
- Clone these changes locally, and then open the same link but in the local viewer. You should see the Y slice appear as expected: http://localhost:9020/viewer?url=https%253A%252F%252Fallencell.s3.amazonaws.com%252Faics%252Femt_timelapse_dataset%252Fdata%252F3500006079_27_raw_converted.ome.zarr&vie

### Demo video (🔊):
https://github.com/user-attachments/assets/c48ece21-daf8-424b-8c7c-3c1a00ad1334

