### PR TITLE
fix: Channels are no longer renamed

### DIFF
--- a/src/aics-image-viewer/shared/utils/viewerState.ts
+++ b/src/aics-image-viewer/shared/utils/viewerState.ts
@@ -1,7 +1,7 @@
-import { ColorArray } from "./colorRepresentations";
 import { ChannelState, ViewerSettingUpdater, ViewerState } from "../../components/ViewerStateProvider/types";
 import { getDefaultChannelState } from "../constants";
-import { ViewerChannelSettings, ViewerChannelSetting, findFirstChannelMatch } from "./viewerChannelSettings";
+import { ColorArray } from "./colorRepresentations";
+import { findFirstChannelMatch, ViewerChannelSetting, ViewerChannelSettings } from "./viewerChannelSettings";
 
 /** Sets all fields of the viewer state to the values of the `newState`. */
 export function overrideViewerState(changeViewerSetting: ViewerSettingUpdater, newState: ViewerState): void {
@@ -65,7 +65,7 @@ export function initializeOneChannelSetting(
   }
 
   return {
-    name: initSettings.name ?? channel ?? "Channel " + index,
+    name: channel ?? "Channel " + index,
     volumeEnabled: initSettings.enabled ?? defaultChannelState.volumeEnabled,
     isosurfaceEnabled: initSettings.surfaceEnabled ?? defaultChannelState.isosurfaceEnabled,
     colorizeEnabled: initSettings.colorizeEnabled ?? defaultChannelState.colorizeEnabled,

--- a/src/aics-image-viewer/shared/utils/viewerState.ts
+++ b/src/aics-image-viewer/shared/utils/viewerState.ts
@@ -52,7 +52,7 @@ export function colorHexToArray(hex: string): ColorArray | null {
 }
 
 export function initializeOneChannelSetting(
-  channel: string,
+  channelName: string,
   index: number,
   defaultColor: ColorArray,
   viewerChannelSettings?: ViewerChannelSettings,
@@ -61,11 +61,11 @@ export function initializeOneChannelSetting(
   let initSettings = {} as Partial<ViewerChannelSetting>;
   if (viewerChannelSettings) {
     // search for channel in settings using groups, names and match values
-    initSettings = findFirstChannelMatch(channel, index, viewerChannelSettings) ?? {};
+    initSettings = findFirstChannelMatch(channelName, index, viewerChannelSettings) ?? {};
   }
 
   return {
-    name: channel ?? "Channel " + index,
+    name: channelName ?? "Channel " + index,
     volumeEnabled: initSettings.enabled ?? defaultChannelState.volumeEnabled,
     isosurfaceEnabled: initSettings.surfaceEnabled ?? defaultChannelState.isosurfaceEnabled,
     colorizeEnabled: initSettings.colorizeEnabled ?? defaultChannelState.colorizeEnabled,


### PR DESCRIPTION
Problem
=======
Closes #325, "don't rename channels in `ChannelState`."

*Estimated review size: tiny, 2 minutes*

Solution
========
- `initializeOneChannelSetting` no longer renames channels unless no value is provided.

## Type of change
* Bug fix (non-breaking change which fixes an issue)