### PR TITLE
Toggle sharing single scene or entire collection

### DIFF
--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -23,6 +23,8 @@ const palette = {
   brightGreen: "#61d900",
   veryBrightGreen: "#61ff00",
   brightBlue: "#0099ff",
+  veryBrightBlue: "#0dc4d9",
+  darkBlue: "#29484c",
   darkYellow: "#4c3c29",
 };
 
@@ -124,9 +126,15 @@ const theme = {
       selectedBg: palette.medGrey,
       textPlaceholder: palette.ltPurple,
     },
-    warning: {
-      text: palette.brightYellow,
-      bg: palette.darkYellow,
+    alert: {
+      warning: {
+        text: palette.brightYellow,
+        bg: palette.darkYellow,
+      },
+      info: {
+        text: palette.veryBrightBlue,
+        bg: palette.darkBlue,
+      },
     },
     tooltip: {
       bg: palette.black,
@@ -217,8 +225,10 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
       --color-statusflag-border: ${$theme.colors.statusFlag.border};
       --color-statusflag-text: ${$theme.colors.statusFlag.text};
 
-      --color-message-warning-text: ${theme.colors.warning.text};
-      --color-message-warning-bg: ${theme.colors.warning.bg};
+      --color-alert-warning-text: ${$theme.colors.alert.warning.text};
+      --color-alert-warning-bg: ${$theme.colors.alert.warning.bg};
+      --color-alert-info-text: ${$theme.colors.alert.info.text};
+      --color-alert-info-bg: ${$theme.colors.alert.info.bg};
 
       --color-layout-dividers: ${$theme.colors.layout.dividers};
 
@@ -401,10 +411,14 @@ export default function StyleProvider(props: PropsWithChildren<{}>): ReactElemen
           colorBgContainer: "transparent",
           colorSplit: theme.colors.layout.split,
           colorPrimaryTextHover: theme.colors.text.selectionText,
-          colorWarning: theme.colors.warning.text,
-          colorWarningBg: theme.colors.warning.bg,
-          colorWarningBorder: theme.colors.warning.text,
-          colorWarningText: theme.colors.warning.text,
+          colorWarning: theme.colors.alert.warning.text,
+          colorWarningBg: theme.colors.alert.warning.bg,
+          colorWarningBorder: theme.colors.alert.warning.text,
+          colorWarningText: theme.colors.alert.warning.text,
+          colorInfo: theme.colors.alert.info.text,
+          colorInfoBg: theme.colors.alert.info.bg,
+          colorInfoBorder: theme.colors.alert.info.text,
+          colorInfoText: theme.colors.alert.info.text,
           fontWeightStrong: 400,
           colorBgElevated: palette.darkGrey,
           controlItemBgHover: theme.colors.menu.hoverBg,

--- a/website/components/AppWrapper.tsx
+++ b/website/components/AppWrapper.tsx
@@ -196,7 +196,7 @@ export default function AppWrapper(props: AppWrapperProps): ReactElement {
         <FlexRowAlignCenter $gap={12}>
           <FlexRowAlignCenter $gap={2}>
             <LoadModal onLoad={onLoad} />
-            {viewerProps && <ShareModal appProps={viewerProps} view3dRef={view3dRef} />}
+            {viewerProps && <ShareModal appProps={viewerProps} view3dRef={view3dRef} imageTitle={imageTitle} />}
           </FlexRowAlignCenter>
           <HelpDropdown />
         </FlexRowAlignCenter>

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -158,28 +158,35 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
         footer={null}
       >
         {urls.length > 0 && (
-          <FlexRow style={{ justifyContent: "space-between" }}>
-            <Radio.Group
-              value={showCurrentScene}
-              onChange={(e) => setShowCurrentScene(e.target.value)}
-              options={[
-                { value: false, label: "All scenes" },
-                {
-                  value: true,
-                  label: props.imageTitle !== undefined ? `Current scene (${props.imageTitle})` : "Current scene",
-                },
-              ]}
-            />
-            {hasTooManyScenes && (
-              <Tooltip
-                title={`Vol-E currently has ${urls.length} scenes open. Sharing a large scene collection requires a very long URL. We don't recommend including more than 4 scenes in a sharing link.`}
-                overlayStyle={{ zIndex: 10000 }}
-                placement="left"
-              >
-                <ExclamationCircleOutlined style={{ color: "var(--color-message-warning-text)", cursor: "pointer" }} />
-              </Tooltip>
-            )}
-          </FlexRow>
+          <Radio.Group
+            value={showCurrentScene}
+            onChange={(e) => setShowCurrentScene(e.target.value)}
+            options={[
+              {
+                value: true,
+                label: props.imageTitle !== undefined ? `Current scene (${props.imageTitle})` : "Current scene",
+              },
+              {
+                value: false,
+                label: hasTooManyScenes ? (
+                  <>
+                    All scenes{" "}
+                    <Tooltip
+                      title={`Vol-E currently has ${urls.length} scenes open. Sharing a large scene collection requires a very long URL. We don't recommend including more than 4 scenes in a sharing link.`}
+                      overlayStyle={{ zIndex: 10000 }}
+                      placement="left"
+                    >
+                      <ExclamationCircleOutlined
+                        style={{ color: "var(--color-message-warning-text)", cursor: "pointer", fontSize: "16px" }}
+                      />
+                    </Tooltip>
+                  </>
+                ) : (
+                  "All scenes"
+                ),
+              },
+            ]}
+          />
         )}
         <FlexRow $gap={8} style={{ marginTop: "12px" }}>
           <Input value={shareUrl} readOnly={true}></Input>

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -1,5 +1,5 @@
 import type { View3d } from "@aics/vole-core";
-import { ExclamationCircleOutlined, ShareAltOutlined } from "@ant-design/icons";
+import { ExclamationCircleOutlined, InfoCircleOutlined, ShareAltOutlined } from "@ant-design/icons";
 import { Alert, Button, Input, Modal, notification, Radio, Tooltip } from "antd";
 import React, { useMemo, useRef, useState } from "react";
 import styled from "styled-components";
@@ -28,7 +28,7 @@ const ModalContainer = styled.div`
     align-items: flex-start;
     margin-top: 12px;
     transition-property: all;
-    color: var(--color-message-warning-text);
+    color: var(--color-alert-warning-text);
   }
 
   .ant-alert-motion-leave {
@@ -37,7 +37,7 @@ const ModalContainer = styled.div`
 
   .ant-alert button,
   .ant-alert button .anticon {
-    color: var(--color-message-warning-text);
+    color: var(--color-alert-warning-text);
   }
 
   .ant-alert button .anticon {
@@ -76,7 +76,7 @@ const Warning: React.FC<React.PropsWithChildren<{ message: React.ReactNode }>> =
     </>
   );
 
-  return <Alert showIcon closable icon={<ExclamationCircleOutlined />} type="warning" message={warningContents} />;
+  return <Alert showIcon icon={<InfoCircleOutlined />} type="info" message={warningContents} />;
 };
 
 const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
@@ -177,7 +177,7 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
                       placement="left"
                     >
                       <ExclamationCircleOutlined
-                        style={{ color: "var(--color-message-warning-text)", cursor: "pointer", fontSize: "16px" }}
+                        style={{ color: "var(--color-alert-warning-text)", cursor: "pointer", fontSize: "16px" }}
                       />
                     </Tooltip>
                   </>

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -18,6 +18,7 @@ import { FlexRow } from "../LandingPage/utils";
 
 type ShareModalProps = {
   appProps: AppDataProps;
+  imageTitle?: string;
   // Used to retrieve the current camera position information
   view3dRef?: React.RefObject<View3d | null>;
 };
@@ -163,7 +164,10 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
               onChange={(e) => setShowCurrentScene(e.target.value)}
               options={[
                 { value: false, label: "All scenes" },
-                { value: true, label: "Current scene" },
+                {
+                  value: true,
+                  label: props.imageTitle !== undefined ? `Current scene (${props.imageTitle})` : "Current scene",
+                },
               ]}
             />
             {hasTooManyScenes && (

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -1,6 +1,6 @@
 import type { View3d } from "@aics/vole-core";
-import { ExclamationCircleOutlined, InfoCircleOutlined, ShareAltOutlined } from "@ant-design/icons";
-import { Alert, Button, Input, Modal, notification, Radio, Tooltip } from "antd";
+import { InfoCircleOutlined, ShareAltOutlined } from "@ant-design/icons";
+import { Alert, Button, Input, Modal, notification, Radio } from "antd";
 import React, { useMemo, useRef, useState } from "react";
 import styled from "styled-components";
 import { useShallow } from "zustand/shallow";
@@ -23,6 +23,8 @@ type ShareModalProps = {
   view3dRef?: React.RefObject<View3d | null>;
 };
 
+const MAX_URL_CHARACTERS = 2000;
+
 const ModalContainer = styled.div`
   .ant-alert {
     margin-top: 12px;
@@ -35,8 +37,6 @@ const ModalContainer = styled.div`
     font-size: 21px;
   }
 `;
-
-const MAX_SCENE_URL_COUNT = 4;
 
 const encodeSceneUrl = (scene: string | string[]): string => {
   if (Array.isArray(scene)) {
@@ -53,7 +53,6 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
     [imageUrl]
   );
   const hasStoredMetadata = useMemo(() => readStoredMetadata(urls).some((meta) => meta !== undefined), [urls]);
-  const hasTooManyScenes = urls.length > MAX_SCENE_URL_COUNT;
 
   const viewerSettings = useViewerState(useShallow(selectViewerSettings));
   const channelSettings = useViewerState(useShallow((store: ViewerStore) => store.channelSettings));
@@ -61,7 +60,7 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
   const [showModal, setShowModal] = useState(false);
   const modalContainerRef = useRef<HTMLDivElement>(null);
 
-  const [showCurrentScene, setShowCurrentScene] = useState(hasTooManyScenes);
+  const [showAllScenes, setShowAllScenes] = useState(false);
 
   const [notificationApi, notificationContextHolder] = notification.useNotification({
     getContainer: modalContainerRef.current ? () => modalContainerRef.current! : undefined,
@@ -71,16 +70,14 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
 
   const paramProps = {
     ...viewerSettings,
-    scene: showCurrentScene ? 0 : viewerSettings.scene,
+    scene: showAllScenes ? viewerSettings.scene : 0,
     channelSettings,
     cameraState: props.view3dRef?.current?.getCameraState(),
   };
 
   const urlParams: string[] = [];
 
-  const serializedUrl = showCurrentScene
-    ? encodeSceneUrl(urls[viewerSettings.scene])
-    : urls.map(encodeSceneUrl).join("+");
+  const serializedUrl = showAllScenes ? urls.map(encodeSceneUrl).join("+") : encodeSceneUrl(urls[viewerSettings.scene]);
 
   urlParams.push(`url=${serializedUrl}`);
 
@@ -126,31 +123,16 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
       >
         {urls.length > 1 && (
           <Radio.Group
-            value={showCurrentScene}
-            onChange={(e) => setShowCurrentScene(e.target.value)}
+            value={showAllScenes}
+            onChange={(e) => setShowAllScenes(e.target.value)}
             options={[
               {
-                value: true,
+                value: false,
                 label: props.imageTitle !== undefined ? `Current scene (${props.imageTitle})` : "Current scene",
               },
               {
-                value: false,
-                label: hasTooManyScenes ? (
-                  <>
-                    All scenes{" "}
-                    <Tooltip
-                      title={`Vol-E currently has ${urls.length} scenes open. Sharing a large scene collection requires a very long URL. We don't recommend including more than 4 scenes in a sharing link.`}
-                      overlayStyle={{ zIndex: 10000 }}
-                      placement="left"
-                    >
-                      <ExclamationCircleOutlined
-                        style={{ color: "var(--color-alert-warning-text)", cursor: "pointer", fontSize: "16px" }}
-                      />
-                    </Tooltip>
-                  </>
-                ) : (
-                  "All scenes"
-                ),
+                value: true,
+                label: "All scenes",
               },
             ]}
           />

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -26,6 +26,7 @@ type ShareModalProps = {
 const ModalContainer = styled.div`
   .ant-alert {
     margin-top: 12px;
+    padding: 10px 14px;
     color: var(--color-alert-info-text);
     border: none;
   }
@@ -43,26 +44,6 @@ const encodeSceneUrl = (scene: string | string[]): string => {
   } else {
     return encodeURIComponent(scene);
   }
-};
-
-const Warning: React.FC<React.PropsWithChildren<{ message: React.ReactNode }>> = ({ message, children }) => {
-  const [showDetails, setShowDetails] = useState(false);
-
-  const warningContents = (
-    <>
-      <div>{message}</div>
-      {showDetails && <div style={{ margin: "8px 0" }}>{children}</div>}
-      <Button
-        type="text"
-        style={{ textDecoration: "underline", fontWeight: "bold", lineHeight: 0.8 }}
-        onClick={() => setShowDetails(!showDetails)}
-      >
-        {showDetails ? "Show less" : "Show more"}
-      </Button>
-    </>
-  );
-
-  return <Alert showIcon icon={<InfoCircleOutlined />} type="info" message={warningContents} />;
 };
 
 const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
@@ -181,10 +162,12 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
           </Button>
         </FlexRow>
         {hasStoredMetadata && (
-          <Warning message="Not all image metadata will be shared.">
-            One or more open images has metadata that was shared with Vol-E by an external application (like BioFile
-            Finder). This metadata can&apos;t be included in the URL above.
-          </Warning>
+          <Alert
+            showIcon
+            icon={<InfoCircleOutlined />}
+            type="info"
+            message="Image metadata from external apps (like BFF) can't be shared."
+          />
         )}
       </Modal>
     </ModalContainer>

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -27,6 +27,7 @@ const ModalContainer = styled.div`
   .ant-alert {
     margin-top: 12px;
     color: var(--color-alert-info-text);
+    border: none;
   }
 
   .ant-alert > .anticon {

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -157,7 +157,7 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
         destroyOnClose={true}
         footer={null}
       >
-        {urls.length > 0 && (
+        {urls.length > 1 && (
           <Radio.Group
             value={showCurrentScene}
             onChange={(e) => setShowCurrentScene(e.target.value)}

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -172,12 +172,6 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
             Copy URL
           </Button>
         </FlexRow>
-        {hasTooManyScenes && (
-          <Warning message="Only the current scene will be shared.">
-            Vol-E has more scenes open than can fit in a single sharing link, so the URL above only includes the current
-            scene.
-          </Warning>
-        )}
         {hasStoredMetadata && (
           <Warning message="Not all image metadata will be shared.">
             One or more open images has metadata that was shared with Vol-E by an external application (like BioFile

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -1,6 +1,6 @@
 import type { View3d } from "@aics/vole-core";
 import { ExclamationCircleOutlined, ShareAltOutlined } from "@ant-design/icons";
-import { Alert, Button, Input, Modal, notification, Radio } from "antd";
+import { Alert, Button, Input, Modal, notification, Radio, Tooltip } from "antd";
 import React, { useMemo, useRef, useState } from "react";
 import styled from "styled-components";
 import { useShallow } from "zustand/shallow";
@@ -157,14 +157,25 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
         footer={null}
       >
         {urls.length > 0 && (
-          <Radio.Group
-            value={showCurrentScene}
-            onChange={(e) => setShowCurrentScene(e.target.value)}
-            options={[
-              { value: false, label: "All scenes" },
-              { value: true, label: "Current scene" },
-            ]}
-          />
+          <FlexRow style={{ justifyContent: "space-between" }}>
+            <Radio.Group
+              value={showCurrentScene}
+              onChange={(e) => setShowCurrentScene(e.target.value)}
+              options={[
+                { value: false, label: "All scenes" },
+                { value: true, label: "Current scene" },
+              ]}
+            />
+            {hasTooManyScenes && (
+              <Tooltip
+                title={`Vol-E currently has ${urls.length} scenes open. Sharing a large scene collection requires a very long URL. We don't recommend including more than 4 scenes in a sharing link.`}
+                overlayStyle={{ zIndex: 10000 }}
+                placement="left"
+              >
+                <ExclamationCircleOutlined style={{ color: "var(--color-message-warning-text)", cursor: "pointer" }} />
+              </Tooltip>
+            )}
+          </FlexRow>
         )}
         <FlexRow $gap={8} style={{ marginTop: "12px" }}>
           <Input value={shareUrl} readOnly={true}></Input>

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -25,23 +25,8 @@ type ShareModalProps = {
 
 const ModalContainer = styled.div`
   .ant-alert {
-    align-items: flex-start;
     margin-top: 12px;
-    transition-property: all;
-    color: var(--color-alert-warning-text);
-  }
-
-  .ant-alert-motion-leave {
-    margin-top: 0;
-  }
-
-  .ant-alert button,
-  .ant-alert button .anticon {
-    color: var(--color-alert-warning-text);
-  }
-
-  .ant-alert button .anticon {
-    font-size: 14px;
+    color: var(--color-alert-info-text);
   }
 
   .ant-alert > .anticon {

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -151,6 +151,14 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
             message="Image metadata from external apps (like BFF) can't be shared."
           />
         )}
+        {shareUrl.length > MAX_URL_CHARACTERS && (
+          <Alert
+            showIcon
+            icon={<InfoCircleOutlined />}
+            type="info"
+            message={`This URL is very long.${showAllScenes ? " Consider sharing only the current scene." : ""}`}
+          />
+        )}
       </Modal>
     </ModalContainer>
   );

--- a/website/components/Modals/ShareModal.tsx
+++ b/website/components/Modals/ShareModal.tsx
@@ -1,7 +1,7 @@
 import type { View3d } from "@aics/vole-core";
 import { ExclamationCircleOutlined, ShareAltOutlined } from "@ant-design/icons";
-import { Alert, Button, Input, Modal, notification } from "antd";
-import React, { useRef, useState } from "react";
+import { Alert, Button, Input, Modal, notification, Radio } from "antd";
+import React, { useMemo, useRef, useState } from "react";
 import styled from "styled-components";
 import { useShallow } from "zustand/shallow";
 
@@ -79,11 +79,21 @@ const Warning: React.FC<React.PropsWithChildren<{ message: React.ReactNode }>> =
 };
 
 const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
+  const { imageUrl } = props.appProps;
+  const urls = useMemo(
+    () => (imageUrl !== undefined ? ((imageUrl as MultisceneUrls).scenes ?? [imageUrl]) : []),
+    [imageUrl]
+  );
+  const hasStoredMetadata = useMemo(() => readStoredMetadata(urls).some((meta) => meta !== undefined), [urls]);
+  const hasTooManyScenes = urls.length > MAX_SCENE_URL_COUNT;
+
   const viewerSettings = useViewerState(useShallow(selectViewerSettings));
   const channelSettings = useViewerState(useShallow((store: ViewerStore) => store.channelSettings));
 
   const [showModal, setShowModal] = useState(false);
   const modalContainerRef = useRef<HTMLDivElement>(null);
+
+  const [showCurrentScene, setShowCurrentScene] = useState(hasTooManyScenes);
 
   const [notificationApi, notificationContextHolder] = notification.useNotification({
     getContainer: modalContainerRef.current ? () => modalContainerRef.current! : undefined,
@@ -91,34 +101,20 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
     duration: 2,
   });
 
-  // location.pathname will include up to `.../viewer`
-  const baseUrl = location.protocol + "//" + location.host + location.pathname;
   const paramProps = {
     ...viewerSettings,
+    scene: showCurrentScene ? 0 : viewerSettings.scene,
     channelSettings,
     cameraState: props.view3dRef?.current?.getCameraState(),
   };
 
   const urlParams: string[] = [];
-  const { imageUrl } = props.appProps;
-  let hasTooManyScenes = false;
-  let hasStoredMetadata = false;
 
-  if (imageUrl) {
-    const urls = (imageUrl as MultisceneUrls).scenes ?? [imageUrl];
-    hasTooManyScenes = urls.length > MAX_SCENE_URL_COUNT;
-    hasStoredMetadata = readStoredMetadata(urls).some((meta) => meta !== undefined);
+  const serializedUrl = showCurrentScene
+    ? encodeSceneUrl(urls[viewerSettings.scene])
+    : urls.map(encodeSceneUrl).join("+");
 
-    if (hasTooManyScenes) {
-      paramProps.scene = 0;
-    }
-
-    const serializedUrl = hasTooManyScenes
-      ? encodeSceneUrl(urls[viewerSettings.scene])
-      : urls.map(encodeSceneUrl).join("+");
-
-    urlParams.push(`url=${serializedUrl}`);
-  }
+  urlParams.push(`url=${serializedUrl}`);
 
   let serializedViewerParams = new URLSearchParams(serializeViewerUrlParams(paramProps) as Record<string, string>);
   if (serializedViewerParams.size > 0) {
@@ -129,6 +125,9 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
       .replace(ENCODED_COMMA_REGEX, ",");
     urlParams.push(viewerParamString);
   }
+
+  // location.pathname will include up to `.../viewer`
+  const baseUrl = location.protocol + "//" + location.host + location.pathname;
 
   const shareUrl = urlParams.length > 0 ? `${baseUrl}?${urlParams.join("&")}` : baseUrl;
 
@@ -157,6 +156,16 @@ const ShareModal: React.FC<ShareModalProps> = (props: ShareModalProps) => {
         destroyOnClose={true}
         footer={null}
       >
+        {urls.length > 0 && (
+          <Radio.Group
+            value={showCurrentScene}
+            onChange={(e) => setShowCurrentScene(e.target.value)}
+            options={[
+              { value: false, label: "All scenes" },
+              { value: true, label: "Current scene" },
+            ]}
+          />
+        )}
         <FlexRow $gap={8} style={{ marginTop: "12px" }}>
           <Input value={shareUrl} readOnly={true}></Input>
           <Button type="primary" onClick={onClickCopy}>


### PR DESCRIPTION
Review time: smallish (~10-15min)

Loosens up the share modal's restrictions on trying to share very large scene collections and image metadata from BFF. This behavior was introduced in #488.

There are two types of data that can be passed to Vol-E from BFF which cause problems for shareable links:
1. Large sets of images, which can make the URL arbitrarily long if every single image's path is included in the URL.
2. Extra image metadata, which we have no means of including in the URL at all.

In #488 I added a restriction around 1. and introduced a warning message when either was present. I talked to UX about this, and we agreed to some revisions:
- Messages should be styled like info, not a warning
- Users should always be given the option to fit the entire scene collection into a URL, no matter how long the URL might become

## Screenshots

Before
<img width="526" height="277" alt="image" src="https://github.com/user-attachments/assets/8f52913e-34c2-46cd-a842-5a992aa15b7c" />

After
<img width="528" height="263" alt="image" src="https://github.com/user-attachments/assets/b9926d3f-e8cf-4794-aaeb-874262ec2472" />
