### PR TITLE
Fix invisible brain image

### DIFF
--- a/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
+++ b/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
@@ -133,7 +133,8 @@ export function controlPointsToRamp(controlPoints: ControlPoint[]): [number, num
   } else if (controlPoints.length === 3) {
     if (
       controlPoints[0].opacity !== controlPoints[1].opacity &&
-      controlPoints[0].opacity !== controlPoints[2].opacity
+      controlPoints[0].opacity !== controlPoints[2].opacity &&
+      controlPoints[1].opacity !== controlPoints[2].opacity
     ) {
       // if all 3 are unequal, assume a ramp from first to last
       return [controlPoints[0].x, controlPoints[2].x];

--- a/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
+++ b/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
@@ -126,7 +126,7 @@ export function initializeLut(
 }
 
 export function controlPointsToRamp(controlPoints: ControlPoint[]): [number, number] {
-  if (controlPoints.length === 1) {
+  if (controlPoints.length <= 1) {
     return [0, TFEDITOR_MAX_BIN];
   } else if (controlPoints.length === 2) {
     return [controlPoints[0].x, controlPoints[1].x];

--- a/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
+++ b/src/aics-image-viewer/shared/utils/controlPointsToLut.ts
@@ -126,10 +126,22 @@ export function initializeLut(
 }
 
 export function controlPointsToRamp(controlPoints: ControlPoint[]): [number, number] {
-  if (controlPoints.length === 1 || controlPoints.length === 3) {
+  if (controlPoints.length === 1) {
     return [0, TFEDITOR_MAX_BIN];
   } else if (controlPoints.length === 2) {
     return [controlPoints[0].x, controlPoints[1].x];
+  } else if (controlPoints.length === 3) {
+    if (
+      controlPoints[0].opacity !== controlPoints[1].opacity &&
+      controlPoints[0].opacity !== controlPoints[2].opacity
+    ) {
+      // if all 3 are unequal, assume a ramp from first to last
+      return [controlPoints[0].x, controlPoints[2].x];
+    } else if (controlPoints[0].opacity !== controlPoints[1].opacity) {
+      return [controlPoints[0].x, controlPoints[1].x];
+    } else if (controlPoints[1].opacity !== controlPoints[2].opacity) {
+      return [controlPoints[1].x, controlPoints[2].x];
+    }
   }
   return [controlPoints[1].x, controlPoints[controlPoints.length - 2].x];
 }


### PR DESCRIPTION
Default LUT had 3 control points and our code was not handling it well.
In production viewer, this url would load and ultimately reset its luts to a generic fullrange LUT which made the image invisible.
With the changes, the volumes show up as expected.
https://allen-genetic-tools.s3.amazonaws.com/tissuecyte/1298553550/ome-zarr

The code change is just trying to make a reasonable guess at a min/max from the given LUT control points.

