### PR TITLE
Refactor: move custom styling for `Select` and `Radio` components into `StyleProvider`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.3.0",
       "license": "ISC",
       "dependencies": {
-        "@aics/vole-core": "^4.9.0",
+        "@aics/vole-core": "^4.9.1",
         "@ant-design/icons": "^5.2.5",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
@@ -96,30 +96,25 @@
       "peerDependencies": {
         "antd": "^5.16.2",
         "react": "18.x",
-        "react-dom": "18.x",
-        "three": "^0.171.0"
+        "react-dom": "18.x"
       }
     },
     "node_modules/@aics/vole-core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-4.9.0.tgz",
-      "integrity": "sha512-/m2chqE/N4xr8A8LfGVhof9QjlGRMsMeOdqkkaJJG+lgN//ovV5eJKk0feGG141TbgBX/r45xRQduo3pZ/A0SQ==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-4.9.1.tgz",
+      "integrity": "sha512-cyqjcikY0KA3dsLBeJRguEZKK0TOprPZGWpBuY6Iw68XOAW9sLujvb2DZAmNhxc8TxZAWlSxsu4obf9UGtTfLw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.6",
         "geotiff": "^2.0.5",
         "serialize-error": "^11.0.3",
-        "three": "^0.184.0",
         "throttled-queue": "^3.0.0",
         "tweakpane": "^3.1.9",
         "zarrita": "^0.5.1"
+      },
+      "peerDependencies": {
+        "three": "^0.184.0"
       }
-    },
-    "node_modules/@aics/vole-core/node_modules/three": {
-      "version": "0.184.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
-      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
-      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -20069,9 +20064,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/three": {
-      "version": "0.171.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.171.0.tgz",
-      "integrity": "sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ==",
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
       "license": "MIT",
       "peer": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.3.0",
       "license": "ISC",
       "dependencies": {
-        "@aics/vole-core": "^4.8.2",
+        "@aics/vole-core": "^4.9.0",
         "@ant-design/icons": "^5.2.5",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
@@ -101,19 +101,25 @@
       }
     },
     "node_modules/@aics/vole-core": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-4.8.2.tgz",
-      "integrity": "sha512-91L/ffxM2hB75Loz86SIYn2sq9GDvP1voJ2HPM0AT+WIH4jrtvcj8rzxFA0M5AGzPFFQcSdnQmQ0uib9td+BDg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-4.9.0.tgz",
+      "integrity": "sha512-/m2chqE/N4xr8A8LfGVhof9QjlGRMsMeOdqkkaJJG+lgN//ovV5eJKk0feGG141TbgBX/r45xRQduo3pZ/A0SQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.6",
         "geotiff": "^2.0.5",
         "serialize-error": "^11.0.3",
-        "three": "^0.171.0",
-        "throttled-queue": "^2.1.4",
+        "three": "^0.184.0",
+        "throttled-queue": "^3.0.0",
         "tweakpane": "^3.1.9",
         "zarrita": "^0.5.1"
       }
+    },
+    "node_modules/@aics/vole-core/node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -20066,7 +20072,8 @@
       "version": "0.171.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.171.0.tgz",
       "integrity": "sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/throttle-debounce": {
       "version": "5.0.2",
@@ -20079,9 +20086,9 @@
       }
     },
     "node_modules/throttled-queue": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/throttled-queue/-/throttled-queue-2.1.4.tgz",
-      "integrity": "sha512-YGdk8sdmr4ge3g+doFj/7RLF5kLM+Mi7DEciu9PHxnMJZMeVuZeTj31g4VE7ekUffx/IdbvrtOCiz62afg0mkg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/throttled-queue/-/throttled-queue-3.0.0.tgz",
+      "integrity": "sha512-8X5YUdgDHaqy9DmJzoRWK45o2vzBZ7Rt4bT1Mody4TUuYOXSb7paRwDPVspCZiiW4rxZopgZQAwnhI2LU0QwFQ==",
       "license": "MIT"
     },
     "node_modules/thunky": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/vole-core": "^4.8.2",
