### PR TITLE
Styling tweaks for scale level controls

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -54,6 +54,7 @@ const defaultVisibleControls: ControlVisibilityFlags = {
   showAxesButton: true,
   showBoundingBoxButton: true,
   metadataViewer: true,
+  scaleLevelControls: true,
 };
 
 const defaultProps: AppProps = {

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -25,7 +25,8 @@ type ControlNames =
   | "resetCameraButton"
   | "showAxesButton"
   | "showBoundingBoxButton"
-  | "metadataViewer";
+  | "metadataViewer"
+  | "scaleLevelControls";
 /** Show/hide different elements of the UI */
 export type ControlVisibilityFlags = { [K in ControlNames]: boolean };
 

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -137,7 +137,7 @@ const theme = {
       },
     },
     tooltip: {
-      bg: palette.black,
+      bg: palette.veryDarkGrey,
     },
     modal: {
       maskBg: "#000000cc",

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -133,7 +133,10 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
       resizeObserver.current.observe(rightRef.current);
     }
     window.addEventListener("resize", checkSize);
-    return () => window.removeEventListener("resize", checkSize);
+    return () => {
+      resizeObserver.current?.disconnect();
+      window.removeEventListener("resize", checkSize);
+    };
   }, [checkSize]);
 
   const scrollX = (amount: number): number => (barRef.current!.scrollLeft += amount);

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -252,7 +252,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
 
           {multiscaleDims !== undefined && multiscaleDims.length > 1 && visibleControls.scaleLevelControls && (
             <div className="viewer-toolbar-group">
-              <span>Resolution</span>
+              <span style={{ color: "var(--color-button-tertiary-text)" }}>Resolution</span>
               <Radio.Group
                 value={useExactScaleLevel}
                 onChange={(e) => changeViewerSetting("useExactScaleLevel", e.target.value)}

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -262,6 +262,8 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
               </Radio.Group>
               <Select
                 className="select-render-setting"
+                popupClassName="viewer-toolbar-dropdown"
+                getPopupContainer={getPopupContainer}
                 style={{ minWidth: 150 }}
                 value={useExactScaleLevel ? scaleLevelIndex : (props.multiscaleIndex ?? scaleLevelIndex)}
                 onChange={(value) => changeViewerSetting("scaleLevelIndex", value)}

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -58,6 +58,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
   const leftRef = React.useRef<HTMLDivElement>(null);
   const rightRef = React.useRef<HTMLDivElement>(null);
   const centerRef = React.useRef<HTMLDivElement>(null);
+  const resizeObserver = React.useRef<ResizeObserver>();
 
   const [scrollMode, setScrollMode] = React.useState(false);
   const [showScrollBtnLeft, setScrollBtnLeft] = React.useState(false);
@@ -118,6 +119,19 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
   React.useEffect(() => {
     // Make sure `checkSize` is run once on mount
     checkSize();
+    if (resizeObserver.current !== undefined) {
+      resizeObserver.current.disconnect();
+    }
+    resizeObserver.current = new ResizeObserver(checkSize);
+    if (leftRef.current !== null) {
+      resizeObserver.current.observe(leftRef.current);
+    }
+    if (centerRef.current !== null) {
+      resizeObserver.current.observe(centerRef.current);
+    }
+    if (rightRef.current !== null) {
+      resizeObserver.current.observe(rightRef.current);
+    }
     window.addEventListener("resize", checkSize);
     return () => window.removeEventListener("resize", checkSize);
   }, [checkSize]);

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -211,7 +211,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
 
           <div className="viewer-toolbar-group">
             <Select
-              className="select-render-setting"
+              className="select-toolbar"
               popupClassName="viewer-toolbar-dropdown"
               value={renderMode}
               onChange={(value) => changeViewerSetting("renderMode", value)}
@@ -261,7 +261,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
                 <Radio.Button value={true}>Manual</Radio.Button>
               </Radio.Group>
               <Select
-                className="select-render-setting select-resolution"
+                className="select-toolbar select-resolution"
                 popupClassName="viewer-toolbar-dropdown"
                 getPopupContainer={getPopupContainer}
                 style={{ minWidth: 150 }}

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -261,7 +261,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
                 <Radio.Button value={true}>Manual</Radio.Button>
               </Radio.Group>
               <Select
-                className="select-render-setting"
+                className="select-render-setting select-resolution"
                 popupClassName="viewer-toolbar-dropdown"
                 getPopupContainer={getPopupContainer}
                 style={{ minWidth: 150 }}

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -81,7 +81,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
       return;
     }
     setScrollBtnLeft(barEl.scrollLeft > 0);
-    setScrollBtnRight(barEl.scrollLeft < barEl.scrollWidth - barEl.clientWidth);
+    setScrollBtnRight(Math.ceil(barEl.scrollLeft) < barEl.scrollWidth - barEl.clientWidth);
   }, []);
 
   // This is effectively a `useCallback` - it memoizes a function - but since we're feeding the whole function into
