### PR TITLE
feat: Styled cookie banner, added link to cookie settings

### DIFF
--- a/public/App.css
+++ b/public/App.css
@@ -11,3 +11,37 @@ body {
 .cell-viewer-app {
   width: 100vw;
 }
+
+#onetrust-consent-sdk {
+  & #onetrust-banner-sdk {
+    border-radius: 5px;
+
+    & #onetrust-pc-btn-handler {
+      font-weight: 400;
+      padding: 12px 10px;
+    }
+  }
+
+  /* Darken all text for increased contrast */
+  & h1,
+  & h2,
+  & h3,
+  & h4,
+  & p,
+  & #onetrust-policy-text {
+    color: #323233 !important;
+  }
+
+  /* Add margin to top of cookie banner popup's header for visual consistency */
+  & #onetrust-pc-sdk {
+    & #ot-pc-title {
+      margin-top: 20px;
+    }
+  }
+
+  & #accept-recommended-btn-handler,
+  & #onetrust-accept-btn-handler,
+  & .save-preference-btn-handler {
+    border-radius: 6px;
+  }
+}

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -422,6 +422,10 @@ export default function StyleProvider(props: PropsWithChildren<{}>): ReactElemen
             borderRadiusLG: 0,
             colorTextHeading: theme.colors.text.section,
           },
+          Divider: {
+            colorSplit: theme.colors.layout.dividers,
+            marginLG: 0,
+          },
           Layout: {
             siderBg: theme.colors.controlPanel.bg,
           },

--- a/website/components/LandingPage/index.tsx
+++ b/website/components/LandingPage/index.tsx
@@ -372,6 +372,7 @@ export default function LandingPage(): ReactElement {
           </p>
         </BannerTextContainer>
       </Banner>
+
       <ContentContainer>
         <FeatureHighlightsContainer>
           <FeatureHighlightsItem>
@@ -394,6 +395,7 @@ export default function LandingPage(): ReactElement {
           </FeatureHighlightsItem>
         </FeatureHighlightsContainer>
       </ContentContainer>
+
       <LoadPromptContainer>
         <h2 style={{ margin: 0 }}>Load dataset(s) below or your own data to get started</h2>
       </LoadPromptContainer>

--- a/website/components/LandingPage/index.tsx
+++ b/website/components/LandingPage/index.tsx
@@ -224,6 +224,7 @@ const InReviewFlag = styled(FlexRowAlignCenter)`
 
 const CookieSettingsButton = styled(Button)`
   color: var(--color-text-body);
+  &:focus-visible > span,
   &:hover > span {
     text-decoration: underline;
   }

--- a/website/components/LandingPage/index.tsx
+++ b/website/components/LandingPage/index.tsx
@@ -1,6 +1,6 @@
 import { faUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Button, Tooltip } from "antd";
+import { Button, Divider, Tooltip } from "antd";
 import React, { ReactElement, useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { useSearchParams } from "react-router-dom";
@@ -222,6 +222,13 @@ const InReviewFlag = styled(FlexRowAlignCenter)`
   }
 `;
 
+const CookieSettingsButton = styled(Button)`
+  color: var(--color-text-body);
+  &:hover > span {
+    text-decoration: underline;
+  }
+`;
+
 export default function LandingPage(): ReactElement {
   // Rendering
   const navigation = useNavigate();
@@ -365,7 +372,6 @@ export default function LandingPage(): ReactElement {
           </p>
         </BannerTextContainer>
       </Banner>
-
       <ContentContainer>
         <FeatureHighlightsContainer>
           <FeatureHighlightsItem>
@@ -388,13 +394,21 @@ export default function LandingPage(): ReactElement {
           </FeatureHighlightsItem>
         </FeatureHighlightsContainer>
       </ContentContainer>
-
       <LoadPromptContainer>
         <h2 style={{ margin: 0 }}>Load dataset(s) below or your own data to get started</h2>
       </LoadPromptContainer>
 
       <ContentContainer style={{ paddingBottom: "400px" }}>
         <ProjectList>{landingPageContent.map(renderProject)}</ProjectList>
+      </ContentContainer>
+
+      <ContentContainer style={{ padding: "0 30px 40px 30px" }}>
+        <Divider />
+        <FlexColumnAlignCenter style={{ paddingTop: "20px" }}>
+          <CookieSettingsButton type="text" className="ot-sdk-show-settings">
+            Cookie settings
+          </CookieSettingsButton>
+        </FlexColumnAlignCenter>
       </ContentContainer>
     </div>
   );

--- a/website/components/LandingPage/index.tsx
+++ b/website/components/LandingPage/index.tsx
@@ -410,6 +410,7 @@ export default function LandingPage(): ReactElement {
         <FlexColumnAlignCenter style={{ paddingTop: "20px" }}>
           <CookieSettingsButton type="text" className="ot-sdk-show-settings">
             Cookie settings
+            <VisuallyHidden>(opens popup menu)</VisuallyHidden>
           </CookieSettingsButton>
         </FlexColumnAlignCenter>
       </ContentContainer>


### PR DESCRIPTION
Completes the cookie settings section of #317, "Prepare for allencell: thumbnail, short description, [Cookie Settings] anchor link".

*Estimated size: small, 5 minutes*

## Changes
These changes are almost entirely copied from TFE, which uses the same cookie banner.

- Adds the cookie banner anchor link and associated styling.
- Adds style overrides for the cookie banner, copied from TFE https://github.com/allen-cell-animated/timelapse-colorizer/blob/main/src/styles/cookie-banner.css

Popup banner:
![image](https://github.com/user-attachments/assets/96362d50-67f0-4a92-bab5-9f703ef24562)

New Cookie settings link:
![image](https://github.com/user-attachments/assets/a439b80e-558d-4eab-8d0d-85b8414f0af1)

Styled menu:
![image](https://github.com/user-attachments/assets/bbfb061f-ae12-469b-9235-e4b1258d4ea7)
