### PR TITLE
Fix `npm start` when using npm workspaces

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -6,6 +6,10 @@ const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 
+// Use require.resolve instead of just "./node_modules/@aics/..." to support
+// local development with both vole-core and vole-app in an npm workspace.
+const voleCorePackagePath = require.resolve("@aics/vole-core/package.json", { paths: [__dirname] });
+
 module.exports = (env) => {
   return {
     entry: { index: "./public/index.tsx", reroute: "./public/gh-reroute/index.tsx" },
@@ -35,7 +39,7 @@ module.exports = (env) => {
       new MiniCssExtractPlugin(),
       new webpack.DefinePlugin({
         VOLEAPP_VERSION: JSON.stringify(require("./package.json").version),
-        VOLECORE_VERSION: JSON.stringify(require("./node_modules/@aics/vole-core/package.json").version),
+        VOLECORE_VERSION: JSON.stringify(require(voleCorePackagePath).version),
         VOLEAPP_BUILD_ENVIRONMENT: JSON.stringify(env.env),
         VOLEAPP_BASENAME: JSON.stringify(env.basename),
       }),


### PR DESCRIPTION
# Context

For my local development, I have `vole-app` and `vole-core` installed as sibling npm workspaces, with the following structure. This is convenient because it removes the need to manually manage `npm link` when working on both repos at once.

```
.
├── package.json
├── vole-app
└── vole-core
```

The top-level `package.json` is just this (the three.js lines are for working around the [issue addressed here](https://github.com/allen-cell-animated/vole-app/pull/541)):

```
{
  "private": true,
  "workspaces": [
    "vole-app",
    "vole-core"
  ],
  "devDependencies": {
    "three": "0.184.0",
    "@types/three": "0.184.0"
  }
}
```

# Problem

An `npm start -w vole-app` fails searching for `@aics/vole-core` in `vole-app/node_modules`. This happens because in the workspace setup, there is a single `node_modules` folder is at the top level.

# Solution

Dynamically resolve the `@aics/vole-core` reference.

## Type of change
- Chore: dev experience

Steps to Verify:
----------------
To confirm the change fixes the issue:

```
mkdir test
cd test

git clone git@github.com:allen-cell-animated/vole-core.git vole-core
git clone git@github.com:allen-cell-animated/vole-app.git vole-app
vim package.json
npm i
npm run start -w vole-app
```