@@ -111,7 +111,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
           return leftRect.right > centerRect.left || centerRect.right > rightRect.left;
         }
       });
-      checkScrollBtnVisible();
+      window.setTimeout(checkScrollBtnVisible, 0);
     }, RESIZE_DEBOUNCE_DELAY);
   }, [checkScrollBtnVisible]);
 
@@ -161,6 +161,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
       >
         <ViewerIcon type="closePanel" style={{ fontSize: "12px", transform: "rotate(180deg)" }} />
       </div>
+
       <div className="viewer-toolbar" ref={barRef} onWheel={wheelHandler} onScroll={checkScrollBtnVisible}>
         <div className="viewer-toolbar-left" ref={leftRef}>
           <Tooltip placement="bottom" title="Reset to initial settings" trigger={["focus", "hover"]}>
@@ -170,6 +171,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
             </Button>
           </Tooltip>
         </div>
+
         <div className="viewer-toolbar-center" ref={centerRef}>
           {renderGroup1 && (
             <div className="viewer-toolbar-group">

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -34,6 +34,7 @@ type ToolbarProps = {
     resetCameraButton: boolean;
     showAxesButton: boolean;
     showBoundingBoxButton: boolean;
+    scaleLevelControls: boolean;
   };
 };
 
@@ -138,7 +139,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
   const classForToggleBtn = (active: boolean): string =>
     "ant-btn-icon-only btn-borderless" + (active ? " btn-active" : "");
 
-  const { visibleControls } = props;
+  const { visibleControls, multiscaleDims } = props;
   const twoDMode = viewMode !== ViewMode.threeD;
 
   const renderGroup1 =
@@ -249,7 +250,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
             </div>
           )}
 
