### PR TITLE
Update channel groupings on new scene

### DIFF
--- a/src/aics-image-viewer/components/useVolume.ts
+++ b/src/aics-image-viewer/components/useVolume.ts
@@ -190,7 +190,14 @@ const useVolume = (
   );
 
   // channel indexes, sorted by category
-  const [channelGroupedByType, setChannelGroupedByType] = useState<ChannelGrouping>({});
+  const channelNames = channelSettings.map(({ name }) => name);
+  const useDefaultViewerChannelSettings = useViewerState(select("useDefaultViewerChannelSettings"));
+  const channelGroupedByType = useMemo(() => {
+    const viewerChannelSettings = useDefaultViewerChannelSettings
+      ? getDefaultViewerChannelSettings()
+      : options?.viewerChannelSettings;
+    return makeChannelIndexGrouping(channelNames, viewerChannelSettings);
+  }, [channelNames, options?.viewerChannelSettings, useDefaultViewerChannelSettings]);
 
   const onChannelDataLoaded = useCallback(
     (aimg: Volume, channelIndex: number): void => {
@@ -217,8 +224,6 @@ const useVolume = (
       const viewerChannelSettings = useDefaultViewerChannelSettings
         ? getDefaultViewerChannelSettings()
         : options?.viewerChannelSettings;
-      const grouping = makeChannelIndexGrouping(channelNames, viewerChannelSettings);
-      setChannelGroupedByType(grouping);
 
       return initChannelSettings(channelNames, viewerChannelSettings);
     },

--- a/src/aics-image-viewer/components/useVolume.ts
+++ b/src/aics-image-viewer/components/useVolume.ts
@@ -189,8 +189,12 @@ const useVolume = (
     [onErrorRef]
   );
 
-  // channel indexes, sorted by category
-  const channelNames = channelSettings.map(({ name }) => name);
+  // channelGroupedByType groups channel indexes by their category.
+  // It depends on `viewerChannelSettings` and the channel names in the current image.
+  // TODO this can be derived much more easily once `Volume` has events
+  const channelNamesKey = channelSettings.map(({ name }) => name).join("\0");
+  const channelNames = useMemo(() => channelNamesKey.split("\0"), [channelNamesKey]);
+
   const useDefaultViewerChannelSettings = useViewerState(select("useDefaultViewerChannelSettings"));
   const channelGroupedByType = useMemo(() => {
     const viewerChannelSettings = useDefaultViewerChannelSettings

--- a/src/aics-image-viewer/components/useVolume.ts
+++ b/src/aics-image-viewer/components/useVolume.ts
@@ -190,7 +190,16 @@ const useVolume = (
   );
 
   // channel indexes, sorted by category
-  const [channelGroupedByType, setChannelGroupedByType] = useState<ChannelGrouping>({});
+  const [_channelGroupedByType, setChannelGroupedByType] = useState<ChannelGrouping>({});
+  // While a new scene is loading, the channel count of the next scene is unknown. Since we load new scene data into
+  // the existing `image`, we can't easily react to changes to image properties, and therefore currently can't prevent
+  // React from rendering with *new* properties in image but the *old* value of `channelGroupedByType`. So we hide
+  // `channelGroupedByType` while the scene is loading to avoid indexing channels that no longer exist.
+  const [scenePending, setScenePending] = useState(false);
+  const channelGroupedByType = useMemo(
+    () => (scenePending ? {} : _channelGroupedByType),
+    [_channelGroupedByType, scenePending]
+  );
 
   const onChannelDataLoaded = useCallback(
     (aimg: Volume, channelIndex: number): void => {
@@ -337,6 +346,7 @@ const useVolume = (
       if (image && !inInitialLoadRef.current) {
         const onCreateScene = (volume: Volume, sceneIndex: number, loadSpec: LoadSpec): void => {
           setChannelStateForNewImage(volume.imageInfo.channelNames);
+          setScenePending(false);
           volume.updateChannelCount();
 
           const prevChannelVersions = channelVersionsRef.current;
@@ -356,6 +366,7 @@ const useVolume = (
 
         sceneLoader.loadScene(scene, image, undefined, { onCreateScene }).catch(onError);
         setIsLoading(LoadType.SCENE);
+        setScenePending(true);
       }
     },
     [

--- a/src/aics-image-viewer/components/useVolume.ts
+++ b/src/aics-image-viewer/components/useVolume.ts
@@ -325,7 +325,6 @@ const useVolume = (
     setIsLoading,
     onChannelDataLoaded,
     changeViewerSetting,
-    initChannelSettings,
     setChannelStateForNewImage,
     options?.viewerChannelSettings,
   ]);

--- a/src/aics-image-viewer/components/useVolume.ts
+++ b/src/aics-image-viewer/components/useVolume.ts
@@ -190,16 +190,7 @@ const useVolume = (
   );
 
   // channel indexes, sorted by category
-  const [_channelGroupedByType, setChannelGroupedByType] = useState<ChannelGrouping>({});
-  // While a new scene is loading, the channel count of the next scene is unknown. Since we load new scene data into
-  // the existing `image`, we can't easily react to changes to image properties, and therefore currently can't prevent
-  // React from rendering with *new* properties in image but the *old* value of `channelGroupedByType`. So we hide
-  // `channelGroupedByType` while the scene is loading to avoid indexing channels that no longer exist.
-  const [scenePending, setScenePending] = useState(false);
-  const channelGroupedByType = useMemo(
-    () => (scenePending ? {} : _channelGroupedByType),
-    [_channelGroupedByType, scenePending]
-  );
+  const [channelGroupedByType, setChannelGroupedByType] = useState<ChannelGrouping>({});
 
   const onChannelDataLoaded = useCallback(
     (aimg: Volume, channelIndex: number): void => {
@@ -345,7 +336,6 @@ const useVolume = (
       if (image && !inInitialLoadRef.current) {
         const onCreateScene = (volume: Volume, sceneIndex: number, loadSpec: LoadSpec): void => {
           setChannelStateForNewImage(volume.imageInfo.channelNames);
-          setScenePending(false);
           volume.updateChannelCount();
 
           const prevChannelVersions = channelVersionsRef.current;
@@ -365,7 +355,6 @@ const useVolume = (
 
         sceneLoader.loadScene(scene, image, undefined, { onCreateScene }).catch(onError);
         setIsLoading(LoadType.SCENE);
-        setScenePending(true);
       }
     },
     [


### PR DESCRIPTION
# Problem

Switching from a scene with more channels to a scene with fewer channels causes an error:
```
Cannot read properties of undefined (reading 'volumeEnabled')
```

# Solution

This error is caused by `ChannelsWidget` rendering in an intermediate state where the zustand store contains settings for the scene's new channels, but the value of `channelGroupedByType` has not been updated to match. When the new scene contains fewer channels than the previous one, `channelGroupedByType` momentarily contains out-of-bounds channel indexes, and `ChannelsWidget` attempts to render `ChannelsWidgetRow`s for channels that no longer exist.

`channelGroupedByType` was being updated in state at the same time as new channel settings were written, but for reasons I haven't properly thought all the way through, the updated viewer store was available sooner than the upated grouping. Whatever the case, `channelGroupedByType` doesn't philosophically belong in state in the first place: it's entirely derivable from other state and props (channel names + `viewerChannelSettings`). Converting from a `useState` to a `useMemo` fixed this problem.
