### PR TITLE
refactor: Updated name from Volume Viewer to Vol-E on landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AICS Image Viewer
+# Vol-E (Volume Explorer)
 
 For the latest stable release, please visit https://allen-cell-animated.github.io/website-3d-cell-viewer-release/
 

--- a/public/gh-reroute/404.html
+++ b/public/gh-reroute/404.html
@@ -1,8 +1,8 @@
-<!DOCTYPE html>
-<html>
+<!doctype html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>AICS 3D Volume Viewer</title>
+    <title>Vol-E</title>
     <style>
       html {
         box-sizing: border-box;
@@ -44,7 +44,7 @@
   <body>
     <div id="error-page-404">
       <h1>Rerouting...</h1>
-      <p>3D Volume Viewer encountered a 404 error when attempting to load this page.</p>
+      <p>Vol-E encountered a 404 error when attempting to load this page.</p>
       <p>
         You should automatically be redirected to a working page. (If this doesn't work, your browser may have
         JavaScript disabled, which the viewer needs to run.)

--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <!-- Google Tag Manager -->
@@ -19,7 +19,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <title>AICS 3D Volume Viewer</title>
+    <title>Vol-E</title>
     <style>
       html {
         box-sizing: border-box;

--- a/website/components/Header.tsx
+++ b/website/components/Header.tsx
@@ -86,7 +86,7 @@ function HeaderLogo({ noNavigate }: { noNavigate?: boolean }): ReactElement {
         rel="noopener noreferrer"
         target={noNavigate ? "_blank" : undefined}
       >
-        <h1>3D Volume Viewer</h1>
+        <h1>Vol-E</h1>
       </HeaderTitleLink>
     </FlexRowAlignCenter>
   );

--- a/website/components/LandingPage/index.tsx
+++ b/website/components/LandingPage/index.tsx
@@ -6,15 +6,15 @@ import { useNavigate } from "react-router";
 import { useSearchParams } from "react-router-dom";
 import styled from "styled-components";
 
-import Header from "../Header";
-import LoadModal from "../Modals/LoadModal";
-import { AppDataProps, DatasetEntry, ProjectEntry } from "../../types";
-import { FlexColumnAlignCenter, FlexColumn, FlexRowAlignCenter, VisuallyHidden } from "./utils";
-import { parseViewerUrlParams } from "../../utils/url_utils";
-import HelpDropdown from "../HelpDropdown";
 import { BannerVideo } from "../../assets/videos";
-
+import { AppDataProps, DatasetEntry, ProjectEntry } from "../../types";
+import { parseViewerUrlParams } from "../../utils/url_utils";
 import { landingPageContent } from "./content";
+import { FlexColumn, FlexColumnAlignCenter, FlexRowAlignCenter, VisuallyHidden } from "./utils";
+
+import Header from "../Header";
+import HelpDropdown from "../HelpDropdown";
+import LoadModal from "../Modals/LoadModal";
 
 const MAX_CONTENT_WIDTH_PX = 1060;
 
@@ -365,9 +365,9 @@ export default function LandingPage(): ReactElement {
           <div></div>
         </BannerVideoContainer>
         <BannerTextContainer style={{ zIndex: 1 }}>
-          <h1>Welcome to 3D Volume Viewer</h1>
+          <h1>Welcome to Vol-E</h1>
           <p>
-            The 3D Volume Viewer is an open-use web-based tool designed to visualize, analyze and interpret
+            Vol-E (Volume Explorer) is an open-use web-based tool designed to visualize, analyze, and interpret
             multi-channel 3D microscopy data. Ideal for researchers, educators, and students, the viewer offers powerful
             interactive tools to extract key insights from imaging data.
           </p>
@@ -378,7 +378,7 @@ export default function LandingPage(): ReactElement {
         <FeatureHighlightsContainer>
           <FeatureHighlightsItem>
             <h3>Multiresolution OME-Zarr support</h3>
-            <p>Load your cloud hosted OME-Zarr v0.4 images via http(s).</p>
+            <p>Load your cloud-hosted OME-Zarr v0.4 images via http(s).</p>
           </FeatureHighlightsItem>
           <FeatureHighlightsItem>
             <h3>Multiple viewing modes</h3>
@@ -390,15 +390,13 @@ export default function LandingPage(): ReactElement {
           </FeatureHighlightsItem>
           <FeatureHighlightsItem>
             <h3>Customizable settings</h3>
-            <p>
-              Switch colors, turn channels on and off or apply a threshold to reveal interesting features in the data.
-            </p>
+            <p>Switch colors, toggle channels, and apply thresholds to reveal interesting features in data.</p>
           </FeatureHighlightsItem>
         </FeatureHighlightsContainer>
       </ContentContainer>
 
       <LoadPromptContainer>
-        <h2 style={{ margin: 0 }}>Load dataset(s) below or your own data to get started</h2>
+        <h2 style={{ margin: 0 }}>Load a dataset below or your own data to get started.</h2>
       </LoadPromptContainer>
 
       <ContentContainer style={{ paddingBottom: "400px" }}>


### PR DESCRIPTION
Problem
=======
Part of #331, renaming. Renames the app to "Vol-E" in the header, HTML documents, landing page content, and README.

*Estimated review size: tiny, <5 minutes*

Solution
========
- Renames "Volume Viewer" to "Vol-E".
- Adjusts some grammar for consistency (oxford commas, etc.)

Screenshots (optional):
-----------------------
Interactive preview here: https://allen-cell-animated.github.io/website-3d-cell-viewer/pr-preview/pr-335/

![image](https://github.com/user-attachments/assets/f6053ee0-20a7-49b8-bff9-a0888b85926f)