-          {props.multiscaleDims !== undefined && props.multiscaleDims.length > 1 && (
+          {multiscaleDims !== undefined && multiscaleDims.length > 1 && visibleControls.scaleLevelControls && (
             <div className="viewer-toolbar-group">
               <span>Resolution</span>
               <Radio.Group
@@ -266,7 +267,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
                 onChange={(value) => changeViewerSetting("scaleLevelIndex", value)}
                 disabled={!useExactScaleLevel}
               >
-                {props.multiscaleDims.map((dims, idx) => {
+                {multiscaleDims.map((dims, idx) => {
                   const [_t, _c, z, y, x] = dims.shape;
                   return (
                     <Select.Option key={idx} value={idx}>

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -161,7 +161,7 @@
   }
 
   /* Dropdown */
-  && .ant-select.select-render-setting {
+  & .ant-select.select-render-setting {
     min-width: 120px;
 
     & .ant-select-selection-item,
@@ -201,8 +201,8 @@
   }
 
   /* Control response to hover + active menu */
-  & .ant-select.select-render-setting:hover:not(:disabled),
-  & .ant-select.select-render-setting:focus-visible:not(:disabled),
+  & .ant-select.select-render-setting:hover:not(.ant-select-disabled),
+  & .ant-select.select-render-setting:focus-visible:not(.ant-select-disabled),
   &&& .ant-select-open {
     & .ant-select-selector,
     & .ant-select-arrow,

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -161,11 +161,11 @@
   }
 
   /* Dropdown */
-  & .ant-select.select-render-setting {
+  .ant-select.select-render-setting {
     min-width: 120px;
 
-    & .ant-select-selection-item,
-    & .ant-select-arrow {
+    .ant-select-selection-item,
+    .ant-select-arrow {
       color: var(--color-button-tertiary-text);
       transition: all 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
     }
@@ -192,7 +192,7 @@
       }
     }
 
-    & .ant-select-selector {
+    .ant-select-selector {
       /* Override default button styling */
       border-color: $light-gray;
       box-shadow: none;
@@ -201,14 +201,20 @@
   }
 
   /* Control response to hover + active menu */
-  & .ant-select.select-render-setting:hover:not(.ant-select-disabled),
-  & .ant-select.select-render-setting:focus-visible:not(.ant-select-disabled),
-  &&& .ant-select-open {
+  .ant-select.select-render-setting:hover:not(.ant-select-disabled),
+  .ant-select.select-render-setting:focus-visible:not(.ant-select-disabled),
+  .ant-select.ant-select-open {
     & .ant-select-selector,
     & .ant-select-arrow,
     & .ant-select-selection-item {
       color: var(--color-button-tertiary-hover-text);
       outline-color: var(--color-button-tertiary-hover-outline);
+    }
+  }
+
+  .ant-select.select-resolution {
+    & > .ant-select-selector {
+      text-align: left;
     }
   }
 }

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -198,23 +198,27 @@
       box-shadow: none;
       background-color: var(--color-toolbar-button-bg);
     }
-  }
 
-  /* Control response to hover + active menu */
-  .ant-select.select-toolbar:hover:not(.ant-select-disabled),
-  .ant-select.select-toolbar:focus-visible:not(.ant-select-disabled),
-  .ant-select.ant-select-open {
-    & .ant-select-selector,
-    & .ant-select-arrow,
-    & .ant-select-selection-item {
-      color: var(--color-button-tertiary-hover-text);
-      outline-color: var(--color-button-tertiary-hover-outline);
+    /* Control response to hover + active menu */
+    &:hover:not(.ant-select-disabled),
+    &:focus-visible:not(.ant-select-disabled),
+    &.ant-select.ant-select-open {
+      .ant-select-selector,
+      .ant-select-arrow,
+      .ant-select-selection-item {
+        color: var(--color-button-tertiary-hover-text);
+        outline-color: var(--color-button-tertiary-hover-outline);
+      }
     }
-  }
 
-  .ant-select.select-resolution {
-    & > .ant-select-selector {
-      text-align: left;
+    &.select-resolution {
+      > .ant-select-selector {
+        text-align: left;
+      }
+
+      &.ant-select-disabled .ant-select-selection-item {
+        color: var(--color-button-tertiary-text);
+      }
     }
   }
 }

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -161,7 +161,7 @@
   }
 
   /* Dropdown */
-  .ant-select.select-render-setting {
+  .ant-select.select-toolbar {
     min-width: 120px;
 
     .ant-select-selection-item,
@@ -201,8 +201,8 @@
   }
 
   /* Control response to hover + active menu */
-  .ant-select.select-render-setting:hover:not(.ant-select-disabled),
-  .ant-select.select-render-setting:focus-visible:not(.ant-select-disabled),
+  .ant-select.select-toolbar:hover:not(.ant-select-disabled),
+  .ant-select.select-toolbar:focus-visible:not(.ant-select-disabled),
   .ant-select.ant-select-open {
     & .ant-select-selector,
     & .ant-select-arrow,


### PR DESCRIPTION
Review time: small (~10-15min)

Implements a number of small styling and behavior improvements requested by @thao-do in a feedback session following #501 merging, or which I noticed in the same session.

- Text in the scale level dropdown should be left-aligned and should be light gray, even while the dropdown is disabled
- A small strip of the scale level selection dropdown triggered incorrect styling when hovered
- Per the [Figma design](https://www.figma.com/design/EJCCnElvRvObznBhN519sl/Vol-E---CFE), tooltips should be dark gray, not black
- The word "Resolution" should be light gray, not white
- The styling of options in the scale level dropdown did not exactly match the adjacent render mode dropdown
- When the toolbar is in "scroll mode" to accommodate narrow screens, the "scroll right" button did not always disappear when the toolbar was scrolled all the way to the right
- Resolution controls appear in the toolbar only after image metadata has been loaded and the image is known to contain multiple scale levels; the toolbar didn't notice when this caused its contents to overflow its horizontal space, so it didn't enter "scroll mode."