### PR TITLE
Prefetch performance improvements

### DIFF
--- a/src/aics-image-viewer/components/useVolume.ts
+++ b/src/aics-image-viewer/components/useVolume.ts
@@ -122,6 +122,7 @@ const useVolume = (
       setPlayingAxis(axis);
       // prioritize prefetching along the playing axis
       sceneLoader.setPrefetchPriority(axis ? [AXIS_TO_LOADER_PRIORITY[axis]] : []);
+      sceneLoader.updateFetchOptions({ onlyPriorityDirections: isPlaying });
       // sync multichannel loading so we don't show loaded channels one at a time
       sceneLoader.syncMultichannelLoading(isPlaying);
       if (image) {

--- a/src/aics-image-viewer/shared/constants.ts
+++ b/src/aics-image-viewer/shared/constants.ts
@@ -34,7 +34,7 @@ export const TFEDITOR_MAX_BIN = 255;
 
 export const CACHE_MAX_SIZE = 1_000_000_000;
 export const QUEUE_MAX_SIZE = 10;
-export const QUEUE_MAX_LOW_PRIORITY_SIZE = 4;
+export const QUEUE_MAX_LOW_PRIORITY_SIZE = 6;
 
 /** Maps an axis the user can "play" through to the direction to prefetch while playing that axis */
 export const AXIS_TO_LOADER_PRIORITY: Record<AxisName | "t", PrefetchDirection> = {

--- a/src/aics-image-viewer/shared/utils/sceneStore.ts
+++ b/src/aics-image-viewer/shared/utils/sceneStore.ts
@@ -5,6 +5,7 @@ import type {
   RawArrayLoaderOptions,
   Volume,
   VolumeLoaderContext,
+  ZarrLoaderFetchOptions,
 } from "@aics/vole-core";
 import { createDefaultMetadata, VolumeFileFormat } from "@aics/vole-core";
 import type { ThreadableVolumeLoader } from "@aics/vole-core/es/types/loaders/IVolumeLoader";
@@ -94,6 +95,13 @@ export default class SceneStore {
     const currentLoader = this.loaders[this.currentScene];
     if (currentLoader) {
       currentLoader.setPrefetchPriority(priority);
+    }
+  }
+
+  public updateFetchOptions(fetchOptions: Partial<ZarrLoaderFetchOptions>): void {
+    const currentLoader = this.loaders[this.currentScene];
+    if (currentLoader) {
+      currentLoader.updateFetchOptions(fetchOptions);
     }
   }
 }


### PR DESCRIPTION
Problem
=======
Playback in time is slower than it could be.

This PR includes the changes from #506 
This PR has a [companion in vole-core](https://github.com/allen-cell-animated/vole-core/pull/396): please review that too.

Solution
========
* During playback, only pre-fetch along the playing axis. (Reviewed already in #506)
* Allow 6 pre-fetch requests in flight at a time (this aligns with browser limitation of 6 requests per domain)
* Increase the maximum number of timesteps that can be pre-fetched to 10 ([companion PR](https://github.com/allen-cell-animated/vole-core/pull/396))

Analysis
======
I estimate this change improves framerate almost to the maximum achievable within Vol-E, while increasing lag by about 16%. I am planning a future PR to improve lag.

In the comparison between main and the changes in this PR, median time per frame decreased from 375ms to 314ms. This difference was statistically significant (p=0.03, N=20).

The error bars below correspond to one standard deviation (it would be more appropriate to center the error bars on the mean than the median, but I think median performance is probably most relevant for our testing).

<img width="914" height="370" alt="Screenshot 2026-04-20 at 4 31 19 PM" src="https://github.com/user-attachments/assets/80805b06-1718-48b2-99f9-6298cab78e40" />

Above, I also compared Vol-E with the changes in this PR to a demo web app that makes the same network requests but doesn't render anything. In this test, the median time per frame was about 2% from optimal (301ms vs. 295ms). This difference was not statistically significant (p=0.12, N=26).

Below, I plot all the data from both tests, including lag and FPS. The comparison between main and this PR has a noticeable outlier in favor of this PR. With that data point removed, the improvement is still statistically significant (p=0.04).

<img width="598" height="741" alt="Screenshot 2026-04-20 at 4 43 04 PM" src="https://github.com/user-attachments/assets/683cfd3a-8dc4-4ddf-8033-888b3f597279" />

I did not record lag metrics from the benchmark demo app.

## Type of change
Performance improvement

Steps to Verify:
----------------
To capture timing information, I added some code to vole-core that's not part of this PR, and operating it is not automated. [Here's the code](https://github.com/allen-cell-animated/vole-core/tree/perf/manual-timing-dont-merge). Let me know if you want to reproduce the statistics above and I can walk you through it.