+    "@aics/vole-core": "^4.9.0",
     "@ant-design/icons": "^5.2.5",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "author": "Megan Riel-Mehan",
   "license": "ISC",
   "dependencies": {
-    "@aics/vole-core": "^4.9.0",
+    "@aics/vole-core": "^4.9.1",
     "@ant-design/icons": "^5.2.5",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
@@ -65,8 +65,7 @@
   "peerDependencies": {
     "antd": "^5.16.2",
     "react": "18.x",
-    "react-dom": "18.x",
-    "three": "^0.171.0"
+    "react-dom": "18.x"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.5",

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -6,7 +6,7 @@ import { PRESET_COLOR_MAP } from "../../shared/constants";
 import type { MetadataRecord } from "../../shared/types";
 import { select, useViewerState } from "../../state/store";
 
-import ChannelsWidget from "../ChannelsWidget";
+import ChannelsWidget, { type ChannelsWidgetProps } from "../ChannelsWidget";
 import CustomizeWidget, { type CustomizeWidgetProps } from "../CustomizeWidget";
 import GlobalVolumeControls, { type GlobalVolumeControlsProps } from "../GlobalVolumeControls";
 import MetadataViewer from "../MetadataViewer";
@@ -14,12 +14,7 @@ import ViewerIcon from "../shared/ViewerIcon";
 
 import "./styles.css";
 
-type PropsOf<T> = T extends React.ComponentType<infer P> ? P : never;
-
-interface ControlPanelProps
-  extends PropsOf<typeof ChannelsWidget>,
-    PropsOf<typeof GlobalVolumeControls>,
-    PropsOf<typeof CustomizeWidget> {
+interface ControlPanelProps extends ChannelsWidgetProps, GlobalVolumeControlsProps, CustomizeWidgetProps {
   hasImage: boolean;
   visibleControls: GlobalVolumeControlsProps["visibleControls"] &
     CustomizeWidgetProps["visibleControls"] & {

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -48,8 +48,8 @@ function ControlPanel(props: ControlPanelProps): React.ReactElement {
   const singleChannelMode = useViewerState(select("singleChannelMode"));
   const changeViewerSetting = useViewerState(select("changeViewerSetting"));
 
-  const controlPanelContainerRef = React.useRef<HTMLDivElement>(null);
-  const getDropdownContainer = controlPanelContainerRef.current ? () => controlPanelContainerRef.current! : undefined;
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const getDropdownContainer = (): HTMLElement => containerRef.current ?? document.body;
 
   const { viewerChannelSettings, visibleControls, hasImage } = props;
 
@@ -155,7 +155,7 @@ function ControlPanel(props: ControlPanelProps): React.ReactElement {
   };
 
   return (
-    <div className="control-panel-col-container" ref={controlPanelContainerRef}>
+    <div className="control-panel-col-container" ref={containerRef}>
       <div className="control-panel-tab-col" style={{ flex: "0 0 50px" }}>
         <Button
           className={"ant-btn-icon-only btn-collapse" + (props.collapsed ? " btn-collapse-collapsed" : "")}

--- a/src/aics-image-viewer/components/ControlPanel/styles.css
+++ b/src/aics-image-viewer/components/ControlPanel/styles.css
@@ -22,16 +22,16 @@
 
       &:not([disabled]) {
         &.btn-tabactive {
-          color: var(--color-button-icon-activated-text);
-          background-color: var(--color-button-icon-activated-bg);
-          border-color: var(--color-button-icon-activated-outline);
+          color: var(--color-button-icon-active-text);
+          background-color: var(--color-button-icon-active-bg);
+          border-color: var(--color-button-icon-active-outline);
         }
 
         &:hover,
         &:focus-visible {
-          color: var(--color-button-icon-activated-text);
+          color: var(--color-button-icon-active-text);
           background-color: var(--color-button-primary-hover-bg);
-          border-color: var(--color-button-icon-activated-outline);
+          border-color: var(--color-button-icon-active-outline);
         }
       }
     }

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -420,7 +420,8 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
       }
     }
 
-    &:hover {
+    &:hover,
+    &:has(:focus-visible) {
       color: var(--color-button-tertiary-hover-text);
       border-color: var(--color-button-tertiary-hover-outline);
 

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -296,6 +296,7 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
       background-color: var(--color-button-primary-hover-bg);
       border-color: var(--color-button-primary-hover-bg);
       color: var(--color-button-primary-text);
+      outline: none;
     }
 
     &:active:not(:disabled) {

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -483,7 +483,8 @@ export default function StyleProvider(props: PropsWithChildren<{}>): ReactElemen
           },
           Radio: {
             buttonCheckedBg: theme.colors.button.tertiary.activatedBg,
-            // Keep the border color consistent; style in custom text & background color that breaks ant's system
+            // can't style borders and text of activated buttons independently within ant's system, so we set border
+            //   colors here and text/bg colors in custom css
             colorPrimary: theme.colors.button.tertiary.activatedOutline,
             colorPrimaryHover: theme.colors.button.tertiary.activatedOutline,
           },

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -407,6 +407,10 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
     }
   }
 
+  // Toolbar has special colors for radio buttons and will use these variables to apply them
+  --color-button-radio-hover-outline: var(--color-button-tertiary-active-outline);
+  --color-button-radio-hover-text: var(--color-button-tertiary-active-outline);
+
   .ant-radio-button-wrapper {
     &::before {
       content: none;
@@ -422,12 +426,12 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
 
     &:hover,
     &:has(:focus-visible) {
-      color: var(--color-button-tertiary-hover-text);
-      border-color: var(--color-button-tertiary-hover-outline);
+      color: var(--color-button-radio-hover-text);
+      border-color: var(--color-button-radio-hover-outline);
       outline: none;
 
       &:not(:first-child) {
-        box-shadow: -1px 0px 0px 0px var(--color-button-tertiary-hover-outline);
+        box-shadow: -1px 0px 0px 0px var(--color-button-radio-hover-outline);
         z-index: 2;
       }
     }
@@ -506,7 +510,6 @@ export default function StyleProvider(props: PropsWithChildren<{}>): ReactElemen
             // can't style borders and text of activated buttons independently within ant's system, so we set border
             //   colors here and text/bg colors in custom css
             colorPrimary: theme.colors.button.tertiary.activeOutline,
-            colorPrimaryHover: theme.colors.button.tertiary.activeOutline,
           },
           Select: {
             colorText: theme.colors.button.tertiary.text,

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -424,6 +424,7 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
     &:has(:focus-visible) {
       color: var(--color-button-tertiary-hover-text);
       border-color: var(--color-button-tertiary-hover-outline);
+      outline: none;
 
       &:not(:first-child) {
         box-shadow: -1px 0px 0px 0px var(--color-button-tertiary-hover-outline);

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -461,6 +461,14 @@ export default function StyleProvider(props: PropsWithChildren<{}>): ReactElemen
             footerBg: theme.colors.modal.bg,
             titleFontSize: 19,
           },
+          Select: {
+            colorText: theme.colors.button.tertiary.text,
+            colorBorder: theme.colors.button.tertiary.outline,
+            // arrow color
+            colorTextQuaternary: theme.colors.button.tertiary.text,
+            colorTextDisabled: theme.colors.button.tertiary.disabledText,
+            colorTextPlaceholder: theme.colors.button.tertiary.hoverText,
+          },
         },
       }}
     >

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -413,6 +413,29 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
       }
     }
   }
