### PR TITLE
doc: Add badge linking to NPM package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Vol-E App
 
+<p>
+  <a href="https://www.npmjs.com/package/@aics/vole-app"><img src="https://img.shields.io/npm/v/%40aics%2Fvole-app" alt="npm package"></a>
+</p>
+
 Volume Explorer (Vol-E) is a browser based volume viewer built with React and WebGL (Three.js). This package wraps the [vole-core](https://github.com/allen-cell-animated/vole-core) library.
 
 For the latest stable release, please visit [https://vole.allencell.org](https://vole.allencell.org)


### PR DESCRIPTION
Problem
=======
Tiny documentation update while I was thinking about it! This adds a small badge linking to our NPM package on the README for vole-app:

<p>
  <a href="https://www.npmjs.com/package/@aics/vole-app"><img src="https://img.shields.io/npm/v/%40aics%2Fvole-app" alt="npm package"></a>
</p>

See the new README here: https://github.com/allen-cell-animated/vole-app/blob/03574952b261d4fa35014f5020f72e0c23a6d3e2/README.md