### PR TITLE
Import/export channel settings to/from file (copy & paste 2)

### DIFF
--- a/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
@@ -258,8 +258,13 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
         overlayStyle={{ minWidth: 100 }}
         getPopupContainer={getDropdownContainer}
         open={dropdownOpen}
+        onOpenChange={(open, { source }) => {
+          if (open || source === "trigger") {
+            setDropdownOpen(open);
+          }
+        }}
       >
-        <Button type="text" size="large" ref={buttonRef} onClick={() => setDropdownOpen(true)}>
+        <Button type="text" size="large" ref={buttonRef}>
           <EllipsisOutlined />
         </Button>
       </Dropdown>

--- a/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
@@ -1,5 +1,5 @@
 import { EllipsisOutlined, ExclamationCircleOutlined } from "@ant-design/icons";
-import { Button, Dropdown, type MenuProps, Tooltip } from "antd";
+import { Button, Dropdown, type MenuProps, Modal, Tooltip, Upload } from "antd";
 import React from "react";
 
 import {
@@ -19,9 +19,56 @@ export type CopySettingsButtonProps = {
   getDropdownContainer?: () => HTMLElement;
 };
 
+type ImportResult =
+  | { success: false }
+  | {
+      success: true;
+      /** The number of channel names in the JSON that were also present in the current image. */
+      matchedCount: number;
+      /** A list of channel names that were present in the JSON but not in the current image. */
+      unmatched: string[];
+      /** Function to restore all channel states from before the new settings were imported. */
+      undo: () => void;
+    };
+
+const importSettings = (settingsString: string): ImportResult => {
+  const { channelSettings, replaceAllChannelSettings } = useViewerState.getState();
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(settingsString);
+  } catch {
+    parsed = undefined;
+  }
+  if (!isClipboardChannelState(parsed)) {
+    return { success: false };
+  }
+
+  const channelStates = clipboardToChannelState(parsed);
+  const channelCount = Object.keys(channelStates).length;
+  const currentStates = channelSettings.map(cloneChannelState);
+  const nextStates = channelSettings.map((state) => {
+    const result = {
+      ...cloneChannelState(state),
+      ...channelStates[state.name],
+    };
+    delete channelStates[state.name];
+    return result;
+  });
+
+  replaceAllChannelSettings(nextStates);
+  const undo = (): void => replaceAllChannelSettings(currentStates);
+
+  const unmatched = Object.keys(channelStates);
+  const matchedCount = channelCount - unmatched.length;
+
+  return { success: true, matchedCount, unmatched, undo };
+};
+
 const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
   const { imageName, scrollContainer, hide, getDropdownContainer } = props;
   const [pasteDenied, setPasteDenied] = React.useState(false);
+  const [importModalOpen, setImportModalOpen] = React.useState(false);
   const buttonRef = React.useRef<HTMLButtonElement>(null);
   const [alert, showMessage] = useContextualAlert(buttonRef.current, { scrollContainer, hide, timeout: 8_000 });
 