+
+  .ant-radio-button-wrapper {
+    &::before {
+      content: none;
+    }
+
+    &.ant-radio-button-wrapper-checked {
+      color: var(--color-button-icon-active-text);
+
+      &:not(:first-child) {
+        box-shadow: -1px 0px 0px 0px var(--color-button-tertiary-active-outline);
+      }
+    }
+
+    &:hover {
+      color: var(--color-button-tertiary-hover-text);
+      border-color: var(--color-button-tertiary-hover-outline);
+
+      &:not(:first-child) {
+        box-shadow: -1px 0px 0px 0px var(--color-button-tertiary-hover-outline);
+      }
+    }
+  }
 `;
 
 /**

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -481,6 +481,12 @@ export default function StyleProvider(props: PropsWithChildren<{}>): ReactElemen
             footerBg: theme.colors.modal.bg,
             titleFontSize: 19,
           },
+          Radio: {
+            buttonCheckedBg: theme.colors.button.tertiary.activatedBg,
+            // Keep the border color consistent; style in custom text & background color that breaks ant's system
+            colorPrimary: theme.colors.button.tertiary.activatedOutline,
+            colorPrimaryHover: theme.colors.button.tertiary.activatedOutline,
+          },
           Select: {
             colorText: theme.colors.button.tertiary.text,
             colorBorder: theme.colors.button.tertiary.outline,

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -456,6 +456,13 @@ export default function StyleProvider(props: PropsWithChildren<{}>): ReactElemen
             defaultActiveBg: theme.colors.button.secondary.bg,
             defaultActiveBorderColor: theme.colors.button.tertiary.activeOutline,
           },
+          Checkbox: {
+            borderRadiusSM: 2,
+            colorBgContainer: theme.colors.checkbox.bg,
+            colorPrimary: theme.colors.checkbox.bg,
+            colorPrimaryHover: theme.colors.checkbox.hoverBg,
+            colorText: theme.colors.checkbox.text,
+          },
           Collapse: {
             borderRadiusLG: 0,
             colorTextHeading: theme.colors.text.section,
@@ -466,16 +473,6 @@ export default function StyleProvider(props: PropsWithChildren<{}>): ReactElemen
           },
           Layout: {
             siderBg: theme.colors.controlPanel.bg,
-          },
-          Checkbox: {
-            borderRadiusSM: 2,
-            colorBgContainer: theme.colors.checkbox.bg,
-            colorPrimary: theme.colors.checkbox.bg,
-            colorPrimaryHover: theme.colors.checkbox.hoverBg,
-            colorText: theme.colors.checkbox.text,
-          },
-          Tooltip: {
-            colorBgSpotlight: theme.colors.tooltip.bg,
           },
           Modal: {
             colorBgMask: theme.colors.modal.maskBg,
@@ -492,6 +489,9 @@ export default function StyleProvider(props: PropsWithChildren<{}>): ReactElemen
             colorTextDisabled: theme.colors.button.tertiary.disabledText,
             colorTextPlaceholder: theme.colors.button.tertiary.hoverText,
             colorBgContainerDisabled: "transparent",
+          },
+          Tooltip: {
+            colorBgSpotlight: theme.colors.tooltip.bg,
           },
         },
       }}

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -280,7 +280,7 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
     color: var(--color-text-link);
   }
 
-  & *::selection {
+  *::selection {
     background-color: var(--color-text-selection-bg);
     color: var(--color-text-selection-text);
   }
@@ -352,14 +352,14 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
   }
 
   // Overrides for checkbox styling
-  & .ant-checkbox-input {
+  .ant-checkbox-input {
     &:hover,
     &:focus-visible {
       border: 1px solid white;
     }
   }
 
-  & .ant-checkbox.ant-checkbox-checked {
+  .ant-checkbox.ant-checkbox-checked {
     background-color: var(--color-checkbox-bg);
   }
 
@@ -368,26 +368,27 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
   }
 
   // Add outlines to modals and dropdowns
-  & .ant-select-dropdown,
-  & .ant-dropdown-menu,
-  & .ant-modal-content {
+  .ant-select-dropdown,
+  .ant-dropdown-menu,
+  .ant-modal-content {
     border: 1px solid var(--color-modal-border);
   }
 
   // Force active/hovered text to be white instead of grey for better contrast
-  & .ant-dropdown-menu-item-active {
+  .ant-dropdown-menu-item-active {
     color: var(--color-menu-hover-text);
   }
 
   // Remove padding in dropdown menus and make items reactangular + flush with the edge
-  & .ant-dropdown-menu,
-  & .ant-select-dropdown {
+  .ant-dropdown-menu,
+  .ant-select-dropdown {
     padding: 0;
     overflow: hidden;
 
-    & .ant-dropdown-menu-item,
-    & .ant-select-item {
+    .ant-dropdown-menu-item,
+    .ant-select-item:not(.ant-select-item-option-disabled) {
       border-radius: 0;
+      color: var(--color-button-icon-activated-text);
     }
   }
 

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -80,10 +80,9 @@ const theme = {
         outline: palette.ltGrey,
         hoverOutline: palette.ltPurple,
         hoverText: palette.ltPurple,
-        activeOutline: palette.medPurple,
-        activatedText: palette.white,
-        activatedBg: palette.medDarkGrey,
-        activatedOutline: palette.purpleGrey,
+        activeText: palette.white,
+        activeBg: palette.medDarkGrey,
+        activeOutline: palette.purpleGrey,
         disabledText: palette.medGrey,
       },
     },
@@ -201,9 +200,9 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
       --color-button-tertiary-active-text: ${$theme.colors.button.tertiary.hoverText};
 
       --color-button-icon-disabled-text: ${$theme.colors.button.tertiary.disabledText};
-      --color-button-icon-activated-text: ${$theme.colors.button.tertiary.activatedText};
-      --color-button-icon-activated-bg: ${$theme.colors.button.tertiary.activatedBg};
-      --color-button-icon-activated-outline: ${$theme.colors.button.tertiary.activatedOutline};
+      --color-button-icon-active-text: ${$theme.colors.button.tertiary.activeText};
+      --color-button-icon-active-bg: ${$theme.colors.button.tertiary.activeBg};
+      --color-button-icon-active-outline: ${$theme.colors.button.tertiary.activeOutline};
 
       --color-toolbar-button-bg: ${$theme.colors.toolbar.buttonBg};
 
@@ -343,12 +342,6 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
       border-color: var(--color-button-tertiary-hover-bg);
       color: var(--color-button-tertiary-hover-text);
     }
-
-    &:active:not(:disabled) {
-      background-color: transparent;
-      border-color: var(--color-button-tertiary-active-outline);
-      color: var(--color-button-tertiary-active-text);
-    }
   }
 
   // Overrides for checkbox styling
@@ -388,7 +381,7 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
     .ant-dropdown-menu-item,
     .ant-select-item:not(.ant-select-item-option-disabled) {
       border-radius: 0;
-      color: var(--color-button-icon-activated-text);
+      color: var(--color-button-icon-active-text);
     }
   }
 
@@ -433,6 +426,7 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
 
       &:not(:first-child) {
         box-shadow: -1px 0px 0px 0px var(--color-button-tertiary-hover-outline);
+        z-index: 2;
       }
     }
   }
@@ -477,7 +471,7 @@ export default function StyleProvider(props: PropsWithChildren<{}>): ReactElemen
             primaryColor: theme.colors.button.primary.text,
             defaultHoverBg: theme.colors.button.secondary.bg,
             defaultActiveBg: theme.colors.button.secondary.bg,
-            defaultActiveBorderColor: theme.colors.button.tertiary.activeOutline,
+            defaultActiveBorderColor: theme.colors.button.primary.activeOutline,
           },
           Checkbox: {
             borderRadiusSM: 2,
@@ -505,12 +499,12 @@ export default function StyleProvider(props: PropsWithChildren<{}>): ReactElemen
             titleFontSize: 19,
           },
           Radio: {
-            buttonCheckedBg: theme.colors.button.tertiary.activatedBg,
+            buttonCheckedBg: theme.colors.button.tertiary.activeBg,
             buttonColor: theme.colors.button.tertiary.text,
             // can't style borders and text of activated buttons independently within ant's system, so we set border
             //   colors here and text/bg colors in custom css
-            colorPrimary: theme.colors.button.tertiary.activatedOutline,
-            colorPrimaryHover: theme.colors.button.tertiary.activatedOutline,
+            colorPrimary: theme.colors.button.tertiary.activeOutline,
+            colorPrimaryHover: theme.colors.button.tertiary.activeOutline,
           },
           Select: {
             colorText: theme.colors.button.tertiary.text,

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -491,6 +491,7 @@ export default function StyleProvider(props: PropsWithChildren<{}>): ReactElemen
             colorTextQuaternary: theme.colors.button.tertiary.text,
             colorTextDisabled: theme.colors.button.tertiary.disabledText,
             colorTextPlaceholder: theme.colors.button.tertiary.hoverText,
+            colorBgContainerDisabled: "transparent",
           },
         },
       }}

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -83,6 +83,7 @@ const theme = {
         activeText: palette.white,
         activeBg: palette.medDarkGrey,
         activeOutline: palette.purpleGrey,
+        disabledOutline: palette.medGrey,
         disabledText: palette.medGrey,
       },
     },
@@ -199,6 +200,7 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
       --color-button-tertiary-active-outline: ${$theme.colors.button.tertiary.activeOutline};
       --color-button-tertiary-active-text: ${$theme.colors.button.tertiary.hoverText};
 
+      --color-button-icon-disabled-outline: ${$theme.colors.button.tertiary.disabledOutline};
       --color-button-icon-disabled-text: ${$theme.colors.button.tertiary.disabledText};
       --color-button-icon-active-text: ${$theme.colors.button.tertiary.activeText};
       --color-button-icon-active-bg: ${$theme.colors.button.tertiary.activeBg};
@@ -340,7 +342,7 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
     &:hover:not(:disabled),
     &:focus-visible:not(:disabled) {
       background-color: transparent;
-      border-color: var(--color-button-tertiary-hover-bg);
+      border-color: var(--color-button-tertiary-hover-outline);
       color: var(--color-button-tertiary-hover-text);
     }
   }
@@ -388,7 +390,7 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
 
   .ant-select {
     &.ant-select-disabled .ant-select-selector {
-      border-color: var(--color-button-icon-disabled-text);
+      border-color: var(--color-button-icon-disabled-outline);
     }
 
     .ant-select-arrow {

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -408,8 +408,8 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
   }
 
   // Toolbar has special colors for radio buttons and will use these variables to apply them
-  --color-button-radio-hover-outline: var(--color-button-tertiary-active-outline);
-  --color-button-radio-hover-text: var(--color-button-tertiary-active-outline);
+  --color-button-radio-hover-outline: var(--color-button-tertiary-hover-outline);
+  --color-button-radio-hover-text: var(--color-button-tertiary-hover-outline);
 
   .ant-radio-button-wrapper {
     &::before {
@@ -429,10 +429,10 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
       color: var(--color-button-radio-hover-text);
       border-color: var(--color-button-radio-hover-outline);
       outline: none;
+      z-index: 2;
 
       &:not(:first-child) {
         box-shadow: -1px 0px 0px 0px var(--color-button-radio-hover-outline);
-        z-index: 2;
       }
     }
   }

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -390,6 +390,28 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
       border-radius: 0;
     }
   }
+
+  .ant-select {
+    &.ant-select-disabled .ant-select-selector {
+      border-color: var(--color-button-icon-disabled-text);
+    }
+
+    .ant-select-arrow {
+      transition: all 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
+    }
+
+    /* Control response to hover + active menu */
+    &:hover:not(.ant-select-disabled),
+    &:focus-visible:not(.ant-select-disabled),
+    &.ant-select.ant-select-open {
+      .ant-select-selector,
+      .ant-select-arrow,
+      .ant-select-selection-item {
+        color: var(--color-button-tertiary-hover-text);
+        outline-color: var(--color-button-tertiary-hover-outline);
+      }
+    }
+  }
 `;
 
 /**

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -483,6 +483,7 @@ export default function StyleProvider(props: PropsWithChildren<{}>): ReactElemen
           },
           Radio: {
             buttonCheckedBg: theme.colors.button.tertiary.activatedBg,
+            buttonColor: theme.colors.button.tertiary.text,
             // can't style borders and text of activated buttons independently within ant's system, so we set border
             //   colors here and text/bg colors in custom css
             colorPrimary: theme.colors.button.tertiary.activatedOutline,

--- a/src/aics-image-viewer/components/StyleProvider/index.tsx
+++ b/src/aics-image-viewer/components/StyleProvider/index.tsx
@@ -340,7 +340,7 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
     &:hover:not(:disabled),
     &:focus-visible:not(:disabled) {
       background-color: transparent;
-      border-color: var(--color-button-tertiary-hover-bg);
+      border-color: var(--color-button-tertiary-hover-outline);
       color: var(--color-button-tertiary-hover-text);
     }
   }
@@ -410,7 +410,7 @@ const CssProvider = styled.div<{ $theme: AppTheme }>`
 
   // Toolbar has special colors for radio buttons and will use these variables to apply them
   --color-button-radio-hover-outline: var(--color-button-tertiary-hover-outline);
-  --color-button-radio-hover-text: var(--color-button-tertiary-hover-outline);
+  --color-button-radio-hover-text: var(--color-button-tertiary-hover-text);
 
   .ant-radio-button-wrapper {
     &::before {

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -286,7 +286,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
   const [colorPickerPosition, setColorPickerPosition] = useState<[number, number] | null>(null);
   const lastColorRef = useRef<ColorArray>(TFEDITOR_DEFAULT_COLOR);
 
-  const containerRef = useRef<HTMLDivElement>(null);
+  const dropdownContainerRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null); // need access to SVG element to measure mouse position
 
   const { histogram } = props.channelData;
@@ -586,7 +586,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
   const { rawMin, rawMax } = props.channelData;
 
   return (
-    <div className="aics-tf-editor" ref={containerRef}>
+    <div className="aics-tf-editor">
       {/* ----- PLOT RANGE ----- */}
       <div className="tf-editor-control-row">
         <div>
