### PR TITLE
Fix syncing URL params to viewer state

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -10,7 +10,6 @@ import {
   CLIPPING_PANEL_HEIGHT_TALL,
   CONTROL_PANEL_CLOSE_WIDTH,
   getDefaultViewerChannelSettings,
-  getDefaultViewerState,
   SCALE_BAR_MARGIN_DEFAULT,
 } from "../../shared/constants";
 import { ImageType, ViewMode } from "../../shared/enums";
@@ -67,7 +66,6 @@ const defaultProps: AppProps = {
 
   appHeight: "100vh",
   visibleControls: defaultVisibleControls,
-  viewerSettings: getDefaultViewerState(),
   cellId: "",
   imageDownloadHref: "",
   parentImageDownloadHref: "",


### PR DESCRIPTION
Review time: tiny (>5min)

# Problem

Resolves #494: global (not per-channel) viewer settings weren't making it from the URL to viewer state.

# Solution

Viewer state parsed out of URL params is now synced directly into the zustand store in `AppWrapper`. *Separately*, `App` detects changes to its `viewerSettings` prop and syncs them to the zustand store, allowing external users of `App` (like CFE) to ergonomically change viewer state from the outside. But `App`'s default value for `viewerSettings` was a record with the default value for every parameter, so since `App`'s initial render happens after URL parsing, every setting we parsed out of URL was immediately overwritten with its default value. No longer providing this default solves the problem.
