### PR TITLE
Fix channel settings not appearing when channel name is the empty string

### DIFF
--- a/src/aics-image-viewer/components/ChannelsWidget.tsx
+++ b/src/aics-image-viewer/components/ChannelsWidget.tsx
@@ -144,7 +144,7 @@ const ChannelsWidget: React.FC<ChannelsWidgetProps> = (props: ChannelsWidgetProp
 
   const renderChannelRow = (channelIndex: number): React.ReactNode => {
     const channelName = channelNames[channelIndex];
-    return channelName ? (
+    return (
       <ChannelsWidgetRow
         key={channelIndex}
         index={channelIndex}
@@ -153,7 +153,7 @@ const ChannelsWidget: React.FC<ChannelsWidgetProps> = (props: ChannelsWidgetProp
         onColorChangeComplete={props.onColorChangeComplete}
         saveIsosurface={props.saveIsosurface}
       />
-    ) : null;
+    );
   };
 
   const rows: CollapseProps["items"] =

--- a/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
+++ b/src/aics-image-viewer/shared/utils/viewerChannelSettings.ts
@@ -161,11 +161,9 @@ export function findFirstChannelMatch(
 export function getDisplayName(name: string, index: number, settings?: ViewerChannelSettings): string {
   if (settings) {
     const c = findFirstChannelMatch(name, index, settings);
-    if (c) {
-      return c.name || name;
-    }
+    return c?.name ?? name;
   }
-  return name;
+  return name ?? index.toString();
 }
 
 export function makeChannelIndexGrouping(channels: string[], settings?: ViewerChannelSettings): ChannelGrouping {


### PR DESCRIPTION
Review time: tiny (>5min)

Fixes a bug where a channel settings row does not render for channels whose name in image metadata is the empty string.

### Steps to verify

- Go to https://vole.allencell.org and open https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/pig_heart.ome.zarr/scale4/pig_heart. There should be no channel settings!
- Open the same image at the PR preview link below. The channel settings should appear properly, apparently missing a channel name.