### PR TITLE
Only prefetch priority directions during playback

### DIFF
--- a/src/aics-image-viewer/components/useVolume.ts
+++ b/src/aics-image-viewer/components/useVolume.ts
@@ -122,6 +122,7 @@ const useVolume = (
       setPlayingAxis(axis);
       // prioritize prefetching along the playing axis
       sceneLoader.setPrefetchPriority(axis ? [AXIS_TO_LOADER_PRIORITY[axis]] : []);
+      sceneLoader.updateFetchOptions({ onlyPriorityDirections: isPlaying });
       // sync multichannel loading so we don't show loaded channels one at a time
       sceneLoader.syncMultichannelLoading(isPlaying);
       if (image) {

--- a/src/aics-image-viewer/shared/utils/sceneStore.ts
+++ b/src/aics-image-viewer/shared/utils/sceneStore.ts
@@ -5,6 +5,7 @@ import type {
   RawArrayLoaderOptions,
   Volume,
   VolumeLoaderContext,
+  ZarrLoaderFetchOptions,
 } from "@aics/vole-core";
 import { createDefaultMetadata, VolumeFileFormat } from "@aics/vole-core";
 import type { ThreadableVolumeLoader } from "@aics/vole-core/es/types/loaders/IVolumeLoader";
@@ -94,6 +95,13 @@ export default class SceneStore {
     const currentLoader = this.loaders[this.currentScene];
     if (currentLoader) {
       currentLoader.setPrefetchPriority(priority);
+    }
+  }
+
+  public updateFetchOptions(fetchOptions: Partial<ZarrLoaderFetchOptions>): void {
+    const currentLoader = this.loaders[this.currentScene];
+    if (currentLoader) {
+      currentLoader.updateFetchOptions(fetchOptions);
     }
   }
 }


### PR DESCRIPTION
## Problem

Playback in time is slower than it could be. 

## Solution

During playback, only prefetch along the playing axis.

## Analysis

I estimate that this change increases Vol-E's framerate by about 22% (N=11, p=0.02). Average framerate increased from ~4.2 FPS to ~5.1 FPS in my benchmark reading real AICS data from S3.

<img width="596" height="368" alt="Screenshot 2026-04-17 at 1 55 28 PM" src="https://github.com/user-attachments/assets/d3716e1c-33b5-4fbb-968b-7ba7698354ab" />

This change should not meaningfully affect lag; in my test, lag increased 2% on average, but this was far from statistically significant (p=0.75).

## Type of change

- Performance improvement

## Steps to Verify

To capture timing information, I added some code to vole-core that's not part of this PR, and operating it is not automated. [Here's the code](https://github.com/allen-cell-animated/vole-core/tree/perf/manual-timing-dont-merge). Let me know if you want to reproduce the statistics above and I can walk you through it.