### PR TITLE
fix: Enable OIDC tokens for npm package publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ permissions:
   # See https://docs.github.com/en/actions/concepts/security/openid-connect
   # and https://docs.npmjs.com/trusted-publishers.
   id-token: write
+  contents: read
 
 jobs:
   lint:


### PR DESCRIPTION
Problem
=======
Fixes failing NPM publishing action by switching to the new [OIDC (OpenID Connect) standard](https://docs.github.com/en/actions/concepts/security/openid-connect). This will also require us to update the NPM package as well to use [Trusted Publishers](https://docs.npmjs.com/trusted-publishers).

Solution
========
- Adds token permissions to the `publish.yml` action.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