@@ -719,7 +719,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
 
           {/* preset buttons */}
           <div className="tf-editor-control-row">
-            <div>
+            <div ref={dropdownContainerRef}>
               <Dropdown
                 trigger={["click"]}
                 menu={{
@@ -731,7 +731,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
                   ],
                   onClick: ({ key }) => applyTFGenerator(key),
                 }}
-                getPopupContainer={() => containerRef.current ?? document.body}
+                getPopupContainer={() => dropdownContainerRef.current ?? document.body}
               >
                 <Button size="small">
                   <span style={{ display: "flex", flexDirection: "row", alignItems: "center", gap: "4px" }}>

--- a/src/aics-image-viewer/components/TfEditor/index.tsx
+++ b/src/aics-image-viewer/components/TfEditor/index.tsx
@@ -286,6 +286,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
   const [colorPickerPosition, setColorPickerPosition] = useState<[number, number] | null>(null);
   const lastColorRef = useRef<ColorArray>(TFEDITOR_DEFAULT_COLOR);
 
+  const containerRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null); // need access to SVG element to measure mouse position
 
   const { histogram } = props.channelData;
@@ -585,7 +586,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
   const { rawMin, rawMax } = props.channelData;
 
   return (
-    <div className="aics-tf-editor">
+    <div className="aics-tf-editor" ref={containerRef}>
       {/* ----- PLOT RANGE ----- */}
       <div className="tf-editor-control-row">
         <div>
@@ -730,6 +731,7 @@ const TfEditor: React.FC<TfEditorProps> = (props) => {
                   ],
                   onClick: ({ key }) => applyTFGenerator(key),
                 }}
