### PR TITLE
Show cause in error alert

### DIFF
--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -30,8 +30,7 @@ const UNKNOWN_ERROR_DESCRIPTION: React.ReactNode = (
   </>
 );
 
-type DescribedErrorTypes = Exclude<VolumeLoadErrorType, VolumeLoadErrorType.TOO_LARGE>;
-const ERROR_TYPE_DESCRIPTIONS: { [T in DescribedErrorTypes]: React.ReactNode } = {
+const ERROR_TYPE_DESCRIPTIONS: { [T in VolumeLoadErrorType]: React.ReactNode } = {
   [VolumeLoadErrorType.UNKNOWN]: (
     <>
       An unknown error occurred while loading volume data. Check the browser console (F12) for more details. If this
@@ -42,6 +41,13 @@ const ERROR_TYPE_DESCRIPTIONS: { [T in DescribedErrorTypes]: React.ReactNode } =
     <>
       The viewer was unable to find any volume data at the specified location. Check that the provided URL is correct
       and try again.
+    </>
+  ),
+  [VolumeLoadErrorType.TOO_LARGE]: (
+    <>
+      No resolution level is available for this volume which fits within our maximum memory footprint. This maximum is
+      tuned to ensure compatibility with the majority of browsers. If you&apos;re trying to load your own OME-Zarr
+      dataset, you may be able to open this volume by including a lower resolution level.
     </>
   ),
   [VolumeLoadErrorType.LOAD_DATA_FAILED]: (
@@ -82,22 +88,10 @@ const getErrorDescription = (error: unknown): React.ReactNode => {
       UNKNOWN_ERROR_DESCRIPTION
     );
   }
-  if (type === VolumeLoadErrorType.TOO_LARGE) {
-    if (useViewerState.getState().useExactScaleLevel) {
-      return (
-        <>
-          The viewer cannot load this resolution level within memory limits. Try again with a smaller resolution level.
-        </>
-      );
-    } else {
-      return (
-        <>
-          No resolution level is available for this volume which fits within our maximum memory footprint. This maximum
-          is tuned to ensure compatibility with the majority of browsers. If you&apos;re trying to load your own
-          OME-Zarr dataset, you may be able to open this volume by including a lower resolution level.
-        </>
-      );
-    }
+  if (type === VolumeLoadErrorType.TOO_LARGE && useViewerState.getState().useExactScaleLevel) {
+    return (
+      <>The viewer cannot load this resolution level within memory limits. Try again with a smaller resolution level.</>
+    );
   }
   return ERROR_TYPE_DESCRIPTIONS[type] ?? UNKNOWN_ERROR_DESCRIPTION;
 };

--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -119,7 +119,7 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, firstErrorCount = 0, af
 
   const errorMessage = (
     <>
-      <div>
+      <div className="error-title">
         {getErrorTitle(error) + (firstErrorCount > 1 ? ` (${firstErrorCount})` : "")}{" "}
         <Button type="text" onClick={() => setShowDetails(!showDetails)}>
           {showDetails ? "Show less info" : "Show more info"}

--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -126,7 +126,11 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, firstErrorCount = 0, af
         </Button>
       </div>
       <div style={infoStyle}>{getErrorDescription(error)}</div>
-      {error.cause !== undefined && <div style={infoStyle}>Caused by: {getErrorTitle(error.cause)}</div>}
+      {error.cause !== undefined && (
+        <div className="error-cause" style={infoStyle}>
+          Caused by: {getErrorTitle(error.cause)}
+        </div>
+      )}
     </>
   );
 

--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -4,6 +4,7 @@ import { Alert, Button } from "antd";
 import React from "react";
 
 import { useConstructor } from "../../shared/utils/hooks";
+import { useViewerState } from "../../state/store";
 
 import "./styles.css";
 
@@ -29,7 +30,8 @@ const UNKNOWN_ERROR_DESCRIPTION: React.ReactNode = (
   </>
 );
 
-const ERROR_TYPE_DESCRIPTIONS: { [T in VolumeLoadErrorType]: React.ReactNode } = {
+type DescribedErrorTypes = Exclude<VolumeLoadErrorType, VolumeLoadErrorType.TOO_LARGE>;
+const ERROR_TYPE_DESCRIPTIONS: { [T in DescribedErrorTypes]: React.ReactNode } = {
   [VolumeLoadErrorType.UNKNOWN]: (
     <>
       An unknown error occurred while loading volume data. Check the browser console (F12) for more details. If this
@@ -40,13 +42,6 @@ const ERROR_TYPE_DESCRIPTIONS: { [T in VolumeLoadErrorType]: React.ReactNode } =
     <>
       The viewer was unable to find any volume data at the specified location. Check that the provided URL is correct
       and try again.
-    </>
-  ),
-  [VolumeLoadErrorType.TOO_LARGE]: (
-    <>
-      No scale level is available for this volume which fits within our maximum GPU memory footprint. This maximum is
-      tuned to ensure compatibility with the majority of browsers. If you&apos;re trying to load your own OME-Zarr
-      dataset, you may be able to open this volume by including a lower scale level.
     </>
   ),
   [VolumeLoadErrorType.LOAD_DATA_FAILED]: (
@@ -86,6 +81,23 @@ const getErrorDescription = (error: unknown): React.ReactNode => {
       (typeof error === "object" && error !== null && (error as ErrorAlertDescription).description) ||
       UNKNOWN_ERROR_DESCRIPTION
     );
+  }
+  if (type === VolumeLoadErrorType.TOO_LARGE) {
+    if (useViewerState.getState().useExactScaleLevel) {
+      return (
+        <>
+          The viewer cannot load this resolution level within memory limits. Try again with a smaller resolution level.
+        </>
+      );
+    } else {
+      return (
+        <>
+          No resolution level is available for this volume which fits within our maximum memory footprint. This maximum
+          is tuned to ensure compatibility with the majority of browsers. If you&apos;re trying to load your own
+          OME-Zarr dataset, you may be able to open this volume by including a lower resolution level.
+        </>
+      );
+    }
   }
   return ERROR_TYPE_DESCRIPTIONS[type] ?? UNKNOWN_ERROR_DESCRIPTION;
 };

--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -115,6 +115,8 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, firstErrorCount = 0, af
   const [errorsSeenCount, setErrorsSeenCount] = React.useState(0);
   const error = Array.isArray(errors) ? errors[0] : errors;
 
+  const infoStyle = { display: showDetails ? undefined : "none" } as const;
+
   const errorMessage = (
     <>
       <div>
@@ -123,7 +125,8 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, firstErrorCount = 0, af
           {showDetails ? "Show less info" : "Show more info"}
         </Button>
       </div>
-      <div style={{ display: showDetails ? undefined : "none" }}>{getErrorDescription(error)}</div>
+      <div style={infoStyle}>{getErrorDescription(error)}</div>
+      {error.cause !== undefined && <div style={infoStyle}>Caused by: {getErrorTitle(error.cause)}</div>}
     </>
   );
 

--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -128,7 +128,7 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, firstErrorCount = 0, af
       <div style={infoStyle}>{getErrorDescription(error)}</div>
       {error.cause !== undefined && (
         <div className="error-cause" style={infoStyle}>
-          Caused by: {getErrorTitle(error.cause)}
+          Caused by {getErrorTitle(error.cause)}
         </div>
       )}
     </>

--- a/src/aics-image-viewer/components/ErrorAlert/styles.css
+++ b/src/aics-image-viewer/components/ErrorAlert/styles.css
@@ -25,7 +25,7 @@
   }
 
   .ant-alert-message > div {
-    &:first-child {
+    &.error-title {
       font-weight: 600;
     }
 

--- a/src/aics-image-viewer/components/ErrorAlert/styles.css
+++ b/src/aics-image-viewer/components/ErrorAlert/styles.css
@@ -7,6 +7,7 @@
   z-index: 5000;
   border-color: #dc4446;
   padding: 12px 30px;
+  color: var(--color-text-section);
 
   /* Keeps icons vertically aligned with the *first row* of text */
   .ant-alert-icon,
@@ -23,8 +24,14 @@
     }
   }
 
-  .ant-alert-message div:first-child {
-    color: var(--color-text-section);
-    font-weight: 600;
+  .ant-alert-message > div {
+    &:first-child {
+      font-weight: 600;
+    }
+
+    &:last-child {
+      font-style: italic;
+      color: var(--color-text-body);
+    }
   }
 }

--- a/src/aics-image-viewer/components/ErrorAlert/styles.css
+++ b/src/aics-image-viewer/components/ErrorAlert/styles.css
@@ -29,7 +29,7 @@
       font-weight: 600;
     }
 
-    &:last-child {
+    &.error-cause {
       font-style: italic;
       color: var(--color-text-body);
     }


### PR DESCRIPTION
Review time: small (5-10min)

Resolves #323: shows an error's `cause` field in the error alert. Also, adds a new error description for out-of-memory errors that occur when the user has manually selected a specific scale level.

<img width="1552" height="175" alt="image" src="https://github.com/user-attachments/assets/2f187bd3-2571-4b65-a5fa-e44c39b4f65c" />
