### PR TITLE
Bump vole-core to v4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.14.0",
       "license": "ISC",
       "dependencies": {
-        "@aics/vole-core": "^4.1.0",
+        "@aics/vole-core": "^4.3.1",
         "@ant-design/icons": "^5.2.5",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@aics/vole-core": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-4.1.0.tgz",
-      "integrity": "sha512-AIyIQ9tUSl5bo60/eV9b28yXa8985aLMbBspliYT9fFEatGuAWb2hdkrL0xRs3ZNY5G/VXjYd+vyGYJI7t7LgA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-4.3.1.tgz",
+      "integrity": "sha512-lVH2oQst3Z5T+BzUPuvV5tRu05ab9yRHT13ZeSsPc0rtmN0yNBeojUzi8cvC7MqqfjLnsfPG4fXi+QjBYuOdbw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.6",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/vole-core": "^4.1.0",
+    "@aics/vole-core": "^4.3.1",
     "@ant-design/icons": "^5.2.5",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",


### PR DESCRIPTION
Review time: tiny (<5min)

Bumps vole-core from v4.1.0 to v4.3.1, picking up these changes:
- allen-cell-animated/vole-core#343
- allen-cell-animated/vole-core#345
- allen-cell-animated/vole-core#346
- allen-cell-animated/vole-core#347
- allen-cell-animated/vole-core#348
