### PR TITLE
feat: Updated PR format, added PR previews

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,44 @@
-**Pull request recommendations:**
+Problem
+=======
+What is the problem this work solves, including
+[Link to story or ticket](https://my-tracking-system.url/ticket-number)
 
-- [ ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
-- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
-- [ ] Provide description and context of changes.
-- [ ] Provide relevant tests for your feature or bug fix.
-- [ ] Provide or update documentation for any feature added by your pull request.
+Solution
+========
+What I/we did to solve this problem
+
+with @pairperson1
+
+## Type of change
+Please delete options that are not relevant.
+
+* Bug fix (non-breaking change which fixes an issue)
+* New feature (non-breaking change which adds functionality)
+* Breaking change (fix or feature that would cause existing functionality to not work as expected)
+* This change requires a documentation update
+* This change requires updated or new tests
+
+Change summary:
+---------------
+* Tidy, well formulated commit message
+* Another great commit message
+* Something else I/we did
+
+Steps to Verify:
+----------------
+1. A setup step / beginning state
+1. What to do next
+1. Any other instructions
+1. Expected behavior
+1. Suggestions for testing
+
+Screenshots (optional):
+-----------------------
+Show-n-tell images/animations here
+
+Keyfiles (delete if not relevant):
+-----------------------
+1. main file/entry point
+2. other important file
 
 Thanks for contributing!

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: github pages
+name: Github Pages Nightly
 
 env:
   NODE_VERSION: "18"
@@ -6,7 +6,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "7 0 * * *"
 
 jobs:
   deploy:
@@ -37,9 +37,9 @@ jobs:
           echo "::set-output name=tag_name::${TAG_NAME}"
           echo "::set-output name=deploy_tag_name::deploy-${TAG_NAME}"
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847
+        uses: JamesIves/github-pages-deploy-action@881db5376404c5c8d621010bcbec0310b58d5e29
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./imageviewer
-          tag_name: ${{ steps.prepare_tag.outputs.deploy_tag_name }}
-          tag_message: "Deployment to gh-pages to test new viewer ${{ steps.prepare_tag.outputs.tag_name }}"
+          folder: ./imageviewer
+          # Leave existing PR preview deployments in place
+          clean-exclude: pr-preview/
+          commit-message: "Deployment to gh-pages to test new viewer ${{ steps.prepare_tag.outputs.tag_name }}"

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,30 @@
+# Adapted from https://github.com/marketplace/actions/deploy-pr-preview.
+name: GitHub Pages PR Preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+
+        # Must override default webpack build base so that assets can still be accessed when not placed in the root directory of gh-pages branch.
+      - name: Install and Build
+        run: npm ci && webpack --config webpack.dev.js --env env=production basename=/website-3d-cell-viewer/pr-preview/pr-${PR_NUMBER}/
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@430e3dfc1de8a8ae77e77d862d25676ef9db55d1
+        with:
+          source-dir: ./imageviewer/


### PR DESCRIPTION
Closes #241 ("Add PR previews via GitHub pages") and #218 "Update the PR template".

Much of these changes was copied from TFE, where we're already using the PR preview system.

*Estimated review size: small, 5-10 minutes*

## Changes
- Updates the PR template format to match other repos.
- Adds the PR preview action so PRs will automatically have a GitHub pages preview build associated with them.
  - Updates the existing nightly build to prevent overwriting of PR previews.
 
## Validation
- PR preview! https://allen-cell-animated.github.io/website-3d-cell-viewer/pr-preview/pr-326/