+                getPopupContainer={() => containerRef.current ?? document.body}
               >
                 <Button size="small">
                   <span style={{ display: "flex", flexDirection: "row", alignItems: "center", gap: "4px" }}>

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -229,7 +229,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
 
           <div className="viewer-toolbar-group">
             <Select
-              className="select-toolbar"
+              style={{ minWidth: 120 }}
               popupClassName="viewer-toolbar-dropdown"
               value={renderMode}
               onChange={(value) => changeViewerSetting("renderMode", value)}

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -230,7 +230,6 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
           <div className="viewer-toolbar-group">
             <Select
               style={{ minWidth: 120 }}
-              popupClassName="viewer-toolbar-dropdown"
               value={renderMode}
               onChange={(value) => changeViewerSetting("renderMode", value)}
               getPopupContainer={getPopupContainer}
@@ -279,8 +278,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
                 <Radio.Button value={true}>Manual</Radio.Button>
               </Radio.Group>
               <Select
-                className="select-toolbar select-resolution"
-                popupClassName="viewer-toolbar-dropdown"
+                className="select-resolution"
                 getPopupContainer={getPopupContainer}
                 style={{ minWidth: 150 }}
                 value={useExactScaleLevel ? scaleLevelIndex : (props.multiscaleIndex ?? scaleLevelIndex)}

