### PR TITLE
Update vole-core to v4.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.4.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@aics/vole-core": "^4.9.1",
+        "@aics/vole-core": "^4.9.2",
         "@ant-design/icons": "^5.2.5",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
@@ -101,17 +101,17 @@
       }
     },
     "node_modules/@aics/vole-core": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-4.9.1.tgz",
-      "integrity": "sha512-cyqjcikY0KA3dsLBeJRguEZKK0TOprPZGWpBuY6Iw68XOAW9sLujvb2DZAmNhxc8TxZAWlSxsu4obf9UGtTfLw==",
-      "license": "MIT",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@aics/vole-core/-/vole-core-4.9.2.tgz",
+      "integrity": "sha512-teT7AsCqNR8N3XptOtC/3gl3mtTMoSJOJ0ZtTQRjHPhtE2N8+kGM5FtpnDeyWB5OpWZ62Tp6tNVhf7aqcLIirw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.25.6",
         "geotiff": "^2.0.5",
         "serialize-error": "^11.0.3",
         "throttled-queue": "^3.0.0",
         "tweakpane": "^3.1.9",
-        "zarrita": "^0.5.1"
+        "zarrita": "^0.7.2"
       },
       "peerDependencies": {
         "three": "^0.184.0"
@@ -5939,13 +5939,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@zarrita/storage": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.2.tgz",
-      "integrity": "sha512-zUi3CqeEU6avbE104qm5y4MGZbyxmqxXBIh3jyAJgQ4eQRG7KJ6cCmoD7wS7y/uCTl6nUiG7QU6k8QbyfrFjyg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.2.0.tgz",
+      "integrity": "sha512-855ZXqtnds7spnT8vNvD+MXa3QExP1m2GqShe8yt7uZXHnQLgJHgkpVwFjE1B0KDDRO0ki09hmk6OboTaIfPsQ==",
       "license": "MIT",
       "dependencies": {
         "reference-spec-reader": "^0.2.0",
-        "unzipit": "^1.4.3"
+        "unzipit": "2.0.0"
       }
     },
     "node_modules/accepts": {
@@ -20779,15 +20779,12 @@
       "license": "MIT"
     },
     "node_modules/unzipit": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
-      "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-2.0.0.tgz",
+      "integrity": "sha512-DVeVIWUZCAQPNzm5sB0hpsG1GygTTdBnzNtYYEpInkttx5evkyqRgZi6rTczoySqp8hO5jHVKzrH0f23X8FZLg==",
       "license": "MIT",
-      "dependencies": {
-        "uzip-module": "^1.0.2"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -20947,12 +20944,6 @@
       "bin": {
         "uuid": "dist-node/bin/uuid"
       }
-    },
-    "node_modules/uzip-module": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
-      "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA==",
-      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -21839,12 +21830,12 @@
       }
     },
     "node_modules/zarrita": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.5.3.tgz",
-      "integrity": "sha512-to2JRq9nHwYdhWEwJwytHYdMYC6I0f2vKUAQfYkgrwwy8OjShhwmv4sH9drzyV3sLzdy7XS9N1ipdMA/Qjspow==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.7.3.tgz",
+      "integrity": "sha512-wChTQ1Ox75INoQCzKAfLWAfB70JJ4KjdW8Sz5x4ZWrFB4Dw+YZdnxHTL0xSdsrB9EmKSeK7fS1Y+I2ibhfGbkw==",
       "license": "MIT",
       "dependencies": {
-        "@zarrita/storage": "^0.1.2",
+        "@zarrita/storage": "^0.2.0",
         "numcodecs": "^0.3.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "author": "Megan Riel-Mehan",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@aics/vole-core": "^4.9.1",
+    "@aics/vole-core": "^4.9.2",
     "@ant-design/icons": "^5.2.5",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",


### PR DESCRIPTION
...from v4.9.1. This picks up the fix in allen-cell-animated/vole-core#431, as well as zarrita updates (allen-cell-animated/vole-core#398), license updates (allen-cell-animated/vole-core#419) and a bunch of dependabots.
