### PR TITLE
Update `Volume` load spec before scene load

### DIFF
--- a/src/aics-image-viewer/shared/utils/sceneStore.ts
+++ b/src/aics-image-viewer/shared/utils/sceneStore.ts
@@ -68,6 +68,9 @@ export default class SceneStore {
       channels: spec.channels?.filter((channelIndex) => channelIndex < imageInfo.channelNames.length),
       time: Math.min(spec.time, maxTime),
     };
+    // TODO it's not great that this is the caller's responsibility... fix this more robustly in vole-core
+    image.loadSpec = { ...image.loadSpec, ...adjustedSpec };
+    image.loadSpecRequired = { ...image.loadSpecRequired, ...adjustedSpec };
 
     options?.onCreateScene?.(image, scene, adjustedSpec);
     loader.loadVolumeData(image, adjustedSpec, options?.onChannelLoaded);


### PR DESCRIPTION
# Problem

After switching from a scene with more channels to a scene with fewer channels, some data loads fail with `VolumeLoadError: Could not load OME-Zarr volume data`.

Reproduction:

1. Open [this link](https://vole.allencell.org/viewer?url=https%3A%2F%2Fs3.us-west-2.amazonaws.com%2Fproduction.files.allencell.org%2F091%2Fb17%2Ffe8%2F551%2Fdd3%2F6a9%2F74e%2F24f%2F435%2F3ee%2F2d%2F20260609_3500008583_b69dc2635b0144d493e3b4cbf1a5d2aa.ome.zarr%2Bhttps%3A%2F%2Fs3.us-west-2.amazonaws.com%2Fproduction.files.allencell.org%2F07e%2Fcaf%2Fa58%2Fe9a%2F242%2F3c9%2F84a%2Fede%2Fd40%2F303%2F3c%2F20251104_3500008082_246ca22d0ad24d838370d6949e114604.ome.zarr)
2. Switch to the second scene. Note that this scene contains fewer channels than the previous scene.
3. Attempt to switch to a new time point. *This should fail.*

# Solution

This is caused by `Volume` holding onto a stale version of its own `LoadSpec`. When this value comes from a previous scene that had more channels than the current one, it attempts to reference and load channels that do not exist, causing an error. Forcing an update to `LoadSpec`s *before* the load begins prevents the error.

This is absolutely a band-aid fix. An ideal fix would involve clarifying the responsibility for updating these values at the vole-core level. This runs into a longstanding problem with the current API design in core: responsibility for initiating and managing new data loads is split awkwardly between `Volume` and `IVolumeLoader`. This has been the case since we introduced time series images, where loading a new frame requires both updating the properties of `Volume` and initiating a load. Should `Volume` always initiate loads via a reference to its `IVolumeLoader`? Or should switching time points and/or scenes require loader access?
