### PR TITLE
feature: Improved reset to defaults behavior

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -42,8 +42,8 @@ import {
   CACHE_MAX_SIZE,
   QUEUE_MAX_SIZE,
   QUEUE_MAX_LOW_PRIORITY_SIZE,
-  getDefaultChannelState,
-  getDefaultViewerState,
+  getEmptyChannelState,
+  getEmptyViewerState,
 } from "../../shared/constants";
 import PlayControls from "../../shared/utils/playControls";
 
@@ -111,7 +111,7 @@ const defaultProps: AppProps = {
 
   appHeight: "100vh",
   visibleControls: defaultVisibleControls,
-  viewerSettings: getDefaultViewerState(),
+  viewerSettings: getEmptyViewerState(),
   cellId: "",
   imageDownloadHref: "",
   parentImageDownloadHref: "",
@@ -132,7 +132,7 @@ const initializeOneChannelSetting = (
   index: number,
   defaultColor: ColorArray,
   viewerChannelSettings?: ViewerChannelSettings,
-  defaultChannelState = getDefaultChannelState()
+  defaultChannelState = getEmptyChannelState()
 ): ChannelState => {
   let initSettings = {} as Partial<ViewerChannelSetting>;
   if (viewerChannelSettings) {

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -612,12 +612,14 @@ const App: React.FC<AppProps> = (props) => {
     [viewerSettings.viewMode]
   );
 
-  useImageEffect((_currentImage) => {
-    // Set camera transform on initial load only
-    if (viewerSettings.cameraState) {
-      view3d.setCameraState(viewerSettings.cameraState);
-    }
-  }, []);
+  useImageEffect(
+    (_currentImage) => {
+      if (viewerSettings.cameraState) {
+        view3d.setCameraState(viewerSettings.cameraState);
+      }
+    },
+    [viewerSettings.cameraState]
+  );
 
   useImageEffect((_currentImage) => view3d.setAutoRotate(viewerSettings.autorotate), [viewerSettings.autorotate]);
 

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -192,8 +192,8 @@ const App: React.FC<AppProps> = (props) => {
     changeViewerSetting,
     changeChannelSetting,
     applyColorPresets,
-    setDefaultChannelState,
-    getDefaultChannelState,
+    setSavedChannelState,
+    getSavedChannelState,
   } = viewerState.current;
 
   const view3d = useConstructor(() => new View3d());
@@ -323,9 +323,10 @@ const App: React.FC<AppProps> = (props) => {
       }
     }
 
+    // TODO: Move to onVolumeLoaded callback in ViewerStateProvider?
     // Check for 3D vs. 2D and only save control points/channel state if the volume is the
     // right type
-    if (getDefaultChannelState(channelIndex) === undefined && viewerSettings.time === aimg.loadSpec.time) {
+    if (getSavedChannelState(channelIndex) === undefined && viewerSettings.time === aimg.loadSpec.time) {
       // TODO: Does this fail if data is chunked in a way that does not allow for subregions where z=1? Is that possible?
       const isXyAndLoadingXy = viewerSettings.viewMode === ViewMode.xy && aimg.imageInfo.subregionSize.z === 1;
       const is3dAndLoading3d = viewerSettings.viewMode === ViewMode.threeD && aimg.imageInfo.subregionSize.z > 1;
@@ -341,7 +342,7 @@ const App: React.FC<AppProps> = (props) => {
           " with control points ",
           newState.controlPoints.map((cp) => cp.x)
         );
-        setDefaultChannelState(channelIndex, newState);
+        setSavedChannelState(channelIndex, newState);
       }
     }
 

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -13,6 +13,7 @@ import {
   IVolumeLoader,
   PrefetchDirection,
   VolumeFileFormat,
+  ControlPoint,
 } from "@aics/volume-viewer";
 
 import type { AppProps, ControlVisibilityFlags, UseImageEffectType } from "./types";
@@ -185,8 +186,14 @@ const App: React.FC<AppProps> = (props) => {
   // State management /////////////////////////////////////////////////////////
 
   const viewerState = useContext(ViewerStateContext).ref;
-  const { channelSettings, setChannelSettings, changeViewerSetting, changeChannelSetting, applyColorPresets } =
-    viewerState.current;
+  const {
+    channelSettings,
+    setChannelSettings,
+    changeViewerSetting,
+    changeChannelSetting,
+    applyColorPresets,
+    setDefaultChannelState,
+  } = viewerState.current;
 
   const view3d = useConstructor(() => new View3d());
   if (props.view3dRef !== undefined) {
@@ -282,6 +289,7 @@ const App: React.FC<AppProps> = (props) => {
       const { ramp, controlPoints } = initializeLut(aimg, channelIndex, props.viewerChannelSettings);
       changeChannelSetting(channelIndex, "controlPoints", controlPoints);
       changeChannelSetting(channelIndex, "ramp", controlPointsToRamp(ramp));
+      setDefaultChannelState(channelIndex, { ...thisChannelsSettings, ramp: controlPointsToRamp(ramp), controlPoints });
     } else {
       // try not to update lut from here if we are in play mode
       // if (playingAxis !== null) {

--- a/src/aics-image-viewer/components/ChannelsWidget.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidget.tsx
@@ -127,54 +127,7 @@ const ChannelsWidget: React.FC<ChannelsWidgetProps> = (props: ChannelsWidgetProp
         };
       });
 
-  const resetAllChannelsToDefaults = (): void => {
-    if (!channelDataChannels) {
-      return;
-    }
-    const allChannelStateKeys = Object.keys(getDefaultChannelState(0)) as ChannelStateKey[];
-    const excludedKeys: ChannelStateKey[] = ["name", "controlPoints", "ramp", "useControlPoints"];
-    const channelStateKeysToReset = allChannelStateKeys.filter((key) => !excludedKeys.includes(key));
-
-    // Reset control points and ramp for each channel
-    for (let i = 0; i < channelDataChannels.length; i++) {
-      const channelData = channelDataChannels[i];
-      const defaultLut = getDefaultLut(channelData.getHistogram());
-      props.changeChannelSetting(i, "controlPoints", defaultLut.controlPoints);
-      props.changeChannelSetting(i, "ramp", controlPointsToRamp(defaultLut.controlPoints));
-      props.changeChannelSetting(i, "useControlPoints", false);
-    }
-    // Reset all other settings. Also, enable volumes on only the first three channels.
-    channelSettings.forEach((_channelSetting, index) => {
-      const defaultChannelState = getDefaultChannelState(index);
-      for (const key of channelStateKeysToReset) {
-        if (key === "volumeEnabled" && index < 3) {
-          props.changeChannelSetting(index, key, true);
-          continue;
-        }
-        props.changeChannelSetting(index, key, defaultChannelState[key]);
-      }
-    });
-
-    // Apply default color map
-    props.onApplyColorPresets(PRESET_COLOR_MAP[0].colors);
-    // `onApplyColorPresets` will fail to reset colors if the number of channels exceeds
-    // the color map length, so we need to reset the colors manually.
-    if (channelDataChannels.length > PRESET_COLOR_MAP[0].colors.length) {
-      for (let i = PRESET_COLOR_MAP[0].colors.length; i < channelDataChannels.length; i++) {
-        const defaultChannelState = getDefaultChannelState(i);
-        props.changeChannelSetting(i, "color", defaultChannelState["color"]);
-      }
-    }
-  };
-
-  return (
-    <div>
-      <Collapse bordered={false} defaultActiveKey={firstKey} items={rows} collapsible="icon" />
-      <div style={{ padding: "20px 15px" }}>
-        <Button onClick={resetAllChannelsToDefaults}>Reset all channels</Button>
-      </div>
-    </div>
-  );
+  return <Collapse bordered={false} defaultActiveKey={firstKey} items={rows} collapsible="icon" />;
 };
 
 export default connectToViewerState(ChannelsWidget, [

--- a/src/aics-image-viewer/components/ChannelsWidget.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidget.tsx
@@ -1,6 +1,6 @@
-import React, { useContext } from "react";
+import React from "react";
 import { find } from "lodash";
-import { Button, Collapse, CollapseProps, List } from "antd";
+import { Collapse, CollapseProps, List } from "antd";
 import { Channel } from "@aics/volume-viewer";
 
 import type { ChannelGrouping, ViewerChannelSettings } from "../shared/utils/viewerChannelSettings";
@@ -10,10 +10,8 @@ import type { IsosurfaceFormat } from "../shared/types";
 
 import ChannelsWidgetRow from "./ChannelsWidgetRow";
 import SharedCheckBox from "./shared/SharedCheckBox";
-import { connectToViewerState, ViewerStateContext } from "./ViewerStateProvider";
+import { connectToViewerState } from "./ViewerStateProvider";
 import type { ChannelSettingUpdater, ChannelState, ChannelStateKey } from "./ViewerStateProvider/types";
-import { PRESET_COLOR_MAP } from "../shared/constants";
-import { controlPointsToRamp, getDefaultLut } from "../shared/utils/controlPointsToLut";
 
 export type ChannelsWidgetProps = {
   // From parent

--- a/src/aics-image-viewer/components/ChannelsWidget.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidget.tsx
@@ -30,18 +30,10 @@ export type ChannelsWidgetProps = {
   // From viewer state
   channelSettings: ChannelState[];
   changeChannelSetting: ChannelSettingUpdater;
-  getDefaultChannelState: (index: number) => ChannelState;
 };
 
 const ChannelsWidget: React.FC<ChannelsWidgetProps> = (props: ChannelsWidgetProps) => {
-  const {
-    channelGroupedByType,
-    channelSettings,
-    channelDataChannels,
-    filterFunc,
-    viewerChannelSettings,
-    getDefaultChannelState,
-  } = props;
+  const { channelGroupedByType, channelSettings, channelDataChannels, filterFunc, viewerChannelSettings } = props;
 
   const createCheckboxHandler = (key: ChannelStateKey, value: boolean) => (channelArray: number[]) => {
     props.changeChannelSetting(channelArray, key, value);
@@ -130,8 +122,4 @@ const ChannelsWidget: React.FC<ChannelsWidgetProps> = (props: ChannelsWidgetProp
   return <Collapse bordered={false} defaultActiveKey={firstKey} items={rows} collapsible="icon" />;
 };
 
-export default connectToViewerState(ChannelsWidget, [
-  "channelSettings",
-  "changeChannelSetting",
-  "getDefaultChannelState",
-]);
+export default connectToViewerState(ChannelsWidget, ["channelSettings", "changeChannelSetting"]);

--- a/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
@@ -4,7 +4,7 @@ import { CheckboxChangeEvent } from "antd/lib/checkbox";
 import { Channel } from "@aics/volume-viewer";
 
 import TfEditor from "../TfEditor";
-import { ISOSURFACE_OPACITY_SLIDER_MAX, PRESET_COLOR_MAP } from "../../shared/constants";
+import { ISOSURFACE_OPACITY_SLIDER_MAX } from "../../shared/constants";
 import ColorPicker from "../ColorPicker";
 import { ColorObject, colorObjectToArray, colorArrayToObject } from "../../shared/utils/colorRepresentations";
 import {
@@ -15,7 +15,6 @@ import {
 import { IsosurfaceFormat } from "../../shared/types";
 import ViewerIcon from "../shared/ViewerIcon";
 import SliderRow from "../shared/SliderRow";
-import { controlPointsToRamp, getDefaultLut } from "../../shared/utils/controlPointsToLut";
 import { connectToViewerState } from "../ViewerStateProvider";
 
 import "./styles.css";
@@ -87,30 +86,6 @@ const ChannelsWidgetRow: React.FC<ChannelsWidgetRowProps> = (props: ChannelsWidg
     </div>
   );
 
-  /**
-   * Resets currently visible settings for this channel to their defaults.
-   */
-  const resetChannelToDefaults = (): void => {
-    // Only modify settings that are currently visible to the user.'
-    const defaultChannelState = getDefaultChannelState(index);
-    if (props.channelState.volumeEnabled) {
-      const defaultLut = getDefaultLut(props.channelDataForChannel.histogram);
-      props.changeChannelSetting(index, "controlPoints", defaultLut.controlPoints);
-      props.changeChannelSetting(index, "ramp", controlPointsToRamp(defaultLut.controlPoints));
-      props.changeChannelSetting(index, "useControlPoints", defaultChannelState.useControlPoints);
-
-      props.changeChannelSetting(index, "colorizeAlpha", defaultChannelState.colorizeAlpha);
-      props.changeChannelSetting(index, "colorizeEnabled", defaultChannelState.colorizeEnabled);
-    }
-
-    if (props.channelState.isosurfaceEnabled) {
-      props.changeChannelSetting(index, "isovalue", defaultChannelState.isovalue);
-      props.changeChannelSetting(index, "opacity", defaultChannelState.opacity);
-    }
-
-    props.changeChannelSetting(index, "color", PRESET_COLOR_MAP[0].colors[index] ?? defaultChannelState.color);
-  };
-
   const createTFEditor = (): React.ReactNode => {
     const { controlPoints, colorizeEnabled, colorizeAlpha, useControlPoints, ramp } = channelState;
     return (
@@ -170,9 +145,6 @@ const ChannelsWidgetRow: React.FC<ChannelsWidgetRowProps> = (props: ChannelsWidg
             {renderSurfaceControls()}
           </>
         )}
-        <div style={{ marginTop: "15px" }}>
-          <Button onClick={resetChannelToDefaults}>Reset to defaults</Button>
-        </div>
       </>
     );
   };

--- a/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
@@ -4,7 +4,7 @@ import { CheckboxChangeEvent } from "antd/lib/checkbox";
 import { Channel } from "@aics/volume-viewer";
 
 import TfEditor from "../TfEditor";
-import { getDefaultChannelState, ISOSURFACE_OPACITY_SLIDER_MAX, PRESET_COLOR_MAP } from "../../shared/constants";
+import { ISOSURFACE_OPACITY_SLIDER_MAX, PRESET_COLOR_MAP } from "../../shared/constants";
 import ColorPicker from "../ColorPicker";
 import { ColorObject, colorObjectToArray, colorArrayToObject } from "../../shared/utils/colorRepresentations";
 import {
@@ -16,6 +16,7 @@ import { IsosurfaceFormat } from "../../shared/types";
 import ViewerIcon from "../shared/ViewerIcon";
 import SliderRow from "../shared/SliderRow";
 import { controlPointsToRamp, getDefaultLut } from "../../shared/utils/controlPointsToLut";
+import { connectToViewerState } from "../ViewerStateProvider";
 
 import "./styles.css";
 
@@ -26,13 +27,14 @@ interface ChannelsWidgetRowProps {
   channelDataForChannel: Channel;
 
   changeChannelSetting: ChannelSettingUpdater;
+  getDefaultChannelState: (index: number) => ChannelState;
 
   saveIsosurface: (channelIndex: number, type: IsosurfaceFormat) => void;
   onColorChangeComplete?: (newRGB: ColorObject, oldRGB?: ColorObject, index?: number) => void;
 }
 
 const ChannelsWidgetRow: React.FC<ChannelsWidgetRowProps> = (props: ChannelsWidgetRowProps) => {
-  const { index, changeChannelSetting, saveIsosurface, channelState } = props;
+  const { index, changeChannelSetting, saveIsosurface, channelState, getDefaultChannelState } = props;
   const [controlsOpen, setControlsOpen] = useState(false);
 
   const changeSettingForThisChannel = useCallback<SingleChannelSettingUpdater>(
@@ -90,7 +92,7 @@ const ChannelsWidgetRow: React.FC<ChannelsWidgetRowProps> = (props: ChannelsWidg
    */
   const resetChannelToDefaults = (): void => {
     // Only modify settings that are currently visible to the user.'
-    const defaultChannelState = getDefaultChannelState();
+    const defaultChannelState = getDefaultChannelState(index);
     if (props.channelState.volumeEnabled) {
       const defaultLut = getDefaultLut(props.channelDataForChannel.histogram);
       props.changeChannelSetting(index, "controlPoints", defaultLut.controlPoints);
@@ -185,4 +187,4 @@ const ChannelsWidgetRow: React.FC<ChannelsWidgetRowProps> = (props: ChannelsWidg
   );
 };
 
-export default ChannelsWidgetRow;
+export default connectToViewerState(ChannelsWidgetRow, ["getDefaultChannelState"]);

--- a/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidgetRow/index.tsx
@@ -15,7 +15,6 @@ import {
 import { IsosurfaceFormat } from "../../shared/types";
 import ViewerIcon from "../shared/ViewerIcon";
 import SliderRow from "../shared/SliderRow";
-import { connectToViewerState } from "../ViewerStateProvider";
 
 import "./styles.css";
 
@@ -26,14 +25,13 @@ interface ChannelsWidgetRowProps {
   channelDataForChannel: Channel;
 
   changeChannelSetting: ChannelSettingUpdater;
-  getDefaultChannelState: (index: number) => ChannelState;
 
   saveIsosurface: (channelIndex: number, type: IsosurfaceFormat) => void;
   onColorChangeComplete?: (newRGB: ColorObject, oldRGB?: ColorObject, index?: number) => void;
 }
 
 const ChannelsWidgetRow: React.FC<ChannelsWidgetRowProps> = (props: ChannelsWidgetRowProps) => {
-  const { index, changeChannelSetting, saveIsosurface, channelState, getDefaultChannelState } = props;
+  const { index, changeChannelSetting, saveIsosurface, channelState } = props;
   const [controlsOpen, setControlsOpen] = useState(false);
 
   const changeSettingForThisChannel = useCallback<SingleChannelSettingUpdater>(
@@ -159,4 +157,4 @@ const ChannelsWidgetRow: React.FC<ChannelsWidgetRowProps> = (props: ChannelsWidg
   );
 };
 
-export default connectToViewerState(ChannelsWidgetRow, ["getDefaultChannelState"]);
+export default ChannelsWidgetRow;

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -13,6 +13,8 @@ import { PRESET_COLOR_MAP } from "../../shared/constants";
 import "./styles.css";
 import ViewerIcon from "../shared/ViewerIcon";
 import { MetadataRecord } from "../../shared/types";
+import { FlexColumn } from "../../../../website/components/LandingPage/utils";
+import { connectToViewerState } from "../ViewerStateProvider";
 
 type PropsOf<T> = T extends React.ComponentType<infer P> ? P : never;
 
@@ -29,6 +31,7 @@ interface ControlPanelProps
   getMetadata: () => MetadataRecord;
   collapsed: boolean;
   setCollapsed: (value: boolean) => void;
+  resetToDefaultViewerState: () => void;
 }
 
 const enum ControlTab {
@@ -113,7 +116,21 @@ function ControlPanel(props: ControlPanelProps): React.ReactElement {
       });
     }
 
-    return <Collapse bordered={false} defaultActiveKey={showCustomize ? [0, 1] : 0} items={items} />;
+    return (
+      <FlexColumn $gap={10}>
+        <Collapse bordered={false} defaultActiveKey={showCustomize ? [0, 1] : 0} items={items} />
+        <div style={{ margin: "0 10px", width: "fit-content" }}>
+          <Tooltip
+            trigger={["hover", "focus"]}
+            placement="right"
+            title="Clears ALL rendering settings and channel configuration to the default viewer state.
+            This will replace any edits to channel settings, color presets, and rendering adjustments."
+          >
+            <Button onClick={props.resetToDefaultViewerState}>Clear all settings</Button>
+          </Tooltip>
+        </div>
+      </FlexColumn>
+    );
   };
 
   return (
@@ -157,4 +174,4 @@ function ControlPanel(props: ControlPanelProps): React.ReactElement {
   );
 }
 
-export default React.memo(ControlPanel);
+export default React.memo(connectToViewerState(ControlPanel, ["resetToDefaultViewerState"]));

--- a/src/aics-image-viewer/components/GlobalVolumeControls.tsx
+++ b/src/aics-image-viewer/components/GlobalVolumeControls.tsx
@@ -25,7 +25,6 @@ export interface GlobalVolumeControlsProps {
   density: number;
   levels: [number, number, number];
   interpolationEnabled: boolean;
-  getDefaultViewerState: () => ViewerState;
 
   changeViewerSetting: ViewerSettingUpdater;
 }
@@ -45,16 +44,7 @@ const GlobalVolumeControls: React.FC<GlobalVolumeControlsProps> = (props) => {
     return <SliderRow label={label} start={start} max={max} onUpdate={onUpdate} />;
   };
 
-  const { visibleControls: showControls, maskAlpha, brightness, density, levels, getDefaultViewerState } = props;
-
-  const resetToDefaults = (): void => {
-    const { maskAlpha, brightness, density, levels, interpolationEnabled } = getDefaultViewerState();
-    props.changeViewerSetting("maskAlpha", maskAlpha);
-    props.changeViewerSetting("brightness", brightness);
-    props.changeViewerSetting("density", density);
-    props.changeViewerSetting("levels", levels);
-    props.changeViewerSetting("interpolationEnabled", interpolationEnabled);
-  };
+  const { visibleControls: showControls, maskAlpha, brightness, density, levels } = props;
 
   return (
     <div style={{ paddingTop: 18, paddingBottom: 22 }}>
@@ -70,7 +60,6 @@ const GlobalVolumeControls: React.FC<GlobalVolumeControlsProps> = (props) => {
           />
         </SliderRow>
       )}
-      <Button onClick={resetToDefaults}>Reset to defaults</Button>
     </div>
   );
 };
@@ -82,5 +71,4 @@ export default connectToViewerState(GlobalVolumeControls, [
   "levels",
   "interpolationEnabled",
   "changeViewerSetting",
-  "getDefaultViewerState",
 ]);

--- a/src/aics-image-viewer/components/GlobalVolumeControls.tsx
+++ b/src/aics-image-viewer/components/GlobalVolumeControls.tsx
@@ -3,14 +3,7 @@ import { Button, Checkbox } from "antd";
 
 import SliderRow from "./shared/SliderRow";
 import { connectToViewerState } from "./ViewerStateProvider";
-import { ViewerSettingUpdater } from "./ViewerStateProvider/types";
-import {
-  ALPHA_MASK_SLIDER_DEFAULT,
-  BRIGHTNESS_SLIDER_LEVEL_DEFAULT,
-  DENSITY_SLIDER_LEVEL_DEFAULT,
-  INTERPOLATION_ENABLED_DEFAULT,
-  LEVELS_SLIDER_DEFAULT,
-} from "../shared/constants";
+import { ViewerSettingUpdater, ViewerState } from "./ViewerStateProvider/types";
 
 type GlobalVolumeControlKey = "maskAlpha" | "brightness" | "density" | "levels";
 
@@ -32,6 +25,7 @@ export interface GlobalVolumeControlsProps {
   density: number;
   levels: [number, number, number];
   interpolationEnabled: boolean;
+  getDefaultViewerState: () => ViewerState;
 
   changeViewerSetting: ViewerSettingUpdater;
 }
@@ -51,14 +45,15 @@ const GlobalVolumeControls: React.FC<GlobalVolumeControlsProps> = (props) => {
     return <SliderRow label={label} start={start} max={max} onUpdate={onUpdate} />;
   };
 
-  const { visibleControls: showControls, maskAlpha, brightness, density, levels } = props;
+  const { visibleControls: showControls, maskAlpha, brightness, density, levels, getDefaultViewerState } = props;
 
   const resetToDefaults = (): void => {
-    props.changeViewerSetting("maskAlpha", ALPHA_MASK_SLIDER_DEFAULT);
-    props.changeViewerSetting("brightness", BRIGHTNESS_SLIDER_LEVEL_DEFAULT);
-    props.changeViewerSetting("density", DENSITY_SLIDER_LEVEL_DEFAULT);
-    props.changeViewerSetting("levels", LEVELS_SLIDER_DEFAULT);
-    props.changeViewerSetting("interpolationEnabled", INTERPOLATION_ENABLED_DEFAULT);
+    const { maskAlpha, brightness, density, levels, interpolationEnabled } = getDefaultViewerState();
+    props.changeViewerSetting("maskAlpha", maskAlpha);
+    props.changeViewerSetting("brightness", brightness);
+    props.changeViewerSetting("density", density);
+    props.changeViewerSetting("levels", levels);
+    props.changeViewerSetting("interpolationEnabled", interpolationEnabled);
   };
 
   return (
@@ -87,4 +82,5 @@ export default connectToViewerState(GlobalVolumeControls, [
   "levels",
   "interpolationEnabled",
   "changeViewerSetting",
+  "getDefaultViewerState",
 ]);

--- a/src/aics-image-viewer/components/GlobalVolumeControls.tsx
+++ b/src/aics-image-viewer/components/GlobalVolumeControls.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { Button, Checkbox } from "antd";
+import { Checkbox } from "antd";
 
 import SliderRow from "./shared/SliderRow";
 import { connectToViewerState } from "./ViewerStateProvider";
-import { ViewerSettingUpdater, ViewerState } from "./ViewerStateProvider/types";
+import { ViewerSettingUpdater } from "./ViewerStateProvider/types";
 
 type GlobalVolumeControlKey = "maskAlpha" | "brightness" | "density" | "levels";
 

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -14,6 +14,7 @@ import "./styles.css";
 import { UndoOutlined } from "@ant-design/icons";
 import { VisuallyHidden } from "../../../../website/components/LandingPage/utils";
 import { resetChannelState, resetViewerState } from "../../shared/utils/viewerState";
+import { getEmptyChannelState } from "../../shared/constants";
 
 interface ToolbarProps {
   // From parent
@@ -43,7 +44,7 @@ interface ToolbarProps {
   showAxes: boolean;
   showBoundingBox: boolean;
   changeViewerSetting: ViewerSettingUpdater;
-  getDefaultChannelState: (index: number) => ChannelState;
+  getDefaultChannelState: (index: number) => ChannelState | undefined;
   getDefaultViewerState: () => ViewerState;
   channelSettings: ChannelState[];
   changeChannelSetting: ChannelSettingUpdater;
@@ -170,7 +171,12 @@ class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
 
       for (let i = 0; i < channelSettings.length; i++) {
         const channelState = props.getDefaultChannelState(i);
-        resetChannelState(changeChannelSetting, i, channelState);
+        // Don't override name on reset, otherwise this can delete the channel from the UI.
+        resetChannelState(
+          changeChannelSetting,
+          i,
+          channelState ?? { ...getEmptyChannelState(), name: props.channelSettings[i].name }
+        );
       }
     };
 

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -6,16 +6,13 @@ import ViewModeRadioButtons from "./ViewModeRadioButtons";
 import DownloadButton from "./DownloadButton";
 import { connectToViewerState } from "../ViewerStateProvider";
 
-import { ChannelSettingUpdater, ChannelState, ViewerSettingUpdater, ViewerState } from "../ViewerStateProvider/types";
+import { ChannelSettingUpdater, ChannelState, ViewerSettingUpdater } from "../ViewerStateProvider/types";
 import { ImageType, RenderMode, ViewMode } from "../../shared/enums";
 import ViewerIcon from "../shared/ViewerIcon";
 
 import "./styles.css";
 import { UndoOutlined } from "@ant-design/icons";
 import { VisuallyHidden } from "../../../../website/components/LandingPage/utils";
-import { resetChannelState, resetViewerState } from "../../shared/utils/viewerState";
-import { getEmptyChannelState } from "../../shared/constants";
-
 interface ToolbarProps {
   // From parent
   cellDownloadHref: string;

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -6,11 +6,14 @@ import ViewModeRadioButtons from "./ViewModeRadioButtons";
 import DownloadButton from "./DownloadButton";
 import { connectToViewerState } from "../ViewerStateProvider";
 
-import { ViewerSettingUpdater } from "../ViewerStateProvider/types";
+import { ChannelSettingUpdater, ChannelState, ViewerSettingUpdater, ViewerState } from "../ViewerStateProvider/types";
 import { ImageType, RenderMode, ViewMode } from "../../shared/enums";
 import ViewerIcon from "../shared/ViewerIcon";
 
 import "./styles.css";
+import { UndoOutlined } from "@ant-design/icons";
+import { VisuallyHidden } from "../../../../website/components/LandingPage/utils";
+import { resetChannelState, resetViewerState } from "../../shared/utils/viewerState";
 
 interface ToolbarProps {
   // From parent
@@ -40,6 +43,10 @@ interface ToolbarProps {
   showAxes: boolean;
   showBoundingBox: boolean;
   changeViewerSetting: ViewerSettingUpdater;
+  getDefaultChannelState: (index: number) => ChannelState;
+  getDefaultViewerState: () => ViewerState;
+  channelSettings: ChannelState[];
+  changeChannelSetting: ChannelSettingUpdater;
 }
 
 interface ToolbarState {
@@ -135,7 +142,15 @@ class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
 
   render(): React.ReactElement {
     const { props } = this;
-    const { changeViewerSetting, visibleControls, showAxes, showBoundingBox, autorotate } = props;
+    const {
+      changeViewerSetting,
+      changeChannelSetting,
+      channelSettings,
+      visibleControls,
+      showAxes,
+      showBoundingBox,
+      autorotate,
+    } = props;
     const { scrollMode, scrollBtnLeft, scrollBtnRight } = this.state;
     const twoDMode = props.viewMode !== ViewMode.threeD;
 
@@ -148,6 +163,16 @@ class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
     const turntableToggleTitle = autorotate ? "Turn off turntable" : "Turn on turntable";
 
     const getPopupContainer = this.containerRef.current ? () => this.containerRef.current! : undefined;
+
+    const resetToInitialView = (): void => {
+      const initialDefault = props.getDefaultViewerState();
+      resetViewerState(changeViewerSetting, initialDefault);
+
+      for (let i = 0; i < channelSettings.length; i++) {
+        const channelState = props.getDefaultChannelState(i);
+        resetChannelState(changeChannelSetting, i, channelState);
+      }
+    };
 
     return (
       <div className={`viewer-toolbar-container${scrollMode ? " viewer-toolbar-scroll" : ""}`} ref={this.containerRef}>
@@ -164,7 +189,14 @@ class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
           onWheel={this.wheelHandler}
           onScroll={this.checkScrollBtnVisible}
         >
-          <div className="viewer-toolbar-left" ref={this.leftRef} />
+          <div className="viewer-toolbar-left" ref={this.leftRef}>
+            <Tooltip placement="bottom" title="Reset to initial settings">
+              <Button className="ant-btn-icon-only btn-borderless" onClick={resetToInitialView}>
+                <UndoOutlined />
+                <VisuallyHidden>Reset to initial settings</VisuallyHidden>
+              </Button>
+            </Tooltip>
+          </div>
           <div className="viewer-toolbar-center" ref={this.centerRef}>
             {renderGroup1 && (
               <div className="viewer-toolbar-group">
@@ -284,4 +316,8 @@ export default connectToViewerState(Toolbar, [
   "showAxes",
   "showBoundingBox",
   "changeViewerSetting",
+  "changeChannelSetting",
+  "channelSettings",
+  "getDefaultChannelState",
+  "getDefaultViewerState",
 ]);

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -44,8 +44,7 @@ interface ToolbarProps {
   showAxes: boolean;
   showBoundingBox: boolean;
   changeViewerSetting: ViewerSettingUpdater;
-  getDefaultChannelState: (index: number) => ChannelState | undefined;
-  getDefaultViewerState: () => ViewerState;
+  resetToSavedViewerState: () => void;
   channelSettings: ChannelState[];
   changeChannelSetting: ChannelSettingUpdater;
 }
@@ -143,15 +142,8 @@ class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
 
   render(): React.ReactElement {
     const { props } = this;
-    const {
-      changeViewerSetting,
-      changeChannelSetting,
-      channelSettings,
-      visibleControls,
-      showAxes,
-      showBoundingBox,
-      autorotate,
-    } = props;
+    const { changeViewerSetting, resetToSavedViewerState, visibleControls, showAxes, showBoundingBox, autorotate } =
+      props;
     const { scrollMode, scrollBtnLeft, scrollBtnRight } = this.state;
     const twoDMode = props.viewMode !== ViewMode.threeD;
 
@@ -164,21 +156,6 @@ class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
     const turntableToggleTitle = autorotate ? "Turn off turntable" : "Turn on turntable";
 
     const getPopupContainer = this.containerRef.current ? () => this.containerRef.current! : undefined;
-
-    const resetToInitialView = (): void => {
-      const initialDefault = props.getDefaultViewerState();
-      resetViewerState(changeViewerSetting, initialDefault);
-
-      for (let i = 0; i < channelSettings.length; i++) {
-        const channelState = props.getDefaultChannelState(i);
-        // Don't override name on reset, otherwise this can delete the channel from the UI.
-        resetChannelState(
-          changeChannelSetting,
-          i,
-          channelState ?? { ...getEmptyChannelState(), name: props.channelSettings[i].name }
-        );
-      }
-    };
 
     return (
       <div className={`viewer-toolbar-container${scrollMode ? " viewer-toolbar-scroll" : ""}`} ref={this.containerRef}>
@@ -197,7 +174,7 @@ class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
         >
           <div className="viewer-toolbar-left" ref={this.leftRef}>
             <Tooltip placement="bottom" title="Reset to initial settings">
-              <Button className="ant-btn-icon-only btn-borderless" onClick={resetToInitialView}>
+              <Button className="ant-btn-icon-only btn-borderless" onClick={resetToSavedViewerState}>
                 <UndoOutlined />
                 <VisuallyHidden>Reset to initial settings</VisuallyHidden>
               </Button>
@@ -324,6 +301,5 @@ export default connectToViewerState(Toolbar, [
   "changeViewerSetting",
   "changeChannelSetting",
   "channelSettings",
-  "getDefaultChannelState",
-  "getDefaultViewerState",
+  "resetToSavedViewerState",
 ]);

--- a/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
+++ b/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
@@ -212,8 +212,8 @@ const ViewerStateProvider: React.FC<{ viewerSettings?: Partial<ViewerState> }> =
         viewerSettings.viewMode !== newState.viewMode &&
         (viewerSettings.viewMode === ViewMode.xy || newState.viewMode === ViewMode.xy);
       const isAtDifferentTime = viewerSettings.time !== newState.time;
-      const isAtDifferentZSlice = newState.viewMode === ViewMode.xy;
-      const willNeedResetOnLoad = isInDifferentViewMode || isAtDifferentTime;
+      const isAtDifferentZSlice = newState.viewMode === ViewMode.xy && newState.region.z !== viewerSettings.region.z;
+      const willNeedResetOnLoad = isInDifferentViewMode || isAtDifferentTime || isAtDifferentZSlice;
 
       resetViewerState(changeViewerSetting, newState);
 

--- a/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
+++ b/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
@@ -102,6 +102,17 @@ const channelSettingsReducer = <K extends keyof ChannelState>(
   channelSettings: ChannelState[],
   { index, key, value }: ChannelStateAction<K>
 ): ChannelState[] => {
+  if (key === "controlPoints") {
+    console.log(
+      "ViewerStateProvider: Updating controlPoints for channel ",
+      index,
+      " to ",
+      value.map((cp) => cp.x)
+    );
+  }
+  if (key === "ramp") {
+    console.log("ViewerStateProvider: Updating ramp for channel ", index, " to ", value);
+  }
   if (key === undefined) {
     // ChannelSettingInitAction
     return value as ChannelState[];
@@ -128,8 +139,8 @@ const nullfn = (): void => {};
 const DEFAULT_VIEWER_CONTEXT: ViewerStateContextType = {
   ...getEmptyViewerState(),
   getDefaultViewerState: getEmptyViewerState,
-  getDefaultChannelState: (_index: number) => getEmptyChannelState(),
-  setDefaultChannelState: (_index: number) => nullfn,
+  getDefaultChannelState: (_index: number) => undefined,
+  setDefaultChannelState: nullfn,
   channelSettings: [],
   changeViewerSetting: nullfn,
   setChannelSettings: nullfn,
@@ -186,7 +197,7 @@ const ViewerStateProvider: React.FC<{ viewerSettings?: Partial<ViewerState> }> =
   );
   const defaultChannelSettings = useRef<Record<number, ChannelState>>({}).current;
   const getDefaultChannelState = useCallback(
-    (index: number) => defaultChannelSettings[index] || getEmptyChannelState(),
+    (index: number) => defaultChannelSettings[index],
     [defaultChannelSettings]
   );
   const setDefaultChannelState = useCallback((index: number, state: ChannelState) => {

--- a/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
+++ b/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
@@ -203,11 +203,14 @@ const ViewerStateProvider: React.FC<{ viewerSettings?: Partial<ViewerState> }> =
       cameraState: getDefaultCameraState(),
       ...props.viewerSettings,
     };
-    // Needs reset on reload if one of the view modes is 2D while the other is 3D
+    // Needs reset on reload if one of the view modes is 2D while the other is 3D,
+    // if the timestamp is different,
     // TODO: or if playback is currently enabled in 2D mode
-    const willNeedResetOnLoad =
+    const isInDifferentViewMode =
       viewerSettings.viewMode !== savedViewerState.viewMode &&
       (viewerSettings.viewMode === ViewMode.xy || savedViewerState.viewMode === ViewMode.xy);
+    const isAtDifferentTime = viewerSettings.time !== savedViewerState.time;
+    const willNeedResetOnLoad = isInDifferentViewMode || isAtDifferentTime;
 
     resetViewerState(changeViewerSetting, savedViewerState);
 

--- a/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
+++ b/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
@@ -245,6 +245,10 @@ const ViewerStateProvider: React.FC<{ viewerSettings?: Partial<ViewerState> }> =
 
   const resetToDefaultViewerState = useCallback(() => {
     const defaultChannelStates = channelSettings.map((_, index) => getEmptyChannelState(index));
+    // TODO: How to apply "default" LUT here?
+    for (let i = 0; i < 3; i++) {
+      defaultChannelStates[i].volumeEnabled = true;
+    }
     resetToState({ ...getEmptyViewerState(), cameraState: getDefaultCameraState() }, defaultChannelStates);
   }, [props.viewerSettings, resetToState, channelSettings]);
 

--- a/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
+++ b/src/aics-image-viewer/components/ViewerStateProvider/index.tsx
@@ -11,7 +11,7 @@ import type {
 } from "./types";
 import { RenderMode, ViewMode } from "../../shared/enums";
 import { ColorArray } from "../../shared/utils/colorRepresentations";
-import { getDefaultViewerState } from "../../shared/constants";
+import { getEmptyChannelState, getEmptyViewerState } from "../../shared/constants";
 
 const isObject = <T,>(val: T): val is Extract<T, Record<string, unknown>> =>
   typeof val === "object" && val !== null && !Array.isArray(val);
@@ -120,7 +120,9 @@ const channelSettingsReducer = <K extends keyof ChannelState>(
 const nullfn = (): void => {};
 
 const DEFAULT_VIEWER_CONTEXT: ViewerStateContextType = {
-  ...getDefaultViewerState(),
+  ...getEmptyViewerState(),
+  getDefaultViewerState: getEmptyViewerState,
+  getDefaultChannelState: (index: number) => getEmptyChannelState(),
   channelSettings: [],
   changeViewerSetting: nullfn,
   setChannelSettings: nullfn,
@@ -139,7 +141,7 @@ export const ViewerStateContext = React.createContext<{ ref: ContextRefType }>(D
 
 /** Provides a central store for the state of the viewer, and the methods to update it. */
 const ViewerStateProvider: React.FC<{ viewerSettings?: Partial<ViewerState> }> = (props) => {
-  const [viewerSettings, viewerDispatch] = useReducer(viewerSettingsReducer, { ...getDefaultViewerState() });
+  const [viewerSettings, viewerDispatch] = useReducer(viewerSettingsReducer, { ...getEmptyViewerState() });
   const [channelSettings, channelDispatch] = useReducer(channelSettingsReducer, []);
   // Provide viewer state via a ref, so that closures that run asynchronously can capture the ref instead of the
   // specific values they need and always have the most up-to-date state.
@@ -177,6 +179,8 @@ const ViewerStateProvider: React.FC<{ viewerSettings?: Partial<ViewerState> }> =
       setChannelSettings,
       changeChannelSetting,
       applyColorPresets,
+      getDefaultViewerState: getEmptyViewerState,
+      getDefaultChannelState: getEmptyChannelState,
     };
 
     // `ref` is wrapped in another object to ensure that the context updates when state does.

--- a/src/aics-image-viewer/components/ViewerStateProvider/types.ts
+++ b/src/aics-image-viewer/components/ViewerStateProvider/types.ts
@@ -86,8 +86,6 @@ export type ViewerStateContextType = ViewerState & {
    * Use `constants.getEmptyChannelState()` to get the global default channel state.
    */
   getDefaultChannelState: (index: number) => ChannelState;
-  /** Overrides the default viewer state returned by `getDefaultViewerState()`. */
-  setDefaultViewerState: (state: ViewerState) => void;
   /** Overrides the default channel state returned by `getDefaultChannelState()` for
    * channel index `index`.
    */

--- a/src/aics-image-viewer/components/ViewerStateProvider/types.ts
+++ b/src/aics-image-viewer/components/ViewerStateProvider/types.ts
@@ -78,6 +78,8 @@ export type SingleChannelSettingUpdater = <K extends ChannelStateKey>(key: K, va
 
 export type ViewerStateContextType = ViewerState & {
   channelSettings: ChannelState[];
+  getDefaultViewerState: () => ViewerState;
+  getDefaultChannelState: (index: number) => ChannelState;
   changeViewerSetting: ViewerSettingUpdater;
   changeChannelSetting: ChannelSettingUpdater;
   setChannelSettings: (settings: ChannelState[]) => void;

--- a/src/aics-image-viewer/components/ViewerStateProvider/types.ts
+++ b/src/aics-image-viewer/components/ViewerStateProvider/types.ts
@@ -78,8 +78,20 @@ export type SingleChannelSettingUpdater = <K extends ChannelStateKey>(key: K, va
 
 export type ViewerStateContextType = ViewerState & {
   channelSettings: ChannelState[];
+  /** Returns the default viewer state for the current session.
+   * Use `constants.getEmptyViewerState()` to get the global default viewer state.
+   */
   getDefaultViewerState: () => ViewerState;
+  /** Returns the default channel state for channel index `index` for the current session.
+   * Use `constants.getEmptyChannelState()` to get the global default channel state.
+   */
   getDefaultChannelState: (index: number) => ChannelState;
+  /** Overrides the default viewer state returned by `getDefaultViewerState()`. */
+  setDefaultViewerState: (state: ViewerState) => void;
+  /** Overrides the default channel state returned by `getDefaultChannelState()` for
+   * channel index `index`.
+   */
+  setDefaultChannelState: (index: number, state: ChannelState) => void;
   changeViewerSetting: ViewerSettingUpdater;
   changeChannelSetting: ChannelSettingUpdater;
   setChannelSettings: (settings: ChannelState[]) => void;

--- a/src/aics-image-viewer/components/ViewerStateProvider/types.ts
+++ b/src/aics-image-viewer/components/ViewerStateProvider/types.ts
@@ -88,7 +88,7 @@ export type ViewerStateContextType = ViewerState & {
    * Resets the viewer and all channels to the default state, as though
    * loaded from scratch with no initial parameters set.
    */
-  // resetToDefaultViewerState: () => void;
+  resetToDefaultViewerState: () => void;
   /** Overrides the default channel state returned by `getDefaultChannelState()` for
    * channel index `index`.
    */

--- a/src/aics-image-viewer/components/ViewerStateProvider/types.ts
+++ b/src/aics-image-viewer/components/ViewerStateProvider/types.ts
@@ -85,7 +85,7 @@ export type ViewerStateContextType = ViewerState & {
   /** Returns the default channel state for channel index `index` for the current session.
    * Use `constants.getEmptyChannelState()` to get the global default channel state.
    */
-  getDefaultChannelState: (index: number) => ChannelState;
+  getDefaultChannelState: (index: number) => ChannelState | undefined;
   /** Overrides the default channel state returned by `getDefaultChannelState()` for
    * channel index `index`.
    */

--- a/src/aics-image-viewer/components/ViewerStateProvider/types.ts
+++ b/src/aics-image-viewer/components/ViewerStateProvider/types.ts
@@ -94,7 +94,7 @@ export type ViewerStateContextType = ViewerState & {
    */
   setSavedChannelState: (index: number, state: ChannelState) => void;
   getSavedChannelState: (index: number) => ChannelState;
-  // onVolumeLoaded: (volume: Volume) => void;
+  onChannelLoaded: (volume: Volume, channelIndex: number) => void;
   changeViewerSetting: ViewerSettingUpdater;
   changeChannelSetting: ChannelSettingUpdater;
   setChannelSettings: (settings: ChannelState[]) => void;

--- a/src/aics-image-viewer/components/ViewerStateProvider/types.ts
+++ b/src/aics-image-viewer/components/ViewerStateProvider/types.ts
@@ -1,4 +1,4 @@
-import { CameraState, ControlPoint } from "@aics/volume-viewer";
+import { CameraState, ControlPoint, Volume } from "@aics/volume-viewer";
 import type { ImageType, RenderMode, ViewMode } from "../../shared/enums";
 import type { PerAxis } from "../../shared/types";
 import type { ColorArray } from "../../shared/utils/colorRepresentations";
@@ -78,18 +78,23 @@ export type SingleChannelSettingUpdater = <K extends ChannelStateKey>(key: K, va
 
 export type ViewerStateContextType = ViewerState & {
   channelSettings: ChannelState[];
-  /** Returns the default viewer state for the current session.
-   * Use `constants.getEmptyViewerState()` to get the global default viewer state.
+  /**
+   * Resets the viewer and all channels to a saved initial state, determined
+   * by the initial parameters passed to the viewer.
+   * Saved states for channels can be set with `setSavedChannelState()`.
    */
-  getDefaultViewerState: () => ViewerState;
-  /** Returns the default channel state for channel index `index` for the current session.
-   * Use `constants.getEmptyChannelState()` to get the global default channel state.
+  resetToSavedViewerState: () => void;
+  /**
+   * Resets the viewer and all channels to the default state, as though
+   * loaded from scratch with no initial parameters set.
    */
-  getDefaultChannelState: (index: number) => ChannelState | undefined;
+  // resetToDefaultViewerState: () => void;
   /** Overrides the default channel state returned by `getDefaultChannelState()` for
    * channel index `index`.
    */
-  setDefaultChannelState: (index: number, state: ChannelState) => void;
+  setSavedChannelState: (index: number, state: ChannelState) => void;
+  getSavedChannelState: (index: number) => ChannelState;
+  // onVolumeLoaded: (volume: Volume) => void;
   changeViewerSetting: ViewerSettingUpdater;
   changeChannelSetting: ChannelSettingUpdater;
   setChannelSettings: (settings: ChannelState[]) => void;

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -93,7 +93,11 @@ export const PRESET_COLOR_MAP = Object.freeze([
   },
 ]);
 
-export const getDefaultViewerState = (): ViewerState => ({
+/**
+ * Returns the blank, default viewer state. Note that this is named differently from
+ * `getDefaultViewerState` in `ViewerStateProvider`, since the 'default' state can be overridden.
+ */
+export const getEmptyViewerState = (): ViewerState => ({
   viewMode: ViewMode.threeD, // "XY", "XZ", "YZ"
   renderMode: RenderMode.volumetric, // "pathtrace", "maxproject"
   imageType: ImageType.segmentedCell,
@@ -119,7 +123,11 @@ export const getDefaultViewerState = (): ViewerState => ({
   },
 });
 
-export const getDefaultChannelState = (): ChannelState => ({
+/**
+ * Returns the blank, default channel state. Note that this is named differently from
+ * `getDefaultChannelState` in `ViewerStateProvider`, since the 'default' state can be overridden.
+ */
+export const getEmptyChannelState = (): ChannelState => ({
   name: "",
   volumeEnabled: false,
   isosurfaceEnabled: false,

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -143,19 +143,23 @@ export const getEmptyViewerState = (): ViewerState => ({
  * Returns the blank, default channel state. Note that this is named differently from
  * `getDefaultChannelState` in `ViewerStateProvider`, since the 'default' state can be overridden.
  */
-export const getEmptyChannelState = (): ChannelState => ({
-  name: "",
-  volumeEnabled: false,
-  isosurfaceEnabled: false,
-  colorizeEnabled: false,
-  colorizeAlpha: 1.0,
-  isovalue: 128,
-  opacity: 1.0,
-  color: [226, 205, 179] as ColorArray,
-  useControlPoints: false,
-  ramp: [0, TFEDITOR_MAX_BIN],
-  controlPoints: [
-    { x: 0, opacity: 0, color: [255, 255, 255] },
-    { x: 255, opacity: 1, color: [255, 255, 255] },
-  ],
-});
+export const getEmptyChannelState = (index: number = 0): ChannelState => {
+  const color = PRESET_COLORS_0[index % PRESET_COLORS_0.length];
+
+  return {
+    name: "",
+    volumeEnabled: false,
+    isosurfaceEnabled: false,
+    colorizeEnabled: false,
+    colorizeAlpha: 1.0,
+    isovalue: 128,
+    opacity: 1.0,
+    color: color,
+    useControlPoints: false,
+    ramp: [0, TFEDITOR_MAX_BIN],
+    controlPoints: [
+      { x: 0, opacity: 0, color: [255, 255, 255] },
+      { x: 255, opacity: 1, color: [255, 255, 255] },
+    ],
+  };
+};

--- a/src/aics-image-viewer/shared/utils/viewerState.ts
+++ b/src/aics-image-viewer/shared/utils/viewerState.ts
@@ -20,7 +20,13 @@ export function resetChannelState(
   index: number,
   newState: ChannelState
 ): void {
+  console.log("Resetting channel ", index);
   for (const key of Object.keys(newState) as (keyof ChannelState)[]) {
+    // Skip resetting name to default, since this causes channels to be dropped from the
+    // UI altogether.
+    if (key === "name") {
+      continue;
+    }
     changeChannelSetting(index, key, newState[key] as any);
   }
 }

--- a/src/aics-image-viewer/shared/utils/viewerState.ts
+++ b/src/aics-image-viewer/shared/utils/viewerState.ts
@@ -1,0 +1,26 @@
+import {
+  ChannelSettingUpdater,
+  ChannelState,
+  ViewerSettingUpdater,
+  ViewerState,
+} from "../../components/ViewerStateProvider/types";
+
+export function resetViewerState(changeViewerSetting: ViewerSettingUpdater, newState: ViewerState): void {
+  for (const key of Object.keys(newState) as (keyof ViewerState)[]) {
+    changeViewerSetting(key, newState[key] as any);
+  }
+
+  // Pathtrace mode is not allowed in 2D mode. Handle the edge case where the user switched
+  // from 2D mode to 3D mode but pathtrace mode was forcibly disabled.
+  changeViewerSetting("renderMode", newState.renderMode);
+}
+
+export function resetChannelState(
+  changeChannelSetting: ChannelSettingUpdater,
+  index: number,
+  newState: ChannelState
+): void {
+  for (const key of Object.keys(newState) as (keyof ChannelState)[]) {
+    changeChannelSetting(index, key, newState[key] as any);
+  }
+}

--- a/src/aics-image-viewer/shared/utils/viewerState.ts
+++ b/src/aics-image-viewer/shared/utils/viewerState.ts
@@ -1,9 +1,11 @@
+import { Volume } from "@aics/volume-viewer";
 import {
   ChannelSettingUpdater,
   ChannelState,
   ViewerSettingUpdater,
   ViewerState,
 } from "../../components/ViewerStateProvider/types";
+import { ViewMode } from "../enums";
 
 export function resetViewerState(changeViewerSetting: ViewerSettingUpdater, newState: ViewerState): void {
   for (const key of Object.keys(newState) as (keyof ViewerState)[]) {
@@ -29,4 +31,11 @@ export function resetChannelState(
     }
     changeChannelSetting(index, key, newState[key] as any);
   }
+}
+
+// TODO: Does this fail if data is chunked in a way that does not allow for subregions of chunk size z=1? Is that possible?
+export function doesVolumeMatchViewMode(viewMode: ViewMode, volume: Volume): boolean {
+  const isXyAndLoadingXy = viewMode === ViewMode.xy && volume.imageInfo.subregionSize.z === 1;
+  const is3dAndLoading3d = viewMode === ViewMode.threeD && volume.imageInfo.subregionSize.z > 1;
+  return isXyAndLoadingXy || is3dAndLoading3d;
 }

--- a/src/aics-image-viewer/shared/utils/viewerState.ts
+++ b/src/aics-image-viewer/shared/utils/viewerState.ts
@@ -36,6 +36,16 @@ export function resetChannelState(
 // TODO: Does this fail if data is chunked in a way that does not allow for subregions of chunk size z=1? Is that possible?
 export function doesVolumeMatchViewMode(viewMode: ViewMode, volume: Volume): boolean {
   const isXyAndLoadingXy = viewMode === ViewMode.xy && volume.imageInfo.subregionSize.z === 1;
-  const is3dAndLoading3d = viewMode === ViewMode.threeD && volume.imageInfo.subregionSize.z > 1;
+  const is3dAndLoading3d = viewMode !== ViewMode.xy && volume.imageInfo.subregionSize.z > 1;
   return isXyAndLoadingXy || is3dAndLoading3d;
+}
+
+export function getEnabledChannelIndices(channelSettings: ChannelState[]): Set<number> {
+  const enabledChannels = new Set<number>();
+  for (let i = 0; i < channelSettings.length; i++) {
+    if (channelSettings[i].volumeEnabled || channelSettings[i].isosurfaceEnabled) {
+      enabledChannels.add(i);
+    }
+  }
+  return enabledChannels;
 }

--- a/website/utils/test/url_utils.test.ts
+++ b/website/utils/test/url_utils.test.ts
@@ -20,7 +20,7 @@ import {
 import { ChannelState, ViewerState } from "../../../src/aics-image-viewer/components/ViewerStateProvider/types";
 import { ImageType, RenderMode, ViewMode } from "../../../src/aics-image-viewer/shared/enums";
 import { ViewerChannelSetting } from "../../../src/aics-image-viewer/shared/utils/viewerChannelSettings";
-import { getDefaultChannelState, getDefaultViewerState } from "../../../src/aics-image-viewer/shared/constants";
+import { getEmptyChannelState, getEmptyViewerState } from "../../../src/aics-image-viewer/shared/constants";
 
 const defaultSettings: ViewerChannelSetting = {
   match: 0,
@@ -832,7 +832,7 @@ describe("serializeViewerUrlParams", () => {
   });
 
   it("can remove viewer settings that match the default", () => {
-    const defaultViewerSettings = getDefaultViewerState();
+    const defaultViewerSettings = getEmptyViewerState();
     const customViewerState: Partial<ViewerState> = {
       viewMode: ViewMode.xy,
       density: 100,
@@ -862,7 +862,7 @@ describe("serializeViewerUrlParams", () => {
       isovalue: 49,
     };
     const serializedParams = serializeViewerUrlParams(
-      { ...getDefaultViewerState(), channelSettings: [{ ...getDefaultChannelState(), ...customChannelState }] },
+      { ...getEmptyViewerState(), channelSettings: [{ ...getEmptyChannelState(), ...customChannelState }] },
       true
     ) as Record<string, string>;
     const urlParams = new URLSearchParams(serializedParams);
@@ -873,13 +873,13 @@ describe("serializeViewerUrlParams", () => {
 
   it("does not use object reference comparison on control points when excluding defaults", () => {
     // Expand control points so it isn't comparing an object reference
-    const defaultChannelState = getDefaultChannelState();
+    const defaultChannelState = getEmptyChannelState();
     const customChannelState: Partial<ChannelState> = {
       controlPoints: [{ ...defaultChannelState.controlPoints[0] }, { ...defaultChannelState.controlPoints[1] }],
     };
 
     const serializedParams = serializeViewerUrlParams(
-      { ...getDefaultViewerState(), channelSettings: [{ ...defaultChannelState, ...customChannelState }] },
+      { ...getEmptyViewerState(), channelSettings: [{ ...defaultChannelState, ...customChannelState }] },
       true
     ) as Record<string, string>;
     const urlParams = new URLSearchParams(serializedParams);

--- a/website/utils/url_utils.ts
+++ b/website/utils/url_utils.ts
@@ -17,7 +17,7 @@ import { PerAxis } from "../../src/aics-image-viewer/shared/types";
 import { clamp } from "./math_utils";
 import { removeMatchingProperties, removeUndefinedProperties } from "./datatype_utils";
 import { isEqual } from "lodash";
-import { getDefaultChannelState, getDefaultViewerState } from "../../src/aics-image-viewer/shared/constants";
+import { getEmptyChannelState, getEmptyViewerState } from "../../src/aics-image-viewer/shared/constants";
 
 export const ENCODED_COMMA_REGEX = /%2C/g;
 export const ENCODED_COLON_REGEX = /%3A/g;
@@ -575,7 +575,7 @@ function parseCameraState(cameraSettings: string | undefined): Partial<CameraSta
 
 function serializeCameraState(cameraState: Partial<CameraState>, removeDefaults: boolean): string | undefined {
   if (removeDefaults) {
-    cameraState = removeMatchingProperties(cameraState, getDefaultViewerState().cameraState ?? {});
+    cameraState = removeMatchingProperties(cameraState, getEmptyViewerState().cameraState ?? {});
     if (Object.keys(cameraState).length === 0) {
       return undefined;
     }
@@ -693,7 +693,7 @@ export function serializeViewerChannelSetting(
   removeDefaults: boolean
 ): Partial<ViewerChannelSettingParams> {
   if (removeDefaults) {
-    channelSetting = removeMatchingProperties(channelSetting, getDefaultChannelState());
+    channelSetting = removeMatchingProperties(channelSetting, getEmptyChannelState());
   }
   return removeUndefinedProperties({
     [ViewerChannelSettingKeys.VolumeEnabled]: serializeBoolean(channelSetting.volumeEnabled),
@@ -766,7 +766,7 @@ export function deserializeViewerState(params: ViewerStateParams): Partial<Viewe
  */
 export function serializeViewerState(state: Partial<ViewerState>, removeDefaults: boolean): ViewerStateParams {
   if (removeDefaults) {
-    state = removeMatchingProperties(state, getDefaultViewerState());
+    state = removeMatchingProperties(state, getEmptyViewerState());
   }
   const result: ViewerStateParams = {
     [ViewerStateKeys.Mode]: state.renderMode,


### PR DESCRIPTION
THIS PR IS WIP!

Closes #174. This change removes some of the first attempts at making a reset to defaults button, and updates it based on the new UX-agreed-upon spec. 

## Changes
- Removes old reset to defaults buttons/behavior in the advanced settings area, channels widget, and channel settings menu.
- Updates `ViewerStateContext` to include additional state:
  - `resetToSavedViewerState`: Resets to the initial view on viewer startup, determined by the input parameters passed to the viewer.
  - `resetToDefaultViewerState`: Resets to the global viewer default.
  - `setSavedChannelState`/`getSavedChannelState`: For each channel, gets or sets a saved state that can be returned to via the reset behavior.
  - `onChannelLoaded`: callback that should be invoked when a channel is loaded.
- Adds a reset button to the viewport toolbar that resets to the initial view seen on load (`resetToSavedViewerState`)
- Adds a reset button ("Clear all settings") in the advanced rendering settings menu that resets to the global viewer default.

## Screenshots

## Keyfiles
