### PR TITLE
Tweak error alert to better surface new errors

### DIFF
--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -340,7 +340,7 @@ const App: React.FC<AppProps> = (props) => {
   );
 
   const onError = useCallback(
-    (image: Volume | undefined, error: unknown) => {
+    (error: unknown, image?: Volume) => {
       showError(error, image);
       onImageTitleChange?.(undefined);
     },

--- a/src/aics-image-viewer/components/App/index.tsx
+++ b/src/aics-image-viewer/components/App/index.tsx
@@ -158,7 +158,7 @@ const App: React.FC<AppProps> = (props) => {
 
   useEffect(() => {
     // Get notifications of loading errors which occur after the initial load, e.g. on time change or new channel load
-    view3d.setLoadErrorHandler((_vol, e) => showError(e));
+    view3d.setLoadErrorHandler((vol, e) => showError(e, vol));
     return () => view3d.setLoadErrorHandler(undefined);
   }, [view3d, showError]);
 
@@ -340,8 +340,8 @@ const App: React.FC<AppProps> = (props) => {
   );
 
   const onError = useCallback(
-    (error: unknown) => {
-      showError(error);
+    (image: Volume | undefined, error: unknown) => {
+      showError(error, image);
       onImageTitleChange?.(undefined);
     },
     [showError, onImageTitleChange]

--- a/src/aics-image-viewer/components/App/types.ts
+++ b/src/aics-image-viewer/components/App/types.ts
@@ -69,6 +69,6 @@ export interface AppProps {
   view3dRef?: MutableRefObject<View3d | null>;
   metadataFormatter?: (metadata: MetadataRecord) => MetadataRecord;
   onControlPanelToggle?: (collapsed: boolean) => void;
-  showError?: (error: any) => void;
+  showError?: (error: unknown, image?: Volume) => void;
   onImageTitleChange?: (title: string | undefined) => void;
 }

--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -147,25 +147,31 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, afterClose }) => {
     </>
   );
 
-  const skipErrorButton = errors.length > 1 && (
-    <>
-      {errorIndex > 0 && (
+  let skipErrorButton: React.ReactNode = undefined;
+
+  if (errors.length > 1) {
+    if (errorIndex === errors.length - 1) {
+      skipErrorButton = (
         <Button type="text" onClick={() => setErrorIndex((i) => i - 1)}>
-          <LeftOutlined />
+          <LeftOutlined /> {errors.length - 1} previous error{errors.length > 2 ? "s" : ""}
         </Button>
-      )}
-
-      {errorIndex === errors.length - 1
-        ? `${errors.length} previous error${errors.length > 1 ? "s" : ""}`
-        : `Error ${errorIndex + 1} of ${errors.length}`}
-
-      {errorIndex < errors.length - 1 && (
-        <Button type="text" onClick={() => setErrorIndex((i) => i + 1)}>
-          <RightOutlined />
-        </Button>
-      )}
-    </>
-  );
+      );
+    } else {
+      skipErrorButton = (
+        <>
+          {errorIndex > 0 && (
+            <Button type="text" onClick={() => setErrorIndex((i) => i - 1)}>
+              <LeftOutlined />
+            </Button>
+          )}
+          Error {errorIndex + 1} of {errors.length}
+          <Button type="text" onClick={() => setErrorIndex((i) => i + 1)}>
+            <RightOutlined />
+          </Button>
+        </>
+      );
+    }
+  }
 
   return (
     <Alert

--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -81,7 +81,7 @@ const getErrorTitle = (error: unknown): string =>
   (typeof error === "object" && error !== null && (error as ErrorAlertDescription).title) ||
   "Unknown error";
 
-const getErrorDescription = (error: unknown): React.ReactNode => {
+const getErrorDescription = (error: unknown, multiscaleDims?: VolumeDims[]): React.ReactNode => {
   const type: VolumeLoadErrorType | undefined = (error as VolumeLoadError).type;
   if (!type) {
     return (
@@ -90,8 +90,17 @@ const getErrorDescription = (error: unknown): React.ReactNode => {
     );
   }
   if (type === VolumeLoadErrorType.TOO_LARGE && useViewerState.getState().useExactScaleLevel) {
+    let dimsDetail = "";
+    if (Array.isArray(multiscaleDims)) {
+      const [_t, _c, z, y, x] = multiscaleDims[useViewerState.getState().scaleLevelIndex].shape;
+      dimsDetail = ` (${x} x ${y} x ${z})`;
+    }
+
     return (
-      <>The viewer cannot load this resolution level within memory limits. Try again with a smaller resolution level.</>
+      <>
+        The viewer cannot load this resolution level{dimsDetail} within memory limits. Try again with a smaller
+        resolution level.
+      </>
     );
   }
   return ERROR_TYPE_DESCRIPTIONS[type] ?? UNKNOWN_ERROR_DESCRIPTION;

--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -1,5 +1,4 @@
 import { type Volume, type VolumeLoadError, VolumeLoadErrorType } from "@aics/vole-core";
-import type { VolumeDims } from "@aics/vole-core/es/types/VolumeDims";
 import { LeftOutlined, RightOutlined } from "@ant-design/icons";
 import { Alert, Button } from "antd";
 import React from "react";

--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -1,5 +1,5 @@
 import { type Volume, type VolumeLoadError, VolumeLoadErrorType } from "@aics/vole-core";
-import { LeftOutlined, RightOutlined } from "@ant-design/icons";
+import { LeftOutlined, RightOutlined, WarningOutlined } from "@ant-design/icons";
 import { Alert, Button } from "antd";
 import React from "react";
 
@@ -175,7 +175,16 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, afterClose }) => {
 
   const clsName = flash ? "load-error-alert error-flash" : "load-error-alert";
   return (
-    <Alert showIcon closable type="error" className={clsName} message={msg} afterClose={afterClose} action={pageBtn} />
+    <Alert
+      showIcon
+      closable
+      type="error"
+      icon={<WarningOutlined />}
+      className={clsName}
+      message={msg}
+      afterClose={afterClose}
+      action={pageBtn}
+    />
   );
 };
 
@@ -201,8 +210,8 @@ export const useErrorAlert = (): [React.ReactNode, (error: unknown, image?: Volu
 
   const afterClose = React.useCallback(() => setErrors([]), []);
 
-  const alertComponent = errors.length > 0 && <ErrorAlert errors={errors} afterClose={afterClose} />;
-  return [alertComponent, addError];
+  const alertNode = errors.length > 0 && <ErrorAlert errors={errors} afterClose={afterClose} />;
+  return [alertNode, addError];
 };
 
 export default ErrorAlert;

--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -130,7 +130,7 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, afterClose }) => {
     window.setTimeout(() => setFlash(false), 100);
   }, [errors]);
 
-  const errorMessage = (
+  const msg = (
     <>
       <div className="error-title">
         {getErrorTitle(error.error) + (error.count > 1 ? ` (${error.count})` : "")}{" "}
@@ -147,17 +147,17 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, afterClose }) => {
     </>
   );
 
-  let errorPageButton: React.ReactNode = undefined;
+  let pageBtn: React.ReactNode = undefined;
 
   if (errors.length > 1) {
     if (errorIndex === errors.length - 1) {
-      errorPageButton = (
+      pageBtn = (
         <Button type="text" onClick={() => setErrorIndex((i) => i - 1)}>
           <LeftOutlined /> {errors.length - 1} previous error{errors.length > 2 ? "s" : ""}
         </Button>
       );
     } else {
-      errorPageButton = (
+      pageBtn = (
         <>
           {errorIndex > 0 && (
             <Button type="text" onClick={() => setErrorIndex((i) => i - 1)}>
@@ -173,16 +173,9 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, afterClose }) => {
     }
   }
 
+  const clsName = flash ? "load-error-alert error-flash" : "load-error-alert";
   return (
-    <Alert
-      showIcon
-      type="error"
-      className={flash ? "load-error-alert error-flash" : "load-error-alert"}
-      message={errorMessage}
-      closable
-      afterClose={afterClose}
-      action={errorPageButton}
-    />
+    <Alert showIcon closable type="error" className={clsName} message={msg} afterClose={afterClose} action={pageBtn} />
   );
 };
 

--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -130,6 +130,7 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, afterClose }) => {
     window.setTimeout(() => setFlash(false), 100);
   }, [errors]);
 
+  const cause = (error.error as any).cause;
   const msg = (
     <>
       <div className="error-title">
@@ -139,25 +140,25 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, afterClose }) => {
         </Button>
       </div>
       <div style={infoStyle}>{getErrorDescription(error)}</div>
-      {(error.error as any).cause !== undefined && (
+      {cause !== undefined && (
         <div className="error-cause" style={infoStyle}>
-          Caused by {getErrorTitle((error.error as any).cause)}
+          Caused by {getErrorTitle(cause)}
         </div>
       )}
     </>
   );
 
-  let pageBtn: React.ReactNode = undefined;
+  let pageButton: React.ReactNode = undefined;
 
   if (errors.length > 1) {
     if (errorIndex === errors.length - 1) {
-      pageBtn = (
+      pageButton = (
         <Button type="text" onClick={() => setErrorIndex((i) => i - 1)}>
           <LeftOutlined /> {errors.length - 1} previous error{errors.length > 2 ? "s" : ""}
         </Button>
       );
     } else {
-      pageBtn = (
+      pageButton = (
         <>
           {errorIndex > 0 && (
             <Button type="text" onClick={() => setErrorIndex((i) => i - 1)}>
@@ -173,17 +174,17 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, afterClose }) => {
     }
   }
 
-  const clsName = flash ? "load-error-alert error-flash" : "load-error-alert";
+  const alertClass = flash ? "load-error-alert error-flash" : "load-error-alert";
   return (
     <Alert
       showIcon
       closable
       type="error"
       icon={<WarningOutlined />}
-      className={clsName}
+      className={alertClass}
       message={msg}
       afterClose={afterClose}
-      action={pageBtn}
+      action={pageButton}
     />
   );
 };

--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -147,17 +147,17 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, afterClose }) => {
     </>
   );
 
-  let skipErrorButton: React.ReactNode = undefined;
+  let errorPageButton: React.ReactNode = undefined;
 
   if (errors.length > 1) {
     if (errorIndex === errors.length - 1) {
-      skipErrorButton = (
+      errorPageButton = (
         <Button type="text" onClick={() => setErrorIndex((i) => i - 1)}>
           <LeftOutlined /> {errors.length - 1} previous error{errors.length > 2 ? "s" : ""}
         </Button>
       );
     } else {
-      skipErrorButton = (
+      errorPageButton = (
         <>
           {errorIndex > 0 && (
             <Button type="text" onClick={() => setErrorIndex((i) => i - 1)}>
@@ -181,7 +181,7 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, afterClose }) => {
       message={errorMessage}
       closable
       afterClose={afterClose}
-      action={skipErrorButton}
+      action={errorPageButton}
     />
   );
 };

--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -1,4 +1,5 @@
-import { type VolumeLoadError, VolumeLoadErrorType } from "@aics/vole-core";
+import { type Volume, type VolumeLoadError, VolumeLoadErrorType } from "@aics/vole-core";
+import type { VolumeDims } from "@aics/vole-core/es/types/VolumeDims";
 import { RightOutlined } from "@ant-design/icons";
 import { Alert, Button } from "antd";
 import React from "react";
@@ -100,11 +101,18 @@ export type ErrorAlertProps = {
   errors: unknown;
   /** The number of times we've seen an error of the type that is currently being displayed before */
   firstErrorCount?: number;
+  multiscaleDims?: VolumeDims[];
   afterClose?: () => void;
   onSkipError?: () => void;
 };
 
-const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, firstErrorCount = 0, afterClose, onSkipError }) => {
+const ErrorAlert: React.FC<ErrorAlertProps> = ({
+  errors,
+  firstErrorCount = 0,
+  afterClose,
+  onSkipError,
+  multiscaleDims,
+}) => {
   const [showDetails, setShowDetails] = React.useState(false);
   const [errorsSeenCount, setErrorsSeenCount] = React.useState(0);
   const error = Array.isArray(errors) ? errors[0] : errors;
@@ -156,7 +164,7 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, firstErrorCount = 0, af
   );
 };
 
-export const useErrorAlert = (): [React.ReactNode, (error: unknown) => void] => {
+export const useErrorAlert = (image?: Volume): [React.ReactNode, (error: unknown) => void] => {
   const [errorList, setErrorList] = React.useState<unknown[]>([]);
   // Keep track of which errors have been seen and how many times
   const seenErrors = useConstructor(() => new Map<string, number>());
@@ -187,7 +195,13 @@ export const useErrorAlert = (): [React.ReactNode, (error: unknown) => void] => 
 
   const errCount = errorCounts[0];
   const alertComponent = errorList.length > 0 && (
-    <ErrorAlert errors={errorList} firstErrorCount={errCount} onSkipError={onSkipError} afterClose={afterClose} />
+    <ErrorAlert
+      errors={errorList}
+      firstErrorCount={errCount}
+      multiscaleDims={image?.imageInfo.imageInfo.multiscaleLevelDims}
+      onSkipError={onSkipError}
+      afterClose={afterClose}
+    />
   );
   return [alertComponent, addError];
 };

--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -119,9 +119,16 @@ export type ErrorAlertProps = {
 const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, afterClose }) => {
   const [showDetails, setShowDetails] = React.useState(false);
   const [errorIndex, setErrorIndex] = React.useState(0);
+  const [flash, setFlash] = React.useState(false);
   const error = errors[errorIndex];
 
   const infoStyle = { display: showDetails ? undefined : "none" } as const;
+
+  React.useEffect(() => {
+    setErrorIndex(errors.length - 1);
+    setFlash(errors.length > 1);
+    window.setTimeout(() => setFlash(false), 100);
+  }, [errors]);
 
   const errorMessage = (
     <>
@@ -164,7 +171,7 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, afterClose }) => {
     <Alert
       showIcon
       type="error"
-      className="load-error-alert"
+      className={flash ? "load-error-alert error-flash" : "load-error-alert"}
       message={errorMessage}
       closable
       afterClose={afterClose}

--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -1,6 +1,6 @@
 import { type Volume, type VolumeLoadError, VolumeLoadErrorType } from "@aics/vole-core";
 import type { VolumeDims } from "@aics/vole-core/es/types/VolumeDims";
-import { RightOutlined } from "@ant-design/icons";
+import { LeftOutlined, RightOutlined } from "@ant-design/icons";
 import { Alert, Button } from "antd";
 import React from "react";
 
@@ -114,23 +114,20 @@ const getErrorDescription = ({ error, dims }: ErrorInfo): React.ReactNode => {
 
 export type ErrorAlertProps = {
   errors: ErrorInfo[];
-  /** The number of times we've seen an error of the type that is currently being displayed before */
-  firstErrorCount?: number;
   afterClose?: () => void;
-  onSkipError?: () => void;
 };
 
-const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, firstErrorCount = 0, afterClose, onSkipError }) => {
+const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, afterClose }) => {
   const [showDetails, setShowDetails] = React.useState(false);
-  const [errorsSeenCount, setErrorsSeenCount] = React.useState(0);
-  const error = errors[0];
+  const [errorIndex, setErrorIndex] = React.useState(0);
+  const error = errors[errorIndex];
 
   const infoStyle = { display: showDetails ? undefined : "none" } as const;
 
   const errorMessage = (
     <>
       <div className="error-title">
-        {getErrorTitle(error.error) + (firstErrorCount > 1 ? ` (${firstErrorCount})` : "")}{" "}
+        {getErrorTitle(error.error) + (error.count > 1 ? ` (${error.count})` : "")}{" "}
         <Button type="text" onClick={() => setShowDetails(!showDetails)}>
           {showDetails ? "Show less info" : "Show more info"}
         </Button>
@@ -144,16 +141,24 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, firstErrorCount = 0, af
     </>
   );
 
-  const skipErrorButton = Array.isArray(errors) && errors.length > 1 && (
-    <Button
-      type="text"
-      onClick={() => {
-        setErrorsSeenCount((count) => count + 1);
-        onSkipError?.();
-      }}
-    >
-      Error {errorsSeenCount + 1} of {errors.length + errorsSeenCount} <RightOutlined />
-    </Button>
+  const skipErrorButton = errors.length > 1 && (
+    <>
+      {errorIndex > 0 && (
+        <Button type="text" onClick={() => setErrorIndex((i) => i - 1)}>
+          <LeftOutlined />
+        </Button>
+      )}
+
+      {errorIndex === errors.length - 1
+        ? `${errors.length} previous error${errors.length > 1 ? "s" : ""}`
+        : `Error ${errorIndex + 1} of ${errors.length}`}
+
+      {errorIndex < errors.length - 1 && (
+        <Button type="text" onClick={() => setErrorIndex((i) => i + 1)}>
+          <RightOutlined />
+        </Button>
+      )}
+    </>
   );
 
   return (
@@ -163,10 +168,7 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, firstErrorCount = 0, af
       className="load-error-alert"
       message={errorMessage}
       closable
-      afterClose={() => {
-        setErrorsSeenCount(0);
-        afterClose?.();
-      }}
+      afterClose={afterClose}
       action={skipErrorButton}
     />
   );
@@ -192,18 +194,9 @@ export const useErrorAlert = (): [React.ReactNode, (error: unknown, image?: Volu
     [seenErrors]
   );
 
-  const onSkipError = React.useCallback(() => {
-    setErrors((prev) => prev.slice(1));
-  }, []);
+  const afterClose = React.useCallback(() => setErrors([]), []);
 
-  const afterClose = React.useCallback(() => {
-    setErrors([]);
-  }, []);
-
-  const errCount = errors[0]?.count;
-  const alertComponent = errors.length > 0 && (
-    <ErrorAlert errors={errors} firstErrorCount={errCount} onSkipError={onSkipError} afterClose={afterClose} />
-  );
+  const alertComponent = errors.length > 0 && <ErrorAlert errors={errors} afterClose={afterClose} />;
   return [alertComponent, addError];
 };
 

--- a/src/aics-image-viewer/components/ErrorAlert/index.tsx
+++ b/src/aics-image-viewer/components/ErrorAlert/index.tsx
@@ -81,7 +81,13 @@ const getErrorTitle = (error: unknown): string =>
   (typeof error === "object" && error !== null && (error as ErrorAlertDescription).title) ||
   "Unknown error";
 
-const getErrorDescription = (error: unknown, multiscaleDims?: VolumeDims[]): React.ReactNode => {
+type ErrorInfo = {
+  error: unknown;
+  count: number;
+  dims?: [number, number, number, number, number];
+};
+
+const getErrorDescription = ({ error, dims }: ErrorInfo): React.ReactNode => {
   const type: VolumeLoadErrorType | undefined = (error as VolumeLoadError).type;
   if (!type) {
     return (
@@ -91,8 +97,8 @@ const getErrorDescription = (error: unknown, multiscaleDims?: VolumeDims[]): Rea
   }
   if (type === VolumeLoadErrorType.TOO_LARGE && useViewerState.getState().useExactScaleLevel) {
     let dimsDetail = "";
-    if (Array.isArray(multiscaleDims)) {
-      const [_t, _c, z, y, x] = multiscaleDims[useViewerState.getState().scaleLevelIndex].shape;
+    if (Array.isArray(dims)) {
+      const [_t, _c, z, y, x] = dims;
       dimsDetail = ` (${x} x ${y} x ${z})`;
     }
 
@@ -107,39 +113,32 @@ const getErrorDescription = (error: unknown, multiscaleDims?: VolumeDims[]): Rea
 };
 
 export type ErrorAlertProps = {
-  errors: unknown;
+  errors: ErrorInfo[];
   /** The number of times we've seen an error of the type that is currently being displayed before */
   firstErrorCount?: number;
-  multiscaleDims?: VolumeDims[];
   afterClose?: () => void;
   onSkipError?: () => void;
 };
 
-const ErrorAlert: React.FC<ErrorAlertProps> = ({
-  errors,
-  firstErrorCount = 0,
-  afterClose,
-  onSkipError,
-  multiscaleDims,
-}) => {
+const ErrorAlert: React.FC<ErrorAlertProps> = ({ errors, firstErrorCount = 0, afterClose, onSkipError }) => {
   const [showDetails, setShowDetails] = React.useState(false);
   const [errorsSeenCount, setErrorsSeenCount] = React.useState(0);
-  const error = Array.isArray(errors) ? errors[0] : errors;
+  const error = errors[0];
 
   const infoStyle = { display: showDetails ? undefined : "none" } as const;
 
   const errorMessage = (
     <>
       <div className="error-title">
-        {getErrorTitle(error) + (firstErrorCount > 1 ? ` (${firstErrorCount})` : "")}{" "}
+        {getErrorTitle(error.error) + (firstErrorCount > 1 ? ` (${firstErrorCount})` : "")}{" "}
         <Button type="text" onClick={() => setShowDetails(!showDetails)}>
           {showDetails ? "Show less info" : "Show more info"}
         </Button>
       </div>
       <div style={infoStyle}>{getErrorDescription(error)}</div>
-      {error.cause !== undefined && (
+      {(error.error as any).cause !== undefined && (
         <div className="error-cause" style={infoStyle}>
-          Caused by {getErrorTitle(error.cause)}
+          Caused by {getErrorTitle((error.error as any).cause)}
         </div>
       )}
     </>
@@ -173,44 +172,37 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({
   );
 };
 
-export const useErrorAlert = (image?: Volume): [React.ReactNode, (error: unknown) => void] => {
-  const [errorList, setErrorList] = React.useState<unknown[]>([]);
+export const useErrorAlert = (): [React.ReactNode, (error: unknown, image?: Volume) => void] => {
+  const [errors, setErrors] = React.useState<ErrorInfo[]>([]);
   // Keep track of which errors have been seen and how many times
   const seenErrors = useConstructor(() => new Map<string, number>());
-  const [errorCounts, setErrorCounts] = React.useState<number[]>([]);
 
   const addError = React.useCallback(
-    (error: unknown) => {
+    (error: unknown, image?: Volume) => {
       const errorTitle = getErrorTitle(error);
       console.error(error instanceof Error ? error : errorTitle);
-      const errorSeenCount = (seenErrors.get(errorTitle) ?? 0) + 1;
+      const count = (seenErrors.get(errorTitle) ?? 0) + 1;
 
-      setErrorList((prev) => [...prev, error]);
-      setErrorCounts((prev) => [...prev, errorSeenCount]);
-      seenErrors.set(errorTitle, errorSeenCount);
+      const imageInfo = image?.imageInfo.imageInfo;
+      const dims = imageInfo && imageInfo.multiscaleLevelDims[imageInfo.multiscaleLevel].shape;
+
+      setErrors((prev) => [...prev, { error, count, dims }]);
+      seenErrors.set(errorTitle, count);
     },
     [seenErrors]
   );
 
   const onSkipError = React.useCallback(() => {
-    setErrorList((prev) => prev.slice(1));
-    setErrorCounts((prev) => prev.slice(1));
+    setErrors((prev) => prev.slice(1));
   }, []);
 
   const afterClose = React.useCallback(() => {
-    setErrorList([]);
-    setErrorCounts([]);
+    setErrors([]);
   }, []);
 
-  const errCount = errorCounts[0];
-  const alertComponent = errorList.length > 0 && (
-    <ErrorAlert
-      errors={errorList}
-      firstErrorCount={errCount}
-      multiscaleDims={image?.imageInfo.imageInfo.multiscaleLevelDims}
-      onSkipError={onSkipError}
-      afterClose={afterClose}
-    />
+  const errCount = errors[0]?.count;
+  const alertComponent = errors.length > 0 && (
+    <ErrorAlert errors={errors} firstErrorCount={errCount} onSkipError={onSkipError} afterClose={afterClose} />
   );
   return [alertComponent, addError];
 };

--- a/src/aics-image-viewer/components/ErrorAlert/styles.css
+++ b/src/aics-image-viewer/components/ErrorAlert/styles.css
@@ -16,12 +16,13 @@
     min-height: 24px;
   }
 
-  .ant-btn-text {
+  .ant-btn-text,
+  .ant-alert-action {
     color: var(--color-text-link);
+  }
 
-    &:hover {
-      color: #25affe !important;
-    }
+  .ant-btn-text:hover {
+    color: #25affe !important;
   }
 
   .ant-alert-message > div {

--- a/src/aics-image-viewer/components/ErrorAlert/styles.css
+++ b/src/aics-image-viewer/components/ErrorAlert/styles.css
@@ -5,12 +5,12 @@
   width: 40vw;
   align-items: start;
   z-index: 5000;
-  border-color: #dc4446;
+  border-color: var(--color-text-error);
   padding: 12px 30px;
   color: var(--color-text-section);
 
   &.error-flash {
-    background-color: #dc4446;
+    background-color: var(--color-text-error);
   }
 
   /* Keeps icons vertically aligned with the *first row* of text */
@@ -20,6 +20,21 @@
     min-height: 24px;
   }
 
+  .ant-alert-close-icon {
+    margin-inline-start: 14px;
+  }
+
+  .ant-alert-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+
+    > button {
+      gap: 4px;
+      border: none !important;
+    }
+  }
+
   .ant-btn-text,
   .ant-alert-action {
     color: var(--color-text-link);
@@ -27,6 +42,10 @@
 
   .ant-btn-text:hover {
     color: #25affe !important;
+  }
+
+  .anticon {
+    font-size: 21px;
   }
 
   .ant-alert-message > div {

--- a/src/aics-image-viewer/components/ErrorAlert/styles.css
+++ b/src/aics-image-viewer/components/ErrorAlert/styles.css
@@ -9,6 +9,10 @@
   padding: 12px 30px;
   color: var(--color-text-section);
 
+  &.error-flash {
+    background-color: #dc4446;
+  }
+
   /* Keeps icons vertically aligned with the *first row* of text */
   .ant-alert-icon,
   .ant-alert-close-icon,

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -18,7 +18,7 @@ const palette = {
   darkPurple: "#7e46d4",
   veryDarkPurple: "#5f369f",
   veryLtPurple: "#e7e4f2",
-  brightRed: "#ff4d4d",
+  brightRed: "#dc4446",
   brightYellow: "#e39b0d",
   brightGreen: "#61d900",
   veryBrightGreen: "#61ff00",

--- a/src/aics-image-viewer/components/useVolume.ts
+++ b/src/aics-image-viewer/components/useVolume.ts
@@ -28,7 +28,7 @@ export type UseVolumeOptions = {
   /** Callback for when a single channel of the volume has loaded. */
   onChannelLoaded?: (image: Volume, channelIndex: number, isInitialLoad: boolean) => void;
   /** Callback for when image loading encounters an error. */
-  onError?: (error: unknown) => void;
+  onError?: (error: unknown, image?: Volume) => void;
   /** The name of a channel which should be treated as a mask rather than as viewable data. */
   maskChannelName?: string;
 };


### PR DESCRIPTION
Review time: smallish (15-20min)

Since #501, it is now possible to trigger an error alert in the relatively normal course of using the app, by selecting a scale level which cannot fit in memory. This PR applies some feedback from @thao-do for how to better surface errors now that this is the case:
- When an error was caused by selecting a specific scale level, the error message includes the dimensions of that scale level
- When an error appears while the alert is still open, the alert briefly flashes to get the user's attention and jumps to that error's message, rather than hiding the new error behind a "next error" button and staying on the last error that hasn't been dismissed

I also aligned the styling of the error banner more closely with the [Figma design](https://www.figma.com/design/EJCCnElvRvObznBhN519sl/Vol-E---CFE?node-id=1834-4812&t=LEZ7b7IdwAei3ehl-0), which features larger icons and uses an outlined "caution" sign rather than a filled "X."

### Screenshots

<img width="1545" height="167" alt="image" src="https://github.com/user-attachments/assets/039b1443-00af-4b56-bddf-17d8f061f1bb" />

<img width="1545" height="95" alt="image" src="https://github.com/user-attachments/assets/dccbab8e-ba15-40c4-b261-bd210f21ca70" />

<img width="1547" height="96" alt="image" src="https://github.com/user-attachments/assets/6f340c67-aecd-461f-a1e3-e17cbe3c29d0" />


This link can be used to test out the new behaviors using the "Resolution" dropdown in the top toolbar &mdash; the largest scale levels of the image are too large: https://allen-cell-animated.github.io/vole-app/pr-preview/pr-511/viewer?url=https%3A%2F%2Fuk1s3.embassy.ebi.ac.uk%2Fidr%2Fzarr%2Fv0.4%2Fidr0048A%2F9846152.zarr