@@ -94,8 +141,6 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
       ),
       disabled: pasteDenied,
       onClick: async () => {
-        const { channelSettings, replaceAllChannelSettings } = useViewerState.getState();
-
         // Try to read the clipboard
         let clipboard: string | undefined = undefined;
         try {
@@ -107,44 +152,21 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
           return;
         }
 
-        let parsed: unknown;
-        try {
-          parsed = JSON.parse(clipboard);
-        } catch {
-          parsed = undefined;
-        }
-        if (!isClipboardChannelState(parsed)) {
+        const importResult = importSettings(clipboard);
+        if (!importResult.success) {
           showMessage("Clipboard does not contain channel settings", "error");
           return;
         }
 
-        const newStates = clipboardToChannelState(parsed);
-        const newStatesCount = Object.keys(newStates).length;
-        const currentStates = channelSettings.map(cloneChannelState);
-        const nextStates = channelSettings.map((state) => {
-          const result = {
-            ...cloneChannelState(state),
-            ...newStates[state.name],
-          };
-          delete newStates[state.name];
-          return result;
-        });
-
-        replaceAllChannelSettings(nextStates);
-
+        const { unmatched, matchedCount } = importResult;
+        const unmatchedCount = unmatched.length;
         const undo = (): void => {
-          replaceAllChannelSettings(currentStates);
+          importResult.undo();
           showMessage(undefined);
         };
 
-        const unmatchedStates = Object.keys(newStates);
-
-        if (unmatchedStates.length > 0) {
-          if (unmatchedStates.length === newStatesCount) {
-            showMessage("No channel names matched", "error");
-          } else {
-            const unmatchedCount = unmatchedStates.length;
-            const matchedCount = newStatesCount - unmatchedCount;
+        if (unmatchedCount > 0) {
+          if (matchedCount > 0) {
             showMessage(
               <>
                 <div>
@@ -157,27 +179,33 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
                   {unmatchedCount} channel name{unmatchedCount > 1 ? "s" : ""} from clipboard did not match:
                 </p>
                 <ul>
-                  {unmatchedStates.map((channelName, index) => (
+                  {unmatched.map((channelName, index) => (
                     <li key={index}>{channelName}</li>
                   ))}
                 </ul>
               </>,
               "warning"
             );
+          } else {
+            showMessage("No channel names matched", "error");
           }
         } else {
-          showMessage(
-            <>
-              Settings applied to {newStatesCount} channel{newStatesCount > 1 ? "s" : ""} -{" "}
-              <Button type="link" style={{ padding: 0, height: "unset" }} onClick={undo}>
-                Undo
-              </Button>
-            </>
-          );
+          if (matchedCount > 0) {
+            showMessage(
+              <>
+                Settings applied to {matchedCount} channel{matchedCount > 1 ? "s" : ""} -{" "}
+                <Button type="link" style={{ padding: 0, height: "unset" }} onClick={undo}>
+                  Undo
+                </Button>
+              </>
+            );
+          } else {
+            showMessage("Clipboard contains an empty settings object", "error");
+          }
         }
       },
     },
-    // { key: 3, label: "Import" },
+    { key: 3, label: "Import", onClick: () => setImportModalOpen(true) },
   ];
 
   return (
@@ -192,6 +220,16 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
           <EllipsisOutlined />
         </Button>
       </Dropdown>
+      <Modal closable title="Import channel settings" open={importModalOpen} onCancel={() => setImportModalOpen(false)}>
+        <Upload.Dragger
+          showUploadList={false}
+          customRequest={async ({ file, onSuccess, onError }) => {
+            const text = await (file as Blob).text();
+            const importResult = importSettings(text);
+            onSuccess?.(undefined);
+          }}
+        ></Upload.Dragger>
+      </Modal>
       {alert}
     </>
   );

--- a/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
@@ -94,6 +94,8 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
 
   const [includeColor, setIncludeColor] = React.useState(true);
   const [pasteDenied, setPasteDenied] = React.useState(false);
+
+  const [dropdownOpen, setDropdownOpen] = React.useState(false);
   const [importModalOpen, setImportModalOpen] = React.useState(false);
 
   const [alert, showContextualAlert] = useContextualAlert(buttonRef.current, { scrollContainer, hide, timeout: 8_000 });
@@ -135,7 +137,8 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
     {
       key: 0,
       label: "Copy",
-      onClick: async () => {
+      onClick: () => {
+        setDropdownOpen(false);
         try {
           const { channelSettings } = useViewerState.getState();
           navigator.clipboard.writeText(JSON.stringify(channelStateToClipboard(channelSettings)));
@@ -149,6 +152,7 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
       key: 1,
       label: "Export",
       onClick: () => {
+        setDropdownOpen(false);
         const { channelSettings } = useViewerState.getState();
         const stateText = JSON.stringify(channelStateToClipboard(channelSettings));
         const link = document.createElement("a");
@@ -174,6 +178,8 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
       ),
       disabled: pasteDenied,
       onClick: async () => {
+        setDropdownOpen(false);
+
         // Try to read the clipboard
         let clipboard: string | undefined = undefined;
         try {
@@ -224,8 +230,9 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
       key: 3,
       label: "Import",
       onClick: () => {
+        setDropdownOpen(false);
         setImportModalOpen(true);
-        setModalAlert(undefined);
+        showModalAlert(undefined);
       },
     },
     { key: 4, type: "divider" },
@@ -248,8 +255,9 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
         trigger={["click"]}
         overlayStyle={{ minWidth: 100 }}
         getPopupContainer={getDropdownContainer}
+        open={dropdownOpen}
       >
-        <Button type="text" size="large" ref={buttonRef}>
+        <Button type="text" size="large" ref={buttonRef} onClick={() => setDropdownOpen(true)}>
           <EllipsisOutlined />
         </Button>
       </Dropdown>

--- a/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
@@ -1,4 +1,4 @@
-import { EllipsisOutlined, ExclamationCircleOutlined } from "@ant-design/icons";
+import { DragOutlined, EllipsisOutlined, ExclamationCircleOutlined } from "@ant-design/icons";
 import { Button, Dropdown, type MenuProps, Modal, Tooltip, Upload } from "antd";
 import React from "react";
 
@@ -220,7 +220,15 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
           <EllipsisOutlined />
         </Button>
       </Dropdown>
-      <Modal closable title="Import channel settings" open={importModalOpen} onCancel={() => setImportModalOpen(false)}>
+      <Modal
+        closable
+        title="Import channel settings"
+        className="modal-settings-import"
+        open={importModalOpen}
+        onCancel={() => setImportModalOpen(false)}
+        footer={null}
+      >
+        <p>Upload a saved .json settings file</p>
         <Upload.Dragger
           showUploadList={false}
           customRequest={async ({ file, onSuccess, onError }) => {
@@ -228,7 +236,9 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
             const importResult = importSettings(text);
             onSuccess?.(undefined);
           }}
-        ></Upload.Dragger>
+        >
+          <DragOutlined /> Drag and drop here or click to browse
+        </Upload.Dragger>
       </Modal>
       {alert}
     </>

--- a/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
@@ -12,12 +12,15 @@ import { cloneChannelState } from "../../state/util";
 
 import { useContextualAlert } from "../shared/ContextualAlert";
 
-const CopySettingsButton: React.FC<{
+export type CopySettingsButtonProps = {
   imageName?: string;
   scrollContainer?: HTMLElement | null;
   hide?: boolean;
   getDropdownContainer?: () => HTMLElement;
-}> = ({ imageName, scrollContainer, hide, getDropdownContainer }) => {
+};
+
+const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
+  const { imageName, scrollContainer, hide, getDropdownContainer } = props;
   const [pasteDenied, setPasteDenied] = React.useState(false);
   const buttonRef = React.useRef<HTMLButtonElement>(null);
   const [alert, showMessage] = useContextualAlert(buttonRef.current, { scrollContainer, hide, timeout: 8_000 });

--- a/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
@@ -210,7 +210,7 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
           if (matchedCount > 0) {
             showContextualAlert(<PartialMatchMessage {...importResult} undo={undo} />, "warning");
           } else {
-            showContextualAlert("No channel names matched", "error");
+            showContextualAlert("Channel names in clipboard did not match names in image", "error");
           }
         } else {
           if (matchedCount > 0) {
@@ -223,7 +223,7 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
               </>
             );
           } else {
-            showContextualAlert("Clipboard contains an empty settings object", "error");
+            showContextualAlert("Clipboard does not contain channel settings", "error");
           }
         }
       },
@@ -241,7 +241,7 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
     {
       key: 5,
       className: "import-dropdown-menu-item-include-color",
-      label: <Checkbox checked={includeColor}>Include color</Checkbox>,
+      label: <Checkbox checked={includeColor}>Include color setting</Checkbox>,
       onClick: ({ domEvent }) => {
         domEvent.stopPropagation();
         domEvent.preventDefault();
@@ -303,7 +303,7 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
                 setImportModalOpen(false);
                 showContextualAlert(<PartialMatchMessage {...importResult} undo={undo} />, "warning");
               } else {
-                showModalAlert("No channel names in file match any channel names in the current image", "error");
+                showModalAlert("Channel names in file did not match names in image", "error");
               }
             } else {
               if (matchedCount > 0) {
@@ -317,7 +317,7 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
                   </>
                 );
               } else {
-                showModalAlert("File is properly formatted but contains no channel settings", "error");
+                showModalAlert("File does not contain channel settings", "error");
               }
             }
             onSuccess?.(undefined);

--- a/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
@@ -13,10 +13,11 @@ import { cloneChannelState } from "../../state/util";
 import { useContextualAlert } from "../shared/ContextualAlert";
 
 const CopySettingsButton: React.FC<{
+  imageName?: string;
   scrollContainer?: HTMLElement | null;
   hide?: boolean;
   getDropdownContainer?: () => HTMLElement;
-}> = ({ scrollContainer, hide, getDropdownContainer }) => {
+}> = ({ imageName, scrollContainer, hide, getDropdownContainer }) => {
   const [pasteDenied, setPasteDenied] = React.useState(false);
   const buttonRef = React.useRef<HTMLButtonElement>(null);
   const [alert, showMessage] = useContextualAlert(buttonRef.current, { scrollContainer, hide, timeout: 8_000 });
@@ -61,7 +62,25 @@ const CopySettingsButton: React.FC<{
         }
       },
     },
-    // { key: 1, label: "Export" },
+    {
+      key: 1,
+      label: "Export",
+      onClick: () => {
+        const { channelSettings } = useViewerState.getState();
+        const stateText = JSON.stringify(channelStateToClipboard(channelSettings));
+        const link = document.createElement("a");
+
+        link.setAttribute("href", "data:text/plain;charset=utf-8," + encodeURIComponent(stateText));
+        const isoDate = new Date().toISOString().split("T")[0];
+        const imgName = imageName ?? "settings";
+        link.setAttribute("download", `${isoDate}_${imgName}.json`);
+        link.style.display = "none";
+
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      },
+    },
     {
       key: 2,
       label: (

--- a/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
@@ -1,5 +1,5 @@
-import { DragOutlined, EllipsisOutlined, ExclamationCircleOutlined } from "@ant-design/icons";
-import { Button, Dropdown, type MenuProps, Modal, Tooltip, Upload } from "antd";
+import { DragOutlined, EllipsisOutlined, ExclamationCircleOutlined, WarningOutlined } from "@ant-design/icons";
+import { Alert, type AlertProps, Button, Dropdown, type MenuProps, Modal, Tooltip, Upload } from "antd";
 import React from "react";
 
 import {
@@ -65,12 +65,42 @@ const importSettings = (settingsString: string): ImportResult => {
   return { success: true, matchedCount, unmatched, undo };
 };
 
+const PartialMatchMessage: React.FC<{ matchedCount: number; unmatched: string[]; undo: () => void }> = (props) => {
+  const { matchedCount, unmatched, undo } = props;
+  const unmatchedCount = unmatched.length;
+  return (
+    <>
+      <div>
+        Settings applied to {matchedCount} channel{matchedCount > 1 ? "s" : ""} -{" "}
+        <Button type="link" style={{ padding: 0, height: "unset" }} onClick={undo}>
+          Undo
+        </Button>
+      </div>
+      <p>
+        {unmatchedCount} channel name{unmatchedCount > 1 ? "s" : ""} from clipboard did not match:
+      </p>
+      <ul>
+        {unmatched.map((channelName, index) => (
+          <li key={index}>{channelName}</li>
+        ))}
+      </ul>
+    </>
+  );
+};
+
 const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
   const { imageName, scrollContainer, hide, getDropdownContainer } = props;
   const [pasteDenied, setPasteDenied] = React.useState(false);
   const [importModalOpen, setImportModalOpen] = React.useState(false);
   const buttonRef = React.useRef<HTMLButtonElement>(null);
-  const [alert, showMessage] = useContextualAlert(buttonRef.current, { scrollContainer, hide, timeout: 8_000 });
+  const [alert, showContextualAlert] = useContextualAlert(buttonRef.current, { scrollContainer, hide, timeout: 8_000 });
+  const [modalAlert, setModalAlert] = React.useState<React.ReactNode>(undefined);
+  const [modalAlertType, setModalAlertType] = React.useState<AlertProps["type"]>(undefined);
+
+  const showModalAlert = React.useCallback((content: React.ReactNode, alertType?: AlertProps["type"]) => {
+    setModalAlert(content);
+    setModalAlertType(alertType);
+  }, []);
 
   /** Learn as much as we can about whether the "paste" action will succeed, so we can disable it in advance. */
   const queryPasteState = React.useCallback(async (): Promise<void> => {
@@ -106,9 +136,9 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
         try {
           const { channelSettings } = useViewerState.getState();
           navigator.clipboard.writeText(JSON.stringify(channelStateToClipboard(channelSettings)));
-          showMessage("Settings copied");
+          showContextualAlert("Settings copied");
         } catch {
-          showMessage("Could not copy settings", "error");
+          showContextualAlert("Could not copy settings", "error");
         }
       },
     },
@@ -146,7 +176,7 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
         try {
           clipboard = await navigator.clipboard.readText();
         } catch {
-          showMessage("Could not read clipboard", "error");
+          showContextualAlert("Could not read clipboard", "error");
           // If paste failed, check if it was because the user was asked to grant clipboard access and said no
           queryPasteState();
           return;
@@ -154,7 +184,7 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
 
         const importResult = importSettings(clipboard);
         if (!importResult.success) {
-          showMessage("Clipboard does not contain channel settings", "error");
+          showContextualAlert("Clipboard does not contain channel settings", "error");
           return;
         }
 
@@ -162,36 +192,18 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
         const unmatchedCount = unmatched.length;
         const undo = (): void => {
           importResult.undo();
-          showMessage(undefined);
+          showContextualAlert(undefined);
         };
 
         if (unmatchedCount > 0) {
           if (matchedCount > 0) {
-            showMessage(
-              <>
-                <div>
-                  Settings applied to {matchedCount} channel{matchedCount > 1 ? "s" : ""} -{" "}
-                  <Button type="link" style={{ padding: 0, height: "unset" }} onClick={undo}>
-                    Undo
-                  </Button>
-                </div>
-                <p>
-                  {unmatchedCount} channel name{unmatchedCount > 1 ? "s" : ""} from clipboard did not match:
-                </p>
-                <ul>
-                  {unmatched.map((channelName, index) => (
-                    <li key={index}>{channelName}</li>
-                  ))}
-                </ul>
-              </>,
-              "warning"
-            );
+            showContextualAlert(<PartialMatchMessage {...importResult} undo={undo} />, "warning");
           } else {
-            showMessage("No channel names matched", "error");
+            showContextualAlert("No channel names matched", "error");
           }
         } else {
           if (matchedCount > 0) {
-            showMessage(
+            showContextualAlert(
               <>
                 Settings applied to {matchedCount} channel{matchedCount > 1 ? "s" : ""} -{" "}
                 <Button type="link" style={{ padding: 0, height: "unset" }} onClick={undo}>
@@ -200,12 +212,19 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
               </>
             );
           } else {
-            showMessage("Clipboard contains an empty settings object", "error");
+            showContextualAlert("Clipboard contains an empty settings object", "error");
           }
         }
       },
     },
-    { key: 3, label: "Import", onClick: () => setImportModalOpen(true) },
+    {
+      key: 3,
+      label: "Import",
+      onClick: () => {
+        setImportModalOpen(true);
+        setModalAlert(undefined);
+      },
+    },
   ];
 
   return (
@@ -227,6 +246,7 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
         open={importModalOpen}
         onCancel={() => setImportModalOpen(false)}
         footer={null}
+        getContainer={getDropdownContainer}
       >
         <p>Upload a saved .json settings file</p>
         <Upload.Dragger
@@ -234,11 +254,63 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
           customRequest={async ({ file, onSuccess, onError }) => {
             const text = await (file as Blob).text();
             const importResult = importSettings(text);
+
+            if (!importResult.success) {
+              showModalAlert("File does not contain channel settings", "error");
+              onError?.(new Error());
+              return;
+            }
+
+            const { matchedCount, unmatched } = importResult;
+            const unmatchedCount = unmatched.length;
+            const undo = (): void => {
+              importResult.undo();
+              showContextualAlert(undefined);
+              showModalAlert(undefined);
+            };
+
+            if (unmatchedCount > 0) {
+              if (matchedCount > 0) {
+                setImportModalOpen(false);
+                showContextualAlert(<PartialMatchMessage {...importResult} undo={undo} />, "warning");
+              } else {
+                showModalAlert("No channel names in file match any channel names in the current image", "error");
+              }
+            } else {
+              if (matchedCount > 0) {
+                setImportModalOpen(false);
+                showContextualAlert(
+                  <>
+                    Settings applied to {matchedCount} channel{matchedCount > 1 ? "s" : ""} -{" "}
+                    <Button type="link" style={{ padding: 0, height: "unset" }} onClick={undo}>
+                      Undo
+                    </Button>
+                  </>
+                );
+              } else {
+                showModalAlert("File is properly formatted but contains no channel settings", "error");
+              }
+            }
             onSuccess?.(undefined);
           }}
         >
           <DragOutlined /> Drag and drop here or click to browse
         </Upload.Dragger>
+        {modalAlert !== undefined && (
+          <Alert
+            showIcon
+            style={{ marginTop: 15 }}
+            message={modalAlert}
+            icon={
+              modalAlertType === "error" ? (
+                <WarningOutlined style={{ fontSize: 21 }} />
+              ) : (
+                <ExclamationCircleOutlined style={{ fontSize: 21 }} />
+              )
+            }
+            type={modalAlertType}
+          />
+        )}
       </Modal>
       {alert}
     </>

--- a/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
@@ -1,5 +1,5 @@
 import { DragOutlined, EllipsisOutlined, ExclamationCircleOutlined, WarningOutlined } from "@ant-design/icons";
-import { Alert, type AlertProps, Button, Dropdown, type MenuProps, Modal, Tooltip, Upload } from "antd";
+import { Alert, type AlertProps, Button, Checkbox, Dropdown, type MenuProps, Modal, Tooltip, Upload } from "antd";
 import React from "react";
 
 import {
@@ -90,9 +90,12 @@ const PartialMatchMessage: React.FC<{ matchedCount: number; unmatched: string[];
 
 const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
   const { imageName, scrollContainer, hide, getDropdownContainer } = props;
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+
+  const [includeColor, setIncludeColor] = React.useState(true);
   const [pasteDenied, setPasteDenied] = React.useState(false);
   const [importModalOpen, setImportModalOpen] = React.useState(false);
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
+
   const [alert, showContextualAlert] = useContextualAlert(buttonRef.current, { scrollContainer, hide, timeout: 8_000 });
   const [modalAlert, setModalAlert] = React.useState<React.ReactNode>(undefined);
   const [modalAlertType, setModalAlertType] = React.useState<AlertProps["type"]>(undefined);
@@ -223,6 +226,17 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
       onClick: () => {
         setImportModalOpen(true);
         setModalAlert(undefined);
+      },
+    },
+    { key: 4, type: "divider" },
+    {
+      key: 5,
+      className: "import-dropdown-menu-item-include-color",
+      label: <Checkbox checked={includeColor}>Include color</Checkbox>,
+      onClick: ({ domEvent }) => {
+        domEvent.stopPropagation();
+        domEvent.preventDefault();
+        setIncludeColor((includeColor) => !includeColor);
       },
     },
   ];

--- a/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
@@ -141,7 +141,8 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
         setDropdownOpen(false);
         try {
           const { channelSettings } = useViewerState.getState();
-          navigator.clipboard.writeText(JSON.stringify(channelStateToClipboard(channelSettings)));
+          const serialized = channelStateToClipboard(channelSettings, includeColor ? undefined : ["color"]);
+          navigator.clipboard.writeText(JSON.stringify(serialized));
           showContextualAlert("Settings copied");
         } catch {
           showContextualAlert("Could not copy settings", "error");
@@ -154,7 +155,8 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
       onClick: () => {
         setDropdownOpen(false);
         const { channelSettings } = useViewerState.getState();
-        const stateText = JSON.stringify(channelStateToClipboard(channelSettings));
+        const serialized = channelStateToClipboard(channelSettings, includeColor ? undefined : ["color"]);
+        const stateText = JSON.stringify(serialized);
         const link = document.createElement("a");
 
         link.setAttribute("href", "data:text/plain;charset=utf-8," + encodeURIComponent(stateText));

--- a/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
@@ -89,6 +89,15 @@ const PartialMatchMessage: React.FC<{ matchedCount: number; unmatched: string[];
   );
 };
 
+const SuccessMessage: React.FC<{ channelCount: number; undo: () => void }> = ({ channelCount, undo }) => (
+  <>
+    Settings applied to {channelCount} channel{channelCount > 1 ? "s" : ""} -{" "}
+    <Button type="link" style={{ padding: 0, height: "unset" }} onClick={undo}>
+      Undo
+    </Button>
+  </>
+);
+
 const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
   const { imageName, scrollContainer, hide, getDropdownContainer } = props;
   const buttonRef = React.useRef<HTMLButtonElement>(null);
@@ -242,14 +251,7 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
       } else {
         if (matchedCount > 0) {
           setImportModalOpen(false);
-          showContextualAlert(
-            <>
-              Settings applied to {matchedCount} channel{matchedCount > 1 ? "s" : ""} -{" "}
-              <Button type="link" style={{ padding: 0, height: "unset" }} onClick={undo}>
-                Undo
-              </Button>
-            </>
-          );
+          showContextualAlert(<SuccessMessage channelCount={matchedCount} undo={undo} />);
         } else {
           showModalAlert("File does not contain channel settings", "error");
         }

--- a/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
@@ -1,5 +1,6 @@
 import { DragOutlined, EllipsisOutlined, ExclamationCircleOutlined, WarningOutlined } from "@ant-design/icons";
-import { Alert, type AlertProps, Button, Checkbox, Dropdown, type MenuProps, Modal, Tooltip, Upload } from "antd";
+import { Alert, Button, Checkbox, Dropdown, Modal, Tooltip, Upload } from "antd";
+import type { AlertProps, DraggerProps, MenuProps } from "antd";
 import React from "react";
 
 import {
@@ -212,6 +213,52 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
     }
   }, [queryPasteState, showContextualAlert]);
 
+  const onImportFile = React.useCallback<DraggerProps["customRequest"] & {}>(
+    async ({ file, onSuccess, onError }) => {
+      const text = await (file as Blob).text();
+      const importResult = importSettings(text);
+
+      if (!importResult.success) {
+        showModalAlert("File does not contain channel settings", "error");
+        onError?.(new Error());
+        return;
+      }
+
+      const { matchedCount, unmatched } = importResult;
+      const unmatchedCount = unmatched.length;
+      const undo = (): void => {
+        importResult.undo();
+        showContextualAlert(undefined);
+        showModalAlert(undefined);
+      };
+
+      if (unmatchedCount > 0) {
+        if (matchedCount > 0) {
+          setImportModalOpen(false);
+          showContextualAlert(<PartialMatchMessage {...importResult} undo={undo} />, "warning");
+        } else {
+          showModalAlert("Channel names in file did not match names in image", "error");
+        }
+      } else {
+        if (matchedCount > 0) {
+          setImportModalOpen(false);
+          showContextualAlert(
+            <>
+              Settings applied to {matchedCount} channel{matchedCount > 1 ? "s" : ""} -{" "}
+              <Button type="link" style={{ padding: 0, height: "unset" }} onClick={undo}>
+                Undo
+              </Button>
+            </>
+          );
+        } else {
+          showModalAlert("File does not contain channel settings", "error");
+        }
+      }
+      onSuccess?.(undefined);
+    },
+    [showContextualAlert, showModalAlert]
+  );
+
   const items: MenuProps["items"] = [
     {
       key: 0,
@@ -284,51 +331,7 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
         getContainer={getDropdownContainer}
       >
         <p>Upload a saved .json settings file</p>
-        <Upload.Dragger
-          showUploadList={false}
-          customRequest={async ({ file, onSuccess, onError }) => {
-            const text = await (file as Blob).text();
-            const importResult = importSettings(text);
-
-            if (!importResult.success) {
-              showModalAlert("File does not contain channel settings", "error");
-              onError?.(new Error());
-              return;
-            }
-
-            const { matchedCount, unmatched } = importResult;
-            const unmatchedCount = unmatched.length;
-            const undo = (): void => {
-              importResult.undo();
-              showContextualAlert(undefined);
-              showModalAlert(undefined);
-            };
-
-            if (unmatchedCount > 0) {
-              if (matchedCount > 0) {
-                setImportModalOpen(false);
-                showContextualAlert(<PartialMatchMessage {...importResult} undo={undo} />, "warning");
-              } else {
-                showModalAlert("Channel names in file did not match names in image", "error");
-              }
-            } else {
-              if (matchedCount > 0) {
-                setImportModalOpen(false);
-                showContextualAlert(
-                  <>
-                    Settings applied to {matchedCount} channel{matchedCount > 1 ? "s" : ""} -{" "}
-                    <Button type="link" style={{ padding: 0, height: "unset" }} onClick={undo}>
-                      Undo
-                    </Button>
-                  </>
-                );
-              } else {
-                showModalAlert("File does not contain channel settings", "error");
-              }
-            }
-            onSuccess?.(undefined);
-          }}
-        >
+        <Upload.Dragger showUploadList={false} customRequest={onImportFile}>
           <DragOutlined /> Drag and drop here or click to browse
         </Upload.Dragger>
         {modalAlert !== undefined && (

--- a/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
@@ -243,16 +243,20 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
 
       if (unmatchedCount > 0) {
         if (matchedCount > 0) {
+          // Some channels in the file matched, some did not
           setImportModalOpen(false);
           showContextualAlert(<PartialMatchMessage {...importResult} undo={undo} />, "warning");
         } else {
+          // No channels in the file matched channels in the current image
           showModalAlert("Channel names in file did not match names in image", "error");
         }
       } else {
         if (matchedCount > 0) {
+          // All channels matched!
           setImportModalOpen(false);
           showContextualAlert(<SuccessMessage channelCount={matchedCount} undo={undo} />);
         } else {
+          // There were no channels in the file at all!
           showModalAlert("File does not contain channel settings", "error");
         }
       }

--- a/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/CopySettingsButton.tsx
@@ -145,6 +145,73 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
     }
   }, [includeColor, showContextualAlert]);
 
+  const onClickExport = React.useCallback(() => {
+    setDropdownOpen(false);
+    const { channelSettings } = useViewerState.getState();
+    const serialized = channelStateToClipboard(channelSettings, includeColor ? undefined : ["color"]);
+    const stateText = JSON.stringify(serialized);
+    const link = document.createElement("a");
+
+    link.setAttribute("href", "data:text/plain;charset=utf-8," + encodeURIComponent(stateText));
+    const isoDate = new Date().toISOString().split("T")[0];
+    const imgName = imageName ?? "settings";
+    link.setAttribute("download", `${isoDate}_${imgName}.json`);
+    link.style.display = "none";
+
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }, [imageName, includeColor]);
+
+  const onClickPaste = React.useCallback(async () => {
+    setDropdownOpen(false);
+
+    // Try to read the clipboard
+    let clipboard: string | undefined = undefined;
+    try {
+      clipboard = await navigator.clipboard.readText();
+    } catch {
+      showContextualAlert("Could not read clipboard", "error");
+      // If paste failed, check if it was because the user was asked to grant clipboard access and said no
+      queryPasteState();
+      return;
+    }
+
+    const importResult = importSettings(clipboard);
+    if (!importResult.success) {
+      showContextualAlert("Clipboard does not contain channel settings", "error");
+      return;
+    }
+
+    const { unmatched, matchedCount } = importResult;
+    const unmatchedCount = unmatched.length;
+    const undo = (): void => {
+      importResult.undo();
+      showContextualAlert(undefined);
+    };
+
+    if (unmatchedCount > 0) {
+      if (matchedCount > 0) {
+        showContextualAlert(<PartialMatchMessage {...importResult} undo={undo} />, "warning");
+      } else {
+        showContextualAlert("Channel names in clipboard did not match names in image", "error");
+      }
+    } else {
+      if (matchedCount > 0) {
+        showContextualAlert(
+          <>
+            Settings applied to {matchedCount} channel{matchedCount > 1 ? "s" : ""} -{" "}
+            <Button type="link" style={{ padding: 0, height: "unset" }} onClick={undo}>
+              Undo
+            </Button>
+          </>
+        );
+      } else {
+        showContextualAlert("Clipboard does not contain channel settings", "error");
+      }
+    }
+  }, [queryPasteState, showContextualAlert]);
+
   const items: MenuProps["items"] = [
     {
       key: 0,
@@ -154,23 +221,7 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
     {
       key: 1,
       label: "Export",
-      onClick: () => {
-        setDropdownOpen(false);
-        const { channelSettings } = useViewerState.getState();
-        const serialized = channelStateToClipboard(channelSettings, includeColor ? undefined : ["color"]);
-        const stateText = JSON.stringify(serialized);
-        const link = document.createElement("a");
-
-        link.setAttribute("href", "data:text/plain;charset=utf-8," + encodeURIComponent(stateText));
-        const isoDate = new Date().toISOString().split("T")[0];
-        const imgName = imageName ?? "settings";
-        link.setAttribute("download", `${isoDate}_${imgName}.json`);
-        link.style.display = "none";
-
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-      },
+      onClick: onClickExport,
     },
     {
       key: 2,
@@ -181,54 +232,7 @@ const CopySettingsButton: React.FC<CopySettingsButtonProps> = (props) => {
         </div>
       ),
       disabled: pasteDenied,
-      onClick: async () => {
-        setDropdownOpen(false);
-
-        // Try to read the clipboard
-        let clipboard: string | undefined = undefined;
-        try {
-          clipboard = await navigator.clipboard.readText();
-        } catch {
-          showContextualAlert("Could not read clipboard", "error");
-          // If paste failed, check if it was because the user was asked to grant clipboard access and said no
-          queryPasteState();
-          return;
-        }
-
-        const importResult = importSettings(clipboard);
-        if (!importResult.success) {
-          showContextualAlert("Clipboard does not contain channel settings", "error");
-          return;
-        }
-
-        const { unmatched, matchedCount } = importResult;
-        const unmatchedCount = unmatched.length;
-        const undo = (): void => {
-          importResult.undo();
-          showContextualAlert(undefined);
-        };
-
-        if (unmatchedCount > 0) {
-          if (matchedCount > 0) {
-            showContextualAlert(<PartialMatchMessage {...importResult} undo={undo} />, "warning");
-          } else {
-            showContextualAlert("Channel names in clipboard did not match names in image", "error");
-          }
-        } else {
-          if (matchedCount > 0) {
-            showContextualAlert(
-              <>
-                Settings applied to {matchedCount} channel{matchedCount > 1 ? "s" : ""} -{" "}
-                <Button type="link" style={{ padding: 0, height: "unset" }} onClick={undo}>
-                  Undo
-                </Button>
-              </>
-            );
-          } else {
-            showContextualAlert("Clipboard does not contain channel settings", "error");
-          }
-        }
-      },
+      onClick: onClickPaste,
     },
     {
       key: 3,

--- a/src/aics-image-viewer/components/ControlPanel/index.tsx
+++ b/src/aics-image-viewer/components/ControlPanel/index.tsx
@@ -184,6 +184,7 @@ function ControlPanel(props: ControlPanelProps): React.ReactElement {
           <h2>{ControlTabNames[tab]}</h2>
           {tab === ControlTab.Channels && (
             <CopySettingsButton
+              imageName={props.imageName}
               scrollContainer={columnRef.current}
               hide={props.collapsed}
               getDropdownContainer={getDropdownContainer}

--- a/src/aics-image-viewer/components/ControlPanel/styles.css
+++ b/src/aics-image-viewer/components/ControlPanel/styles.css
@@ -134,18 +134,33 @@
     /*slider settings*/
     @extend %axis-override;
   }
-}
 
-.ant-modal.modal-settings-import {
-  .ant-upload.ant-upload-drag {
-    transition-property: background-color, border-color;
+  .ant-modal.modal-settings-import {
+    .ant-upload.ant-upload-drag {
+      transition-property: background-color, border-color;
 
-    &:hover {
-      background-color: #ffffff20;
+      &:hover {
+        background-color: #ffffff20;
+      }
+    }
+
+    .ant-upload.ant-upload-btn {
+      padding: 32px;
     }
   }
 
-  .ant-upload.ant-upload-btn {
-    padding: 32px;
+  .ant-dropdown {
+    .import-dropdown-menu-item-include-color {
+      white-space: nowrap;
+      padding-bottom: 9px;
+
+      &.ant-dropdown-menu-item-active {
+        background-color: transparent;
+      }
+    }
+
+    .ant-dropdown-menu-item-divider {
+      background-color: var(--color-controlpanel-border);
+    }
   }
 }

--- a/src/aics-image-viewer/components/ControlPanel/styles.css
+++ b/src/aics-image-viewer/components/ControlPanel/styles.css
@@ -135,3 +135,17 @@
     @extend %axis-override;
   }
 }
+
+.ant-modal.modal-settings-import {
+  .ant-upload.ant-upload-drag {
+    transition-property: background-color, border-color;
+
+    &:hover {
+      background-color: #ffffff20;
+    }
+  }
+
+  .ant-upload.ant-upload-btn {
+    padding: 32px;
+  }
+}

--- a/src/aics-image-viewer/shared/utils/parseClipboard.ts
+++ b/src/aics-image-viewer/shared/utils/parseClipboard.ts
@@ -1,6 +1,7 @@
 import { deserializeChannelState, parseKeyValueList } from "../../state/deserialize";
 import { objectToKeyValueList, serializeViewerChannelSetting } from "../../state/serialize";
 import type { ChannelState } from "../../state/types";
+import { cloneChannelState } from "../../state/util";
 
 export type ClipboardChannelStates = {
   version: string;
@@ -21,10 +22,19 @@ export const isClipboardChannelState = (settings: unknown): settings is Clipboar
 };
 
 /** Converts an array of `ChannelState`s to a compact JSON representation that can be stringified into the clipboard. */
-export const channelStateToClipboard = (channelStates: ChannelState[]): ClipboardChannelStates => {
+export const channelStateToClipboard = (
+  channelStates: ChannelState[],
+  excludeKeys?: (keyof ChannelState)[]
+): ClipboardChannelStates => {
   const channels: Record<string, string> = {};
   for (const ch of channelStates) {
-    const stateString = objectToKeyValueList(serializeViewerChannelSetting(ch, false));
+    const setting = cloneChannelState(ch);
+    if (excludeKeys !== undefined) {
+      for (const key of excludeKeys) {
+        delete setting[key];
+      }
+    }
+    const stateString = objectToKeyValueList(serializeViewerChannelSetting(setting, false));
     channels[ch.name] = stateString;
   }
 


### PR DESCRIPTION
Review time: medium (~25-30min)

Implements the remaining features to close #536:

- Export channel settings to a .json file
- Import those settings back into Vol-E through a special modal
- Option to exclude color when copying or exporting

## Screenshots

<img width="3809" height="2028" alt="image" src="https://github.com/user-attachments/assets/f79ba938-29c0-47eb-bf6b-776c3af5b031" />
<img width="3814" height="2024" alt="image" src="https://github.com/user-attachments/assets/ee29ef49-1464-488b-a464-4b34b77a35a7" />
<img width="3810" height="2026" alt="image" src="https://github.com/user-attachments/assets/9d8190bf-eaa2-42d9-a73b-13634dde3fd2" />
