### PR TITLE
feat: Added runtime basename resolution

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -20,7 +20,7 @@ jobs:
 
         # Must override default webpack build base so that assets can still be accessed when not placed in the root directory of gh-pages branch.
       - name: Install and Build
-        run: npm ci && webpack --config webpack.dev.js --env env=production basename=/vole-app/pr-preview/pr-${PR_NUMBER}/
+        run: npm ci && webpack --config webpack.dev.js --env env=production
         env:
           PR_NUMBER: ${{ github.event.number }}
 

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -19,7 +19,6 @@ import "./App.css";
 // vars filled at build time using webpack DefinePlugin
 console.log(`vole-app ${VOLEAPP_BUILD_ENVIRONMENT} build`);
 console.log(`vole-app Version ${VOLEAPP_VERSION}`);
-console.log(`vole-core Version ${VOLECORE_VERSION}`);
 
 const basename = resolveBasename(VOLEAPP_BASENAME);
 if (basename !== VOLEAPP_BASENAME) {
@@ -27,6 +26,8 @@ if (basename !== VOLEAPP_BASENAME) {
 } else {
   console.log(`vole-app Basename ${VOLEAPP_BASENAME}`);
 }
+
+console.log(`vole-core Version ${VOLECORE_VERSION}`);
 
 // Decode URL path if it was encoded for GitHub pages or uses hash routing.
 const locationUrl = new URL(window.location.toString());

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -16,22 +16,16 @@ import LocalStorageReceiver from "./LocalStorageReceiver";
 
 import "./App.css";
 
-const enum Subpages {
-  VIEWER = "viewer",
-  WRITE_STORAGE = "write_storage",
-}
-const subpagesList = [Subpages.VIEWER, Subpages.WRITE_STORAGE];
-
 // vars filled at build time using webpack DefinePlugin
 console.log(`vole-app ${VOLEAPP_BUILD_ENVIRONMENT} build`);
-console.log(`vole-app Version: ${VOLEAPP_VERSION}`);
-console.log(`vole-core Version: ${VOLECORE_VERSION}`);
+console.log(`vole-app Version ${VOLEAPP_VERSION}`);
+console.log(`vole-core Version ${VOLECORE_VERSION}`);
 
-const basename = resolveBasename(VOLEAPP_BASENAME, subpagesList);
+const basename = resolveBasename(VOLEAPP_BASENAME);
 if (basename !== VOLEAPP_BASENAME) {
-  console.log(`vole-app Basename: ${VOLEAPP_BASENAME} (resolved to "${basename}")`);
+  console.log(`vole-app Basename ${VOLEAPP_BASENAME} (resolved to "${basename}")`);
 } else {
-  console.log(`vole-app Basename: ${VOLEAPP_BASENAME}`);
+  console.log(`vole-app Basename ${VOLEAPP_BASENAME}`);
 }
 
 // Decode URL path if it was encoded for GitHub pages or uses hash routing.
@@ -58,7 +52,7 @@ const routes: RouteObject[] = [
     errorElement: <ErrorPage />,
   },
   {
-    path: Subpages.VIEWER,
+    path: "viewer",
     lazy: async () => {
       const AppWrapper = (await import("../website/components/AppWrapper")).default;
       return {
@@ -68,7 +62,7 @@ const routes: RouteObject[] = [
     errorElement: <ErrorPage />,
   },
   {
-    path: Subpages.WRITE_STORAGE,
+    path: "write_storage",
     element: <LocalStorageReceiver />,
     errorElement: <ErrorPage />,
   },

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -21,11 +21,9 @@ console.log(`vole-app ${VOLEAPP_BUILD_ENVIRONMENT} build`);
 console.log(`vole-app Version ${VOLEAPP_VERSION}`);
 
 const basename = resolveBasename(VOLEAPP_BASENAME);
-if (basename !== VOLEAPP_BASENAME) {
-  console.log(`vole-app Basename ${VOLEAPP_BASENAME} (resolved to "${basename}")`);
-} else {
-  console.log(`vole-app Basename ${VOLEAPP_BASENAME}`);
-}
+console.log(`vole-app Basename ${VOLEAPP_BASENAME}` +
+  ((VOLEAPP_BASENAME !== basename) ? ` (resolved to "${basename}")` : "")
+);
 
 console.log(`vole-core Version ${VOLECORE_VERSION}`);
 

--- a/public/index.tsx
+++ b/public/index.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { createBrowserRouter, type RouteObject, RouterProvider } from "react-router-dom";
 
-import { decodeGitHubPagesUrl, isEncodedPathUrl, tryRemoveHashRouting } from "../website/utils/gh_route_utils";
+import {
+  decodeGitHubPagesUrl,
+  isEncodedPathUrl,
+  resolveBasename,
+  tryRemoveHashRouting,
+} from "../website/utils/gh_route_utils";
 import firestore from "./firebase/configure_firebase";
 
 import StyleProvider from "../src/aics-image-viewer/components/StyleProvider";
@@ -11,13 +16,23 @@ import LocalStorageReceiver from "./LocalStorageReceiver";
 
 import "./App.css";
 
+const enum Subpages {
+  VIEWER = "viewer",
+  WRITE_STORAGE = "write_storage",
+}
+const subpagesList = [Subpages.VIEWER, Subpages.WRITE_STORAGE];
+
 // vars filled at build time using webpack DefinePlugin
 console.log(`vole-app ${VOLEAPP_BUILD_ENVIRONMENT} build`);
-console.log(`vole-app Version ${VOLEAPP_VERSION}`);
-console.log(`vole-app Basename ${VOLEAPP_BASENAME}`);
-console.log(`vole-core Version ${VOLECORE_VERSION}`);
+console.log(`vole-app Version: ${VOLEAPP_VERSION}`);
+console.log(`vole-core Version: ${VOLECORE_VERSION}`);
 
-const basename = VOLEAPP_BASENAME;
+const basename = resolveBasename(VOLEAPP_BASENAME, subpagesList);
+if (basename !== VOLEAPP_BASENAME) {
+  console.log(`vole-app Basename: ${VOLEAPP_BASENAME} (resolved to "${basename}")`);
+} else {
+  console.log(`vole-app Basename: ${VOLEAPP_BASENAME}`);
+}
 
 // Decode URL path if it was encoded for GitHub pages or uses hash routing.
 const locationUrl = new URL(window.location.toString());
@@ -43,7 +58,7 @@ const routes: RouteObject[] = [
     errorElement: <ErrorPage />,
   },
   {
-    path: "viewer",
+    path: Subpages.VIEWER,
     lazy: async () => {
       const AppWrapper = (await import("../website/components/AppWrapper")).default;
       return {
@@ -53,7 +68,7 @@ const routes: RouteObject[] = [
     errorElement: <ErrorPage />,
   },
   {
-    path: "write_storage",
+    path: Subpages.WRITE_STORAGE,
     element: <LocalStorageReceiver />,
     errorElement: <ErrorPage />,
   },

--- a/website/utils/gh_route_utils.ts
+++ b/website/utils/gh_route_utils.ts
@@ -123,14 +123,11 @@ export function tryRemoveHashRouting(url: URL): URL {
  * Resolves a basename for the app at runtime.
  * @param basename A basename to resolve. If undefined, defaults to the relative
  * basename ('./').
- * @param excludedPaths An array of paths as subpages to exclude from the
- * basename resolution. If the basename ends in any of these, that portion of
- * the path will be removed.
  * @param pathname Pathname to use, `window.location.pathname` by default. Used
  * for testing.
  * @returns The resolved basename.
  *   - If basename is `./` or `undefined`, the function will resolve the basename
- *     using the pathname. Any excluded paths will be removed and the leading
+ *     using the pathname. Removes any trailing subpages so only the leading
  *     path segment will be taken.
  *   - Otherwise, the provided basename is returned as-is, with a trailing slash
  *     added if not present.
@@ -138,12 +135,11 @@ export function tryRemoveHashRouting(url: URL): URL {
  * @example
  * ```ts
  * // Open at https://www.example.com/viewer/vole-app/main/viewer
- * const excludedPaths = ["viewer", "write_storage"];
- * resolveBasename("/viewer/vole-app/", excludedPaths) // => "/vole-app/"
- * resolveBasename("./", excludedPaths); // => "/viewer/vole-app/main/"
+ * resolveBasename("/viewer/vole-app/") // => "/viewer/vole-app/"
+ * resolveBasename("./"); // => "/viewer/vole-app/main/"
  * ```
  */
-export function resolveBasename(basename: string | undefined, excludedPaths: string[] = [], pathname?: string): string {
+export function resolveBasename(basename: string | undefined, pathname?: string): string {
   // Default to the relative basename and current pathname if not provided.
   basename = basename ?? RELATIVE_BASENAME;
   pathname = pathname ?? window.location.pathname;
@@ -154,12 +150,11 @@ export function resolveBasename(basename: string | undefined, excludedPaths: str
   }
 
   // Resolve the basename at runtime.
-  for (const subpage of excludedPaths) {
-    if (pathname.endsWith(`${subpage}/`)) {
-      pathname = pathname.slice(0, -subpage.length - 1);
-      break;
-    }
-  }
+
+  // Removes any non-directory trailing path segments to get the basename e.g.
+  // "/viewer/vole-app/subpage" becomes "/viewer/vole-app/". See
+  // https://developer.mozilla.org/en-US/docs/Web/API/Location/pathname.
   basename = pathname.replace(/(\/[^/]+)$/, "");
+  basename = basename.endsWith("/") ? basename : `${basename}/`;
   return basename;
 }

--- a/website/utils/gh_route_utils.ts
+++ b/website/utils/gh_route_utils.ts
@@ -2,9 +2,6 @@
  * When the vole-app basename is set to './', resolve it to the current path at
  * runtime. This allows the app to be deployed to a subdirectory without needing
  * to rebuild with a specified basename.
- *
- * Subdirectories cannot have names matching subpages of Vol-E (e.g. "viewer" or
- * "write_storage").
  */
 export const RELATIVE_BASENAME = "./";
 
@@ -123,12 +120,12 @@ export function tryRemoveHashRouting(url: URL): URL {
  * Resolves a basename for the app at runtime.
  * @param basename A basename to resolve. If undefined, defaults to the relative
  * basename ('./').
- * @param pathname Pathname to use, `window.location.pathname` by default. Used
- * for testing.
+ * @param pathname Pathname to use, `window.location.pathname` by default.
+ * Override for testing.
  * @returns The resolved basename.
- *   - If basename is `./` or `undefined`, the function will resolve the basename
- *     using the pathname. Removes any trailing subpages so only the leading
- *     path segment will be taken.
+ *   - If basename is `"./"` or `undefined`, the function will resolve the
+ *     basename using the pathname. Removes any trailing subpages so only the
+ *     leading path segment will be taken.
  *   - Otherwise, the provided basename is returned as-is, with a trailing slash
  *     added if not present.
  *
@@ -149,11 +146,10 @@ export function resolveBasename(basename: string | undefined, pathname?: string)
     return basename;
   }
 
-  // Resolve the basename at runtime.
-
-  // Removes any non-directory trailing path segments to get the basename e.g.
-  // "/viewer/vole-app/subpage" becomes "/viewer/vole-app/". See
+  // Removes any non-directory trailing path segments from the pathname to get
+  // the basename. See
   // https://developer.mozilla.org/en-US/docs/Web/API/Location/pathname.
+  // ex: "/viewer/vole-app/subpage" becomes "/viewer/vole-app/".
   basename = pathname.replace(/(\/[^/]+)$/, "");
   basename = basename.endsWith("/") ? basename : `${basename}/`;
   return basename;

--- a/website/utils/gh_route_utils.ts
+++ b/website/utils/gh_route_utils.ts
@@ -1,3 +1,13 @@
+/**
+ * When the vole-app basename is set to './', resolve it to the current path at
+ * runtime. This allows the app to be deployed to a subdirectory without needing
+ * to rebuild with a specified basename.
+ *
+ * Subdirectories cannot have names matching subpages of Vol-E (e.g. "viewer" or
+ * "write_storage").
+ */
+export const RELATIVE_BASENAME = "./";
+
 const ESCAPED_AMPERSAND = "~and~";
 
 /**
@@ -107,4 +117,49 @@ export function tryRemoveHashRouting(url: URL): URL {
     url.hash = "";
   }
   return url;
+}
+
+/**
+ * Resolves a basename for the app at runtime.
+ * @param basename A basename to resolve. If undefined, defaults to the relative
+ * basename ('./').
+ * @param excludedPaths An array of paths as subpages to exclude from the
+ * basename resolution. If the basename ends in any of these, that portion of
+ * the path will be removed.
+ * @param pathname Pathname to use, `window.location.pathname` by default. Used
+ * for testing.
+ * @returns The resolved basename.
+ *   - If basename is `./` or `undefined`, the function will resolve the basename
+ *     using the pathname. Any excluded paths will be removed and the leading
+ *     path segment will be taken.
+ *   - Otherwise, the provided basename is returned as-is, with a trailing slash
+ *     added if not present.
+ *
+ * @example
+ * ```ts
+ * // Open at https://www.example.com/viewer/vole-app/main/viewer
+ * const excludedPaths = ["viewer", "write_storage"];
+ * resolveBasename("/viewer/vole-app/", excludedPaths) // => "/vole-app/"
+ * resolveBasename("./", excludedPaths); // => "/viewer/vole-app/main/"
+ * ```
+ */
+export function resolveBasename(basename: string | undefined, excludedPaths: string[] = [], pathname?: string): string {
+  // Default to the relative basename and current pathname if not provided.
+  basename = basename ?? RELATIVE_BASENAME;
+  pathname = pathname ?? window.location.pathname;
+
+  basename = basename.endsWith("/") ? basename : `${basename}/`;
+  if (basename !== RELATIVE_BASENAME) {
+    return basename;
+  }
+
+  // Resolve the basename at runtime.
+  for (const subpage of excludedPaths) {
+    if (pathname.endsWith(`${subpage}/`)) {
+      pathname = pathname.slice(0, -subpage.length - 1);
+      break;
+    }
+  }
+  basename = pathname.replace(/(\/[^/]+)$/, "");
+  return basename;
 }

--- a/website/utils/gh_route_utils.ts
+++ b/website/utils/gh_route_utils.ts
@@ -136,11 +136,10 @@ export function tryRemoveHashRouting(url: URL): URL {
  * resolveBasename("./"); // => "/viewer/vole-app/main/"
  * ```
  */
-export function resolveBasename(basename: string | undefined, pathname?: string): string {
-  // Default to the relative basename and current pathname if not provided.
-  basename = basename ?? RELATIVE_BASENAME;
-  pathname = pathname ?? window.location.pathname;
-
+export function resolveBasename(
+  basename: string = RELATIVE_BASENAME,
+  pathname: string = window.location.pathname
+): string {
   basename = basename.endsWith("/") ? basename : `${basename}/`;
   if (basename !== RELATIVE_BASENAME) {
     return basename;

--- a/website/utils/test/gh_route_utils.test.ts
+++ b/website/utils/test/gh_route_utils.test.ts
@@ -5,6 +5,8 @@ import {
   decodeUrlQueryStringPath,
   encodeGitHubPagesUrl,
   encodeUrlPathAsQueryString,
+  RELATIVE_BASENAME,
+  resolveBasename,
   tryRemoveHashRouting,
 } from "../gh_route_utils";
 
@@ -171,6 +173,43 @@ describe("Route utils", () => {
         const url = new URL(input);
         expect(tryRemoveHashRouting(decodeGitHubPagesUrl(url)).toString()).toEqual(expected);
       }
+    });
+  });
+
+  describe("resolveBasename", () => {
+    it("returns the provided basename if it's not the relative basename", () => {
+      expect(resolveBasename("/myapp/")).toEqual("/myapp/");
+      expect(resolveBasename("/vole-app/")).toEqual("/vole-app/");
+      expect(resolveBasename("/website-3d-cell-viewer-release/")).toEqual("/website-3d-cell-viewer-release/");
+    });
+
+    it("appends trailing slash to the basename if missing", () => {
+      expect(resolveBasename("/myapp")).toEqual("/myapp/");
+      expect(resolveBasename("/vole-app")).toEqual("/vole-app/");
+      expect(resolveBasename("/website-3d-cell-viewer-release")).toEqual("/website-3d-cell-viewer-release/");
+    });
+
+    it("resolves relative basenames", () => {
+      expect(resolveBasename(RELATIVE_BASENAME, [], "/myapp/")).toEqual("/myapp/");
+      expect(resolveBasename(RELATIVE_BASENAME, [], "/myapp/subfolder/")).toEqual("/myapp/subfolder/");
+      expect(resolveBasename(RELATIVE_BASENAME, [], "/viewers/vole-app/")).toEqual("/viewers/vole-app/");
+      expect(resolveBasename(RELATIVE_BASENAME, [], "/viewers/website-3d-cell-viewer-release/")).toEqual(
+        "/viewers/website-3d-cell-viewer-release/"
+      );
+    });
+
+    it("excludes paths from the returned basename", () => {
+      expect(resolveBasename(RELATIVE_BASENAME, ["subpage"], "/myapp/subpage/")).toEqual("/myapp/");
+      expect(resolveBasename(RELATIVE_BASENAME, ["subpage1", "subpage2"], "/myapp/subpage2/")).toEqual("/myapp/");
+      expect(resolveBasename(RELATIVE_BASENAME, ["subpage1", "subpage2"], "/myapp/subpage1/subpage2/")).toEqual(
+        "/myapp/subpage1/"
+      );
+      expect(resolveBasename(RELATIVE_BASENAME, ["viewer", "write_storage"], "/my-path/vole-app/viewer/")).toEqual(
+        "/my-path/vole-app/"
+      );
+      expect(
+        resolveBasename(RELATIVE_BASENAME, ["viewer", "write_storage"], "/my-path/vole-app/write_storage/")
+      ).toEqual("/my-path/vole-app/");
     });
   });
 });

--- a/website/utils/test/gh_route_utils.test.ts
+++ b/website/utils/test/gh_route_utils.test.ts
@@ -178,18 +178,22 @@ describe("Route utils", () => {
 
   describe("resolveBasename", () => {
     it("returns the provided basename if it's not the relative basename", () => {
+      expect(resolveBasename("/")).toEqual("/");
       expect(resolveBasename("/myapp/")).toEqual("/myapp/");
       expect(resolveBasename("/vole-app/")).toEqual("/vole-app/");
       expect(resolveBasename("/website-3d-cell-viewer-release/")).toEqual("/website-3d-cell-viewer-release/");
     });
 
     it("appends trailing slash to the basename if missing", () => {
+      expect(resolveBasename("")).toEqual("/");
       expect(resolveBasename("/myapp")).toEqual("/myapp/");
       expect(resolveBasename("/vole-app")).toEqual("/vole-app/");
       expect(resolveBasename("/website-3d-cell-viewer-release")).toEqual("/website-3d-cell-viewer-release/");
     });
 
     it("resolves relative basenames", () => {
+      expect(resolveBasename(RELATIVE_BASENAME, "")).toEqual("/");
+      expect(resolveBasename(RELATIVE_BASENAME, "/")).toEqual("/");
       expect(resolveBasename(RELATIVE_BASENAME, "/myapp/")).toEqual("/myapp/");
       expect(resolveBasename(RELATIVE_BASENAME, "/myapp/subfolder/")).toEqual("/myapp/subfolder/");
       expect(resolveBasename(RELATIVE_BASENAME, "/viewers/vole-app/")).toEqual("/viewers/vole-app/");

--- a/website/utils/test/gh_route_utils.test.ts
+++ b/website/utils/test/gh_route_utils.test.ts
@@ -190,26 +190,20 @@ describe("Route utils", () => {
     });
 
     it("resolves relative basenames", () => {
-      expect(resolveBasename(RELATIVE_BASENAME, [], "/myapp/")).toEqual("/myapp/");
-      expect(resolveBasename(RELATIVE_BASENAME, [], "/myapp/subfolder/")).toEqual("/myapp/subfolder/");
-      expect(resolveBasename(RELATIVE_BASENAME, [], "/viewers/vole-app/")).toEqual("/viewers/vole-app/");
-      expect(resolveBasename(RELATIVE_BASENAME, [], "/viewers/website-3d-cell-viewer-release/")).toEqual(
+      expect(resolveBasename(RELATIVE_BASENAME, "/myapp/")).toEqual("/myapp/");
+      expect(resolveBasename(RELATIVE_BASENAME, "/myapp/subfolder/")).toEqual("/myapp/subfolder/");
+      expect(resolveBasename(RELATIVE_BASENAME, "/viewers/vole-app/")).toEqual("/viewers/vole-app/");
+      expect(resolveBasename(RELATIVE_BASENAME, "/viewers/website-3d-cell-viewer-release/")).toEqual(
         "/viewers/website-3d-cell-viewer-release/"
       );
     });
 
-    it("excludes paths from the returned basename", () => {
-      expect(resolveBasename(RELATIVE_BASENAME, ["subpage"], "/myapp/subpage/")).toEqual("/myapp/");
-      expect(resolveBasename(RELATIVE_BASENAME, ["subpage1", "subpage2"], "/myapp/subpage2/")).toEqual("/myapp/");
-      expect(resolveBasename(RELATIVE_BASENAME, ["subpage1", "subpage2"], "/myapp/subpage1/subpage2/")).toEqual(
-        "/myapp/subpage1/"
-      );
-      expect(resolveBasename(RELATIVE_BASENAME, ["viewer", "write_storage"], "/my-path/vole-app/viewer/")).toEqual(
-        "/my-path/vole-app/"
-      );
-      expect(
-        resolveBasename(RELATIVE_BASENAME, ["viewer", "write_storage"], "/my-path/vole-app/write_storage/")
-      ).toEqual("/my-path/vole-app/");
+    it("excludes subpages from the returned basename", () => {
+      expect(resolveBasename(RELATIVE_BASENAME, "/myapp/subpage")).toEqual("/myapp/");
+      expect(resolveBasename(RELATIVE_BASENAME, "/myapp/subpage2")).toEqual("/myapp/");
+      expect(resolveBasename(RELATIVE_BASENAME, "/myapp/subfolder/subpage2")).toEqual("/myapp/subfolder/");
+      expect(resolveBasename(RELATIVE_BASENAME, "/my-path/vole-app/viewer")).toEqual("/my-path/vole-app/");
+      expect(resolveBasename(RELATIVE_BASENAME, "/my-path/vole-app/write_storage")).toEqual("/my-path/vole-app/");
     });
   });
 });


### PR DESCRIPTION
Problem
=======
Part 1 of 2 for #526. This change adds basename resolution at runtime, meaning that the built viewer files can be placed in different subdirectories and still load correctly.

*Estimated review size: small, 10-15 minutes*

Solution
========
- Updated vole-app to default to using automatic basename detection if not specified, using the window location.
- Added the `resolveBasename` helper method.
  - Added unit tests.
- For testing, removed basename specifier from PR preview action.

## Type of change
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Open PR preview. The page will load correctly. https://allen-cell-animated.github.io/vole-app/pr-preview/pr-531/
2. Open the developer console to confirm that the basename was detected correctly (should be `/vole-app/pr-preview/pr-531/`)
3. Open PR preview on the `viewer` subpage, which will also load correctly: https://allen-cell-animated.github.io/vole-app/pr-preview/pr-531/viewer?url=https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Fhipsc_fov_nuclei_timelapse_dataset%2Fhipsc_fov_nuclei_timelapse_data_used_for_analysis%2Fbaseline_colonies_fov_timelapse_dataset%2F20200323_05_large%2Fraw.ome.zarr,https%3A%2F%2Fallencell.s3.amazonaws.com%2Faics%2Fnuc-morph-dataset%2Fhipsc_fov_nuclei_timelapse_dataset%2Fhipsc_fov_nuclei_timelapse_data_used_for_analysis%2Fbaseline_colonies_fov_timelapse_dataset%2F20200323_05_large%2Fseg.ome.zarr&hideTitle=true

<img width="537" height="102" alt="image" src="https://github.com/user-attachments/assets/ffdf4249-ecd9-4e52-8df1-3bfd0193b9b7" />
