### PR TITLE
Upgrade @types/three to 0.184.0 and pin three exactly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-color": "^2.19.3",
         "react-router-dom": "^6.26.2",
         "styled-components": "^6.1.13",
+        "three": "0.184.0",
         "usehooks-ts": "^3.1.0",
         "uuid": "^13.0.0",
         "zustand": "^5.0.6"
@@ -43,7 +44,7 @@
         "@types/react": "^18.x",
         "@types/react-color": "^3.0.12",
         "@types/react-dom": "^18.x",
-        "@types/three": "^0.171.0",
+        "@types/three": "0.184.0",
         "@typescript-eslint/eslint-plugin": "^8.46.2",
         "@typescript-eslint/parser": "^8.46.2",
         "antd": "^5.16.2",
@@ -2346,6 +2347,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -5371,18 +5379,18 @@
       "license": "MIT"
     },
     "node_modules/@types/three": {
-      "version": "0.171.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.171.0.tgz",
-      "integrity": "sha512-oLuT1SAsT+CUg/wxUTFHo0K3NtJLnx9sJhZWQJp/0uXqFpzSk1hRHmvWvpaAWSfvx2db0lVKZ5/wV0I0isD2mQ==",
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
-        "@types/webxr": "*",
-        "@webgpu/types": "*",
+        "@types/webxr": ">=0.5.17",
         "fflate": "~0.8.2",
-        "meshoptimizer": "~0.18.1"
+        "meshoptimizer": "~1.1.1"
       }
     },
     "node_modules/@types/tough-cookie": {
@@ -5877,13 +5885,6 @@
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
       }
-    },
-    "node_modules/@webgpu/types": {
-      "version": "0.1.55",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.55.tgz",
-      "integrity": "sha512-p97I8XEC1h04esklFqyIH+UhFrUcj8/1/vBWgc6lAK4jMJc+KbhUy8D4dquHYztFj6pHLqGcp/P1xvBBF4r3DA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/@webpack-cli/configtest": {
       "version": "1.2.0",
@@ -14539,9 +14540,9 @@
       }
     },
     "node_modules/meshoptimizer": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
-      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
       "dev": true,
       "license": "MIT"
     },
@@ -20074,8 +20075,7 @@
       "version": "0.184.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
       "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/throttle-debounce": {
       "version": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-color": "^2.19.3",
     "react-router-dom": "^6.26.2",
     "styled-components": "^6.1.13",
+    "three": "0.184.0",
     "usehooks-ts": "^3.1.0",
     "uuid": "^13.0.0",
     "zustand": "^5.0.6"
@@ -85,7 +86,7 @@
     "@types/react": "^18.x",
     "@types/react-color": "^3.0.12",
     "@types/react-dom": "^18.x",
-    "@types/three": "^0.171.0",
+    "@types/three": "0.184.0",
     "@typescript-eslint/eslint-plugin": "^8.46.2",
     "@typescript-eslint/parser": "^8.46.2",
     "antd": "^5.16.2",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -6,6 +6,10 @@ const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 
+// Use require.resolve instead of just "./node_modules/@aics/..." to support
+// local development with both vole-core and vole-app in an npm workspace.
+const voleCorePackagePath = require.resolve("@aics/vole-core/package.json", { paths: [__dirname] });
+
 module.exports = (env) => {
   return {
     entry: { index: "./public/index.tsx", reroute: "./public/gh-reroute/index.tsx" },
@@ -35,7 +39,7 @@ module.exports = (env) => {
       new MiniCssExtractPlugin(),
       new webpack.DefinePlugin({
         VOLEAPP_VERSION: JSON.stringify(require("./package.json").version),
-        VOLECORE_VERSION: JSON.stringify(require("./node_modules/@aics/vole-core/package.json").version),
+        VOLECORE_VERSION: JSON.stringify(require(voleCorePackagePath).version),
         VOLEAPP_BUILD_ENVIRONMENT: JSON.stringify(env.env),
         VOLEAPP_BASENAME: JSON.stringify(env.basename),
       }),


### PR DESCRIPTION
Problem
=======
When building `vole-app` with a linked local `vole-core`, there is a mismatch in the versions of `@types/three` that results in the following error upon an `npm install` from `vole-app`:

```
src/aics-image-viewer/components/useVolume.ts(298,9): error TS2739: Type 'Box3' is missing the following properties from type 'Box3': toJSON, fromJSON
```

Solution
========
Update `@types/three` to `0.184.0` from `0.171.0`

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Change summary:
---------------
In addition, I made some updates how the three.js dependency is handled.
* `three` is now an explicit dependency of `vole-app`.
  * It was previously not listed in `package.json`, despite `useVolume.ts` doing an explicit import from `three`.
  * `vole-core` lists `three` as a peer dependency, meaning that the consumer (`vole-app`) should provide it.
* `three` and `@types/three` are pinned to an exact version, instead of with `^`.
  * In order to keep the `package-lock.json` files in sync between `vole-app` and `vole-core`, I recommend pinning these dependencies exactly. `0.184.1` has been released, but `vole-app` shouldn't update to it yet without `vole-core`.

Steps to Verify:
----------------
1. From `vole-core`, do `npm i` and `npm link`
2. In `vole-app`, do `npm link vole-core`
3. In `vole-app`, do `npm i`: it should not error.