--- a/src/aics-image-viewer/components/Toolbar/index.tsx
+++ b/src/aics-image-viewer/components/Toolbar/index.tsx
@@ -1,5 +1,4 @@
-// TODO this really ought to be exported at the top level...
-import type { VolumeDims } from "@aics/vole-core/es/types/VolumeDims";
+import type { VolumeDims } from "@aics/vole-core";
 import { ReloadOutlined } from "@ant-design/icons";
 import { Button, Radio, Select, Tooltip } from "antd";
 import { debounce } from "lodash";

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -110,7 +110,7 @@
   .btn-borderless,
   .ant-select.ant-select-outlined .ant-select-selector,
   .ant-radio-button-wrapper {
-    background-color: var(--color-toolbar-btn-bg);
+    background-color: var(--color-toolbar-button-bg);
   }
 
   & .ant-btn-icon-only {

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -192,24 +192,13 @@
 
     .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled):has(:focus-visible) {
       outline: none;
-      border-color: $light-gray;
-
-      &:not(:first-child) {
-        box-shadow: -1px 0px 0px 0px $light-gray;
-      }
     }
   }
 }
 
 @supports not (selector(:has(:focus-visible))) {
-  .viewer-toolbar {
-    .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled):focus-within {
-      outline: none;
-      border-color: $light-gray;
-
-      &:not(:first-child) {
-        box-shadow: -1px 0px 0px 0px $light-gray;
-      }
-    }
+  .viewer-toolbar .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled):focus-within {
+    outline: none;
+    border-color: $light-gray;
   }
 }

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -131,40 +131,17 @@
 
   /* Radio buttons */
 
-  .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled) {
-    &.ant-radio-button-wrapper-checked,
-    &:hover {
-      outline: none;
-      color: white;
-      border-color: $light-gray;
+  --color-button-radio-hover-outline: $light-gray;
+  --color-button-radio-hover-text: var(--color-button-icon-active-text);
 
-      &:not(:first-child) {
-        box-shadow: -1px 0px 0px 0px $light-gray;
-      }
-    }
-
-    &:hover {
-      background-color: $highlight-purple;
-      color: white;
-    }
-
-    &:focus-within {
-      outline: none;
-    }
-
-    &::before {
-      content: none;
-    }
+  .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled):hover {
+    background-color: $highlight-purple;
   }
 
-  .ant-select-selection:focus-visible,
   .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled):has(:focus-visible),
   .btn-borderless:focus-visible {
-    background-color: $highlight-purple !important;
-    color: white !important;
-  }
-
-  .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled):has(:focus-visible) {
+    background-color: $highlight-purple;
+    color: white;
     outline: none;
   }
 

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -70,38 +70,38 @@
   flex-direction: row;
   justify-content: space-around;
 
