### PR TITLE
refactor: Bump volume-viewer to 3.12.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.10.3",
       "license": "ISC",
       "dependencies": {
-        "@aics/volume-viewer": "^3.12.2",
+        "@aics/volume-viewer": "^3.12.3",
         "@ant-design/icons": "^5.2.5",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
@@ -97,25 +97,23 @@
       }
     },
     "node_modules/@aics/volume-viewer": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.12.2.tgz",
-      "integrity": "sha512-YRL7gYqQcjiudaHyFXPyCqPMKZkUq+pJ4gXTlgEwcNV2ozLei8/xMlJdi6bmvPTDbTyeii2N3mgsJZT2dGXkqw==",
-      "license": "MIT",
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/@aics/volume-viewer/-/volume-viewer-3.12.3.tgz",
+      "integrity": "sha512-iH4BgfucChsaQO6/WEf3rBMnyCETXONhBmhkHKKX3YrJ8hzswEw1NlgBUFKCj5xUxB1K943xVCRgQolYoBbfGA==",
       "dependencies": {
         "@babel/runtime": "^7.25.6",
         "geotiff": "^2.0.5",
         "serialize-error": "^11.0.3",
-        "three": "^0.162.0",
+        "three": "^0.171.0",
         "throttled-queue": "^2.1.4",
         "tweakpane": "^3.1.9",
         "zarrita": "^0.3.2"
       }
     },
     "node_modules/@aics/volume-viewer/node_modules/three": {
-      "version": "0.162.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.162.0.tgz",
-      "integrity": "sha512-xfCYj4RnlozReCmUd+XQzj6/5OjDNHBy5nT6rVwrOKGENAvpXe2z1jL+DZYaMu4/9pNsjH/4Os/VvS9IrH7IOQ==",
-      "license": "MIT"
+      "version": "0.171.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.171.0.tgz",
+      "integrity": "sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/volume-viewer": "^3.12.2",
+    "@aics/volume-viewer": "^3.12.3",
     "@ant-design/icons": "^5.2.5",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",


### PR DESCRIPTION
Picks up the fix for https://github.com/allen-cell-animated/cell-feature-explorer/issues/223 ("volumes are blown out on load") by upgrading to volume-viewer 3.12.3.

## Testing:
1. Open branch and run locally.
2. Open this volume, which was previously bugged: https://s3-us-west-2.amazonaws.com/bisque.allencell.org/v2.0.0/Cell-Viewer_Thumbnails/AICS-14/AICS-14_7889_atlas.json