### PR TITLE
Present each frame for at least 125ms

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -327,14 +327,13 @@ const App: React.FC<AppProps> = (props) => {
       // save the channel's new range for remapping next time
       channelRangesRef.current[channelIndex] = [thisChannel.rawMin, thisChannel.rawMax];
 
-      view3d.updateLuts(image);
+      // Note: updateLuts and updateActiveChannels are not called here because the
+      // channelVersion bump (via onChannelDataLoaded) will trigger ChannelUpdater
+      // effects that apply LUT/color settings and call updateLuts with the final state.
       view3d.onVolumeData(image, [channelIndex]);
 
       if (image.channelNames[channelIndex] === maskChannelName) {
         view3d.setVolumeChannelAsMask(image, channelIndex);
-      }
-      if (image.isLoaded()) {
-        view3d.updateActiveChannels(image);
       }
     },
     [view3d, changeChannelSetting, maskChannelName, props.viewerChannelSettings]

--- a/src/aics-image-viewer/shared/utils/playControls.ts
+++ b/src/aics-image-viewer/shared/utils/playControls.ts
@@ -9,6 +9,7 @@ export default class PlayControls {
   playWaitingForLoad = false;
   playHolding = false;
   playTimeoutId = 0;
+  private lastStepTime = 0;
 
   public getVolumeIsLoaded?: () => boolean;
   public stepAxis?: (axis: PlayAxisName) => void;
@@ -17,6 +18,12 @@ export default class PlayControls {
   private setPlayingAxis(axis: PlayAxisName | null): void {
     this.playingAxis = axis;
     this.onPlayingAxisChanged?.(axis);
+  }
+
+  private scheduleNextStep(): void {
+    const elapsed = performance.now() - this.lastStepTime;
+    const delay = Math.max(0, PLAY_STEP_INTERVAL_MS - elapsed);
+    this.playTimeoutId = window.setTimeout(this.playStep.bind(this), delay);
   }
 
   private playStep(): void {
@@ -30,14 +37,17 @@ export default class PlayControls {
     }
 
     this.stepAxis(this.playingAxis);
-    this.playTimeoutId = window.setTimeout(this.playStep.bind(this), PLAY_STEP_INTERVAL_MS);
+    this.scheduleNextStep();
   }
 
   /** Call whenever new data is loaded to resume playback if it was paused for data loading. */
   onImageLoaded(): void {
+    // Record when the frame was presented, so scheduleNextStep enforces
+    // PLAY_STEP_INTERVAL_MS between presentations (not between requests).
+    this.lastStepTime = performance.now();
     if (this.playWaitingForLoad) {
       this.playWaitingForLoad = false;
-      this.playStep();
+      this.scheduleNextStep();
     }
   }
 

--- a/src/aics-image-viewer/shared/utils/playControls.ts
+++ b/src/aics-image-viewer/shared/utils/playControls.ts
@@ -20,24 +20,25 @@ export default class PlayControls {
     this.onPlayingAxisChanged?.(axis);
   }
 
-  private scheduleNextStep(): void {
-    const elapsed = performance.now() - this.lastStepTime;
-    const delay = Math.max(0, PLAY_STEP_INTERVAL_MS - elapsed);
-    this.playTimeoutId = window.setTimeout(this.playStep.bind(this), delay);
-  }
-
   private playStep(): void {
     if (!this.playingAxis || this.playHolding || !this.stepAxis) {
       return;
     }
-    // If the volume is not loaded, wait for it to load before continuing
     if (!this.getVolumeIsLoaded?.()) {
       this.playWaitingForLoad = true;
       return;
     }
 
+    // Enforce minimum interval between frame *presentations* (not requests).
+    // lastStepTime is set in onImageLoaded when a frame's data arrives.
+    const delay = PLAY_STEP_INTERVAL_MS - (performance.now() - this.lastStepTime);
+    if (delay > 0) {
+      this.playTimeoutId = window.setTimeout(this.playStep.bind(this), delay);
+      return;
+    }
+
     this.stepAxis(this.playingAxis);
-    this.scheduleNextStep();
+    this.playTimeoutId = window.setTimeout(this.playStep.bind(this), PLAY_STEP_INTERVAL_MS);
   }
 
   /** Call whenever new data is loaded to resume playback if it was paused for data loading. */
@@ -47,7 +48,7 @@ export default class PlayControls {
     this.lastStepTime = performance.now();
     if (this.playWaitingForLoad) {
       this.playWaitingForLoad = false;
-      this.scheduleNextStep();
+      this.playStep();
     }
   }
 


### PR DESCRIPTION
Problem
=======
Playback in time is laggier than it could be.

This PR has a [companion in vole-core](https://github.com/allen-cell-animated/vole-core/pull/397): please review that too.

Solution
========
* Require that each frame be presented at least 125ms after the previous
* Increase the maximum number of timesteps that can be pre-fetched to 12 ([companion PR](https://github.com/allen-cell-animated/vole-core/pull/397))
  - Pre-fetching improves total framerate at the cost of lag. The 125ms minimum decreases total framerate. This change offsets that framerate drop.
* Not directly important for performance, but nice to have: remove duplicate `gpuFuse` calls (App/index.tsx)

Analysis
======
I estimate this change decreases lag by about 24% for AICS zarrs on S3, with minimal to no impact on aggregate framerate.

I measure lag as the coefficient of variation of the time between frames. For example, without this change, three frames might be presented for 25ms, 35ms, and 480ms (CV = 1.44). After this change, those three frames would ideally be presented for 125ms, 125ms, and 290ms (CV = 0.53).

In the comparison between my previous PR #507 and this one, median lag decreased from 1.30 to 0.96. This difference was statistically significant (p=0.003, N=9). Median framerate nominally improved, but is absolutely not statistically significant (p=0.98, N=9).

<img width="598" height="368" alt="Screenshot 2026-04-21 at 12 32 51 AM" src="https://github.com/user-attachments/assets/aedfe6ab-60b7-43df-8134-5d24ffecbb48" />

Since you might be wondering why this change was necessary, here's a comparison of the time each frame was presented between two runs, one with this PR and one without. Note that without this PR, many frames are presented for less than 125ms. This is because without this PR, frames are requested every 125ms, but there can be a long gap between the request and the presentation.

<img width="598" height="368" alt="Screenshot 2026-04-23 at 2 42 30 PM" src="https://github.com/user-attachments/assets/d0160f5c-afd6-437c-8e92-9d789825dbc9" />



## Type of change
Performance improvement

Steps to Verify:
----------------
To capture timing information, I added some code to vole-core that's not part of this PR, and operating it is not automated. [Here's the code](https://github.com/allen-cell-animated/vole-core/tree/perf/manual-timing-dont-merge). Let me know if you want to reproduce the statistics above and I can walk you through it.