-  & > div {
+  > div {
     display: flex;
     flex-direction: row;
     align-items: center;
     vertical-align: middle;
   }
 
-  & .viewer-toolbar-left,
-  & .viewer-toolbar-right {
+  .viewer-toolbar-left,
+  .viewer-toolbar-right {
     position: absolute;
     &:not(:empty) {
       padding: 0 12px;
     }
   }
-  & .viewer-toolbar-left {
+  .viewer-toolbar-left {
     left: 0;
   }
-  & .viewer-toolbar-right {
+  .viewer-toolbar-right {
     right: 0;
   }
 
-  & .viewer-toolbar-group {
+  .viewer-toolbar-group {
     display: flex;
     flex-direction: row;
     align-items: center;
     vertical-align: middle;
   }
 
-  & .viewer-toolbar-group:not(:last-child) {
+  .viewer-toolbar-group:not(:last-child) {
     margin-right: 14px;
   }
-  & .viewer-toolbar-group > :not(:last-child) {
+  .viewer-toolbar-group > :not(:last-child) {
     margin-right: 6px;
   }
 
@@ -113,17 +113,17 @@
     background-color: var(--color-toolbar-button-bg);
   }
 
-  & .ant-btn-icon-only {
+  .ant-btn-icon-only {
     padding-bottom: 4px;
     padding-left: 1px;
   }
 
-  & .btn-borderless {
+  .btn-borderless {
     border-color: transparent;
     color: var(--color-text-body);
   }
 
-  & .btn-active {
+  .btn-active {
     color: var(--color-button-icon-activated-text);
     background-color: var(--color-button-icon-activated-bg);
     border: 1px solid var(--color-button-icon-activated-outline);
@@ -131,10 +131,7 @@
 
   /* Radio buttons */
 
-  & .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled) {
-    box-shadow: -1px 0px 0px 0px transparent;
-    transition-property: color, background-color, border-color, box-shadow;
-
+  .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled) {
     &.ant-radio-button-wrapper-checked,
     &:hover {
       outline: none;

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -165,30 +165,6 @@
   }
 
   /* Dropdown */
-  .ant-select.select-toolbar {
-    min-width: 120px;
-
-    &.ant-select-disabled .ant-select-selector {
-      border-color: var(--color-button-icon-disabled-text);
-    }
-
-    .ant-select-arrow {
-      transition: all 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
-    }
-
-    /* Control response to hover + active menu */
-    &:hover:not(.ant-select-disabled),
-    &:focus-visible:not(.ant-select-disabled),
-    &.ant-select.ant-select-open {
-      .ant-select-selector,
-      .ant-select-arrow,
-      .ant-select-selection-item {
-        color: var(--color-button-tertiary-hover-text);
-        outline-color: var(--color-button-tertiary-hover-outline);
-      }
-    }
-  }
-
   .ant-select.select-resolution {
     > .ant-select-selector {
       text-align: left;
@@ -203,32 +179,6 @@
         display: none;
       }
     }
-  }
-}
-
-/* Dropdown menu contents aren't children of .viewer-toolbar in the DOM */
-.viewer-toolbar-dropdown {
-  .ant-select-dropdown-menu-item-active {
-    transition-property: background-color, color;
-  }
-
-  .ant-select-dropdown-menu-item-disabled,
-  .ant-select-dropdown-menu-item-disabled:hover {
-    color: #6e6e6e;
-  }
-
-  .ant-select-dropdown-menu-item-active:not(.ant-select-dropdown-menu-item-disabled) {
-    background-color: transparent;
-    color: white;
-
-    &.ant-select-dropdown-menu-item-selected {
-      background-color: #4b4b4b;
-    }
-  }
-
-  .ant-select-dropdown-menu-item:hover:not(.ant-select-dropdown-menu-item-disabled) {
-    background-color: #f6f0ff;
-    color: #4b4b4b;
   }
 }
 

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -131,21 +131,23 @@
 
   /* Radio buttons */
 
-  --color-button-radio-hover-outline: $light-gray;
+  /* Override some default colors from `StyleProvider` */
+  --color-button-radio-hover-outline: var(--color-button-tertiary-active-outline);
   --color-button-radio-hover-text: var(--color-button-icon-active-text);
 
   .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled):hover {
-    background-color: $highlight-purple;
+    background-color: var(--color-button-tertiary-hover-text);
   }
 
   .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled):has(:focus-visible),
   .btn-borderless:focus-visible {
-    background-color: $highlight-purple;
+    background-color: var(--color-button-tertiary-hover-text);
     color: white;
     outline: none;
   }
 
   /* Dropdown */
+
   .ant-select.select-resolution {
     > .ant-select-selector {
       text-align: left;

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -135,15 +135,9 @@
   --color-button-radio-hover-outline: var(--color-button-tertiary-active-outline);
   --color-button-radio-hover-text: var(--color-button-icon-active-text);
 
-  .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled):hover {
+  .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled):hover,
+  .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled):has(:focus-visible) {
     background-color: var(--color-button-tertiary-hover-text);
-  }
-
-  .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled):has(:focus-visible),
-  .btn-borderless:focus-visible {
-    background-color: var(--color-button-tertiary-hover-text);
-    color: white;
-    outline: none;
   }
 
   /* Dropdown */

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -109,7 +109,7 @@
 
   .btn-borderless,
   .ant-select.ant-select-outlined .ant-select-selector,
-  .ant-radio-button-wrapper {
+  .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-checked) {
     background-color: var(--color-toolbar-button-bg);
   }
 
@@ -141,10 +141,6 @@
       &:not(:first-child) {
         box-shadow: -1px 0px 0px 0px $light-gray;
       }
-    }
-
-    &.ant-radio-button-wrapper-checked {
-      background-color: #4b4b4b;
     }
 
     &:hover {

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -107,13 +107,18 @@
 
   /* Icon-only buttons */
 
+  .btn-borderless,
+  .ant-select.ant-select-outlined .ant-select-selector,
+  .ant-radio-button-wrapper {
+    background-color: var(--color-toolbar-btn-bg);
+  }
+
   & .ant-btn-icon-only {
     padding-bottom: 4px;
     padding-left: 1px;
   }
 
   & .btn-borderless {
-    background-color: var(--color-toolbar-button-bg);
     border-color: transparent;
     color: var(--color-text-body);
   }
@@ -127,7 +132,6 @@
   /* Radio buttons */
 
   & .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled) {
-    background-color: black;
     box-shadow: -1px 0px 0px 0px transparent;
     transition-property: color, background-color, border-color, box-shadow;
 
@@ -164,39 +168,12 @@
   .ant-select.select-toolbar {
     min-width: 120px;
 
-    .ant-select-selection-item,
+    &.ant-select-disabled .ant-select-selector {
+      border-color: var(--color-button-icon-disabled-text);
+    }
+
     .ant-select-arrow {
-      color: var(--color-button-tertiary-text);
       transition: all 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
-    }
-
-    &.ant-select-disabled {
-      .ant-select-selection-item,
-      .ant-select-selection-search {
-        padding-inline-end: 0;
-      }
-
-      .ant-select-selection-item {
-        color: var(--color-button-icon-disabled-text);
-        &:hover {
-          color: var(--color-button-icon-disabled-text);
-        }
-      }
-
-      .ant-select-selector {
-        border-color: var(--color-button-icon-disabled-text);
-      }
-
-      .ant-select-arrow {
-        display: none;
-      }
-    }
-
-    .ant-select-selector {
-      /* Override default button styling */
-      border-color: $light-gray;
-      box-shadow: none;
-      background-color: var(--color-toolbar-button-bg);
     }
 
     /* Control response to hover + active menu */
@@ -210,14 +187,20 @@
         outline-color: var(--color-button-tertiary-hover-outline);
       }
     }
+  }
 
-    &.select-resolution {
-      > .ant-select-selector {
-        text-align: left;
-      }
+  .ant-select.select-resolution {
+    > .ant-select-selector {
+      text-align: left;
+    }
 
-      &.ant-select-disabled .ant-select-selection-item {
-        color: var(--color-button-tertiary-text);
+    .ant-select-selection-item {
+      color: var(--color-button-tertiary-text);
+    }
+
+    &.ant-select-disabled {
+      .ant-select-arrow {
+        display: none;
       }
     }
   }

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -157,6 +157,17 @@
     }
   }
 
+  .ant-select-selection:focus-visible,
+  .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled):has(:focus-visible),
+  .btn-borderless:focus-visible {
+    background-color: $highlight-purple !important;
+    color: white !important;
+  }
+
+  .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled):has(:focus-visible) {
+    outline: none;
+  }
+
   /* Dropdown */
   .ant-select.select-resolution {
     > .ant-select-selector {
@@ -172,29 +183,5 @@
         display: none;
       }
     }
-  }
-}
-
-/* :focus-visible is our ideal focus behavior, but support for the required selectors (namely :has) is spotty. */
-
-@supports selector(:has(:focus-visible)) {
-  .viewer-toolbar {
-    .ant-select-selection:focus-visible,
-    .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled):has(:focus-visible),
-    .btn-borderless:focus-visible {
-      background-color: $highlight-purple !important;
-      color: white !important;
-    }
-
-    .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled):has(:focus-visible) {
-      outline: none;
-    }
-  }
-}
-
-@supports not (selector(:has(:focus-visible))) {
-  .viewer-toolbar .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-disabled):focus-within {
-    outline: none;
-    border-color: $light-gray;
   }
 }

