### PR TITLE
fix: Track channel load status individually

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -187,7 +187,7 @@ const App: React.FC<AppProps> = (props) => {
   // State for image loading/reloading
 
   // `true` when this is the initial load of an image
-  const initialLoadRef = useRef(true);
+  const hasChannelLoadedRef = useRef<boolean[]>([]);
   // `true` when image data has been requested, but no data has been received yet
   const [sendingQueryRequest, setSendingQueryRequest] = useState(false);
   // `true` when all channels of the current image are loaded
@@ -258,7 +258,7 @@ const App: React.FC<AppProps> = (props) => {
 
     // If this is the first load of this image, auto-generate initial LUTs
     if (
-      initialLoadRef.current ||
+      !hasChannelLoadedRef.current[channelIndex] ||
       !thisChannelsSettings.controlPoints ||
       !thisChannelsSettings.ramp ||
       getChannelsAwaitingResetOnLoad().has(channelIndex)
@@ -309,6 +309,7 @@ const App: React.FC<AppProps> = (props) => {
     if (aimg.channelNames[channelIndex] === getCurrentViewerChannelSettings()?.maskChannelName) {
       view3d.setVolumeChannelAsMask(aimg, channelIndex);
     }
+    hasChannelLoadedRef.current[channelIndex] = true;
 
     // when any channel data has arrived:
     setSendingQueryRequest(false);
@@ -316,7 +317,6 @@ const App: React.FC<AppProps> = (props) => {
     if (aimg.isLoaded()) {
       view3d.updateActiveChannels(aimg);
       setImageLoaded(true);
-      initialLoadRef.current = false;
       playControls.onImageLoaded();
     }
   };
@@ -400,7 +400,7 @@ const App: React.FC<AppProps> = (props) => {
 
     setSendingQueryRequest(true);
     setImageLoaded(false);
-    initialLoadRef.current = true;
+    hasChannelLoadedRef.current = [];
 
     const loadSpec = new LoadSpec();
     loadSpec.time = viewerState.current.time;

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -186,7 +186,7 @@ const App: React.FC<AppProps> = (props) => {
 
   // State for image loading/reloading
 
-  // `true` when this is the initial load of an image
+  /** `true` when a channel's data has been loaded for the current image. */
   const hasChannelLoadedRef = useRef<boolean[]>([]);
   // `true` when image data has been requested, but no data has been received yet
   const [sendingQueryRequest, setSendingQueryRequest] = useState(false);


### PR DESCRIPTION
Problem
=======
Fixes #342, "Volumes that are initially disabled are remapped incorrectly when enabled."

The issue seemed to be caused by the `initialLoadRef` only allowing normal initialization of channels for enabled channels were loaded for the first time. Channels that were initially disabled, but then enabled later, would have the initial default ramps or control points remapped to incorrect values.

This change fixes the issue by changing `initialLoadRef` to be a boolean array, and the loaded status of each channel is tracked individually. This way, the normal initialization can occur even when a channel is loaded later.

From testing it seems like the bug was introduced in #338, but I can't tell exactly what changes to the viewer would have broken this behavior. 

*Estimated review size: tiny, <5 minutes*

Solution
========
- Channel load status is now tracked using `channelLoadedRef`, and checks for initial load are performed against it.
  - This allows channel LUTs to be initialized for channels that are initially disabled and later reenabled.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Open this URL: http://localhost:9020/viewer?url=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Femt_timelapse_dataset%2Fdata%2F3500005829_4_raw_converted.ome.zarr&mode=maxproject&c0=cps:0:0:1:108:0:1:127:1:1:255:1:1,rmp:108:127&c1=ven:1,col:ffffff,cps:0:0:1:30:0:1:42:1:1:255:1:1,rmp:30:65.495&c2=col:bd10e0,cps:0:0:1:13:0:1:21:1:1:255:1:1,rmp:13:21
2. Enable the Brightfield channel. It should have the expected range of 108, 127.

Screenshots (optional):
-----------------------
![image](https://github.com/user-attachments/assets/35e57941-5004-4c04-966f-dbfae727021f)

