### PR TITLE
fix: Slider max now reflects zero-based indexing

### DIFF
--- a/src/aics-image-viewer/assets/styles/noui-slider-override.css
+++ b/src/aics-image-viewer/assets/styles/noui-slider-override.css
@@ -2,7 +2,7 @@
 
 %axis-override {
   /*slider settings*/
-  .noUi-handle {
+  .noUi-horizontal .noUi-handle {
     box-shadow: none;
     cursor: pointer;
     pointer-events: inherit;

--- a/src/aics-image-viewer/components/AxisClipSliders/index.tsx
+++ b/src/aics-image-viewer/components/AxisClipSliders/index.tsx
@@ -1,17 +1,17 @@
-import React, { useCallback, useEffect, useState } from "react";
-import { Button, Tooltip } from "antd";
-import { CaretRightOutlined, PauseOutlined } from "@ant-design/icons";
 import { Volume } from "@aics/volume-viewer";
+import { CaretRightOutlined, PauseOutlined } from "@ant-design/icons";
+import { Button, Tooltip } from "antd";
+import React, { useCallback, useEffect, useState } from "react";
+
+import { ViewMode } from "../../shared/enums";
+import { activeAxisMap, AxisName, PerAxis } from "../../shared/types";
+import PlayControls from "../../shared/utils/playControls";
+import { ViewerSettingUpdater } from "../ViewerStateProvider/types";
 
 import NumericInput from "../shared/NumericInput";
 import SmarterSlider from "../shared/SmarterSlider";
 
 import "./styles.css";
-
-import { ViewMode } from "../../shared/enums";
-import { ViewerSettingUpdater } from "../ViewerStateProvider/types";
-import { AxisName, PerAxis, activeAxisMap } from "../../shared/types";
-import PlayControls from "../../shared/utils/playControls";
 
 const AXES: AxisName[] = ["x", "y", "z"];
 
@@ -92,7 +92,7 @@ const SliderRow: React.FC<SliderRowProps> = ({
             </>
           )}
           {" / "}
-          {max}
+          {max - 1}
         </span>
       )}
     </span>


### PR DESCRIPTION
Problem
=======
Closes #303, "last timepoint is (N-1)/N".

Subtracted 1 from the max to reflect zero-based indexing used for time and z-index.

*Estimated review size: tiny, <5 minutes*

Solution
========
- Timepoint denominator now matches maximum slider value.
- Sorted imports.
- Copied a change from #324 which fixes a rendering bug in the slider.

## Type of change
* Bug fix (non-breaking change which fixes an issue)


Screenshots (optional):
-----------------------
![image](https://github.com/user-attachments/assets/aa841e7d-34b2-42a2-aec8-74010a447fbb)