--- a/src/aics-image-viewer/components/Toolbar/styles.css
+++ b/src/aics-image-viewer/components/Toolbar/styles.css
@@ -124,9 +124,9 @@
   }
 
   .btn-active {
-    color: var(--color-button-icon-activated-text);
-    background-color: var(--color-button-icon-activated-bg);
-    border: 1px solid var(--color-button-icon-activated-outline);
+    color: var(--color-button-icon-active-text);
+    background-color: var(--color-button-icon-active-bg);
+    border: 1px solid var(--color-button-icon-active-outline);
   }
 
   /* Radio buttons */

--- a/src/aics-image-viewer/components/shared/ControlPanelRow/styles.css
+++ b/src/aics-image-viewer/components/shared/ControlPanelRow/styles.css
@@ -26,7 +26,7 @@
 
   /* Channel settings open/close button */
   .ant-btn-text {
-    color: var(--color-button-icon-activated-text);
+    color: var(--color-button-icon-active-text);
     transition: color 0.3s;
 
     &:hover,


### PR DESCRIPTION
Review time: medium (~25min)

Currently, the `Select` (dropdown) and `Radio` (radio button group) components from `antd` are only meaningfully used in the toolbar. As a result, we've ended up with quite a lot of styling for these components down in `Toolbar`'s stylesheet which in principle should apply to these components no matter where they appear in the app.

Future work will add instances of both components to the control panel. So rather than have to redo all of `Toolbar`'s bespoke styling in the control panel, I took the opportunity to update, polish, and reorganize a bunch of styling up in `StyleProvider`, where app-wide styling lives.